### PR TITLE
Rewrite DIIS for better convergence

### DIFF
--- a/src/atom/solvers.cpp
+++ b/src/atom/solvers.cpp
@@ -171,13 +171,13 @@ void UHF(const std::vector<bf_t> & basis, int Z, uscf_t & sol, double convthr, b
   }
 
   bool usediis=true;
-  bool diis_c1=false;
   const double diiseps=0.1;
   const double diisthr=0.01;
   bool useadiis=true;
+  bool diiscomb=false;
   const int diisorder=10;
 
-  uDIIS diis(S,Sinvh,usediis,diis_c1,diiseps,diisthr,useadiis,diisorder,verbose);
+  uDIIS diis(S,Sinvh,diiscomb,usediis,diiseps,diisthr,useadiis,diisorder,verbose);
   double diiserr;
 
   arma::mat oldHa, oldHb;
@@ -301,12 +301,11 @@ void RHF(const std::vector<bf_t> & basis, int Z, rscf_t & sol, double convthr, b
   }
 
   bool usediis=true;
-  bool diis_c1=false;
   const double diiseps=0.01;
   const double diisthr=0.01;
   bool useadiis=true;
   const int diisorder=10;
-  rDIIS diis(S,Sinvh,usediis,diis_c1,diiseps,diisthr,useadiis,diisorder,verbose);
+  rDIIS diis(S,Sinvh,usediis,diiseps,diisthr,useadiis,diisorder,verbose);
   double diiserr;
 
   arma::mat oldH;

--- a/src/diis.cpp
+++ b/src/diis.cpp
@@ -36,11 +36,10 @@ bool operator<(const diis_unpol_entry_t & lhs, const diis_unpol_entry_t & rhs) {
   return lhs.E < rhs.E;
 }
 
-DIIS::DIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, bool c1diis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) {
+DIIS::DIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) {
   S=S_;
   Sinvh=Sinvh_;
   usediis=usediis_;
-  c1diis=c1diis_;
   useadiis=useadiis_;
   verbose=verbose_;
   imax=imax_;
@@ -54,10 +53,10 @@ DIIS::DIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, bool c
   cooloff=0;
 }
 
-rDIIS::rDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, bool c1diis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_,Sinvh_,usediis_,c1diis_,diiseps_,diisthr_,useadiis_,verbose_,imax_) {
+rDIIS::rDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_,Sinvh_,usediis_,diiseps_,diisthr_,useadiis_,verbose_,imax_) {
 }
 
-uDIIS::uDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool usediis_, bool c1diis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : DIIS(S_,Sinvh_,usediis_,c1diis_,diiseps_,diisthr_,useadiis_,verbose_,imax_) {
+uDIIS::uDIIS(const arma::mat & S_, const arma::mat & Sinvh_, bool combine_, bool usediis_, double diiseps_, double diisthr_, bool useadiis_, bool verbose_, size_t imax_) : combine(combine_), DIIS(S_,Sinvh_,usediis_,diiseps_,diisthr_,useadiis_,verbose_,imax_) {
 }
 
 DIIS::~DIIS() {
@@ -141,12 +140,19 @@ void uDIIS::update(const arma::mat & Fa, const arma::mat & Fb, const arma::mat &
   arma::mat errmata=Fa*Pa*S-S*Pa*Fa;
   arma::mat errmatb=Fb*Pb*S-S*Pb*Fb;
   // and transform them to the orthonormal basis (1982 paper, page 557)
-  arma::mat errmat=arma::trans(Sinvh)*(errmata+errmatb)*Sinvh;
+  errmata=arma::trans(Sinvh)*errmata*Sinvh;
+  errmatb=arma::trans(Sinvh)*errmatb*Sinvh;
   // and store it
-  hlp.err=MatToVec(errmat);
-
+  if(combine) {
+    hlp.err=MatToVec(errmata+errmatb);
+  } else {
+    hlp.err.zeros(errmata.n_elem+errmatb.n_elem);
+    hlp.err.subvec(0,errmata.n_elem-1)=MatToVec(errmata);
+    hlp.err.subvec(errmata.n_elem,hlp.err.n_elem-1)=MatToVec(errmatb);
+  }
+  
   // DIIS error is
-  error=max_abs(errmat);
+  error=arma::max(arma::abs(hlp.err));
 
   // Is stack full?
   if(stack.size()==imax) {
@@ -229,8 +235,10 @@ arma::vec DIIS::get_w() {
       print_mat(w.t(),"% .2e ");
     }
   } else if(useadiis && usediis) {
-    // Sliding scale
+    // Sliding scale: DIIS weight
     double diisw=std::max(std::min(1.0 - (err-diisthr)/(diiseps-diisthr), 1.0), 0.0);
+    // ADIIS weght
+    double adiisw=1.0-diisw;
 
     // Determine cooloff
     if(cooloff>0) {
@@ -245,17 +253,32 @@ arma::vec DIIS::get_w() {
       }
     }
 
-    arma::vec wa=get_w_adiis();
-    arma::vec wd=get_w_diis();
-    w=diisw*wd + (1.0-diisw)*wa;
+    w.zeros(de.n_cols);
+
+    // DIIS and ADIIS weights
+    arma::vec wd, wa;
+    if(diisw!=0.0) {
+      wd=get_w_diis();
+      w+=diisw*wd;
+    }
+    if(adiisw!=0.0) {
+      wa=get_w_adiis();
+      w+=adiisw*wa;
+    }
 
     if(verbose) {
-      printf("ADIIS weights\n");
-      print_mat(wa.t(),"% .2e ");
-      printf("CDIIS weights\n");
-      print_mat(wd.t(),"% .2e ");
-      printf(" DIIS weights\n");
-      print_mat(w.t(),"% .2e ");
+      if(adiisw!=0.0) {
+        printf("ADIIS weights\n");
+        print_mat(wa.t(),"% .2e ");
+      }
+      if(diisw!=0.0) {
+        printf("CDIIS weights\n");
+        print_mat(wd.t(),"% .2e ");
+      }
+      if(adiisw!=0.0 && diisw!=0.0) {
+        printf(" DIIS weights\n");
+        print_mat(w.t(),"% .2e ");
+      }
     }
 
   } else
@@ -273,117 +296,68 @@ arma::vec DIIS::get_w_diis_wrk(const arma::mat & errs) const {
   // Size of LA problem
   int N=(int) errs.n_cols;
 
-  // DIIS weights
+  // Array holding the errors
+  arma::mat B(N,N);
+  B.zeros();
+  // Compute errors
+  for(int i=0;i<N;i++)
+    for(int j=0;j<N;j++) {
+      B(i,j)=arma::dot(errs.col(i),errs.col(j));
+    }
+
+  /*
+    The C1-DIIS method is equivalent to solving the group of linear
+    equations
+            B w = lambda 1       (1)
+
+    where B is the error matrix, w are the DIIS weights, lambda is the
+    Lagrange multiplier that guarantees that the weights sum to unity,
+    and 1 stands for a unit vector (1 1 ... 1)^T.
+
+    By rescaling the weights as w -> w/lambda, equation (1) is
+    reverted to the form
+            B w = 1              (2)
+
+    which can easily be solved using SVD techniques.
+
+    Finally, the weights are renormalized to satisfy
+            \sum_i w_i = 1
+    which takes care of the Lagrange multipliers.
+  */
+
+  // Right-hand side of equation is
+  arma::vec rh(N);
+  rh.ones();
+
+  // Singular value decomposition
+  arma::mat U, V;
+  arma::vec sval;
+  if(!arma::svd(U,sval,V,B,"std")) {
+    throw std::logic_error("SVD failed in DIIS.\n");
+  }
+  //sval.print("Singular values");
+
+  // Form solution vector
   arma::vec sol(N);
   sol.zeros();
-
-  if(c1diis) {
-    // Original, Pulay's DIIS (C1-DIIS)
-
-    // Array holding the errors
-    arma::mat B(N+1,N+1);
-    B.zeros();
-    // Compute errors
-    for(int i=0;i<N;i++)
-      for(int j=0;j<N;j++) {
-	B(i,j)=arma::dot(errs.col(i),errs.col(j));
-      }
-    // Fill in the rest of B
-    for(int i=0;i<N;i++) {
-      B(i,N)=-1.0;
-      B(N,i)=-1.0;
-    }
-
-    // RHS vector
-    arma::vec A(N+1);
-    A.zeros();
-    A(N)=-1.0;
-
-    // Solve B*X = A
-    arma::vec X;
-    bool succ;
-
-    succ=arma::solve(X,B,A);
-
-    if(succ) {
-      // Solution is (last element of X is DIIS error)
-      sol=X.subvec(0,N-1);
-
-      // Check that weights are within tolerance
-      if(arma::max(arma::abs(sol))>=MAXWEIGHT) {
-	printf("Large coefficient produced by DIIS. Reducing to %i matrices.\n",N-1);
-	arma::vec w0=get_w_diis_wrk(errs.submat(1,1,errs.n_rows-1,errs.n_cols-1));
-
-	// Helper vector
-	arma::vec w(N);
-	w.zeros();
-	w.subvec(w.n_elem-w0.n_elem,w.n_elem-1)=w0;
-	return w;
-      }
-    }
-
-    if(!succ) {
-      // Failed to invert matrix. Use the two last iterations instead.
-      printf("C1-DIIS was not succesful, mixing matrices instead.\n");
-      sol.zeros();
-      sol(0)=0.5;
-      sol(1)=0.5;
-    }
-  } else {
-    // C2-DIIS
-
-    // Array holding the errors
-    arma::mat B(N,N);
-    B.zeros();
-    // Compute errors
-    for(int i=0;i<N;i++)
-      for(int j=0;j<N;j++) {
-	B(i,j)=arma::dot(errs.col(i),errs.col(j));
-      }
-
-    // Solve eigenvectors of B
-    arma::mat Q;
-    arma::vec lambda;
-    eig_sym_ordered(lambda,Q,B);
-
-    // Normalize weights
-    for(int i=0;i<N;i++) {
-      Q.col(i)/=arma::sum(Q.col(i));
-    }
-
-    // Choose solution by picking out solution with smallest error
-    arma::vec errors(N);
-    arma::mat eQ=errs*Q;
-    // The weighted error is
-    for(int i=0;i<N;i++) {
-      errors(i)=arma::norm(eQ.col(i),2);
-    }
-
-    // Find minimal error
-    double mine=DBL_MAX;
-    int minloc=-1;
-    for(int i=0;i<N;i++) {
-      if(errors[i]<mine) {
-	// Check weights
-	bool ok=arma::max(arma::abs(Q.col(i)))<MAXWEIGHT;
-	if(ok) {
-	  mine=errors(i);
-	  minloc=i;
-	}
-      }
-    }
-
-    if(minloc!=-1) {
-      // Solution is
-      sol=Q.col(minloc);
-    } else {
-      printf("C2-DIIS did not find a suitable solution. Mixing matrices instead.\n");
-
-      sol.zeros();
-      sol(0)=0.5;
-      sol(1)=0.5;
-    }
+  for(int i=0;i<N;i++) {
+#if 0
+    // Perform Tikhonov regularization for the singular
+    // eigenvalues. This doesn't appear to work as well as just
+    // cutting out the spectrum.
+    double s(sval(i));
+    double t=1e-4;
+    double invs=s/(s*s + t*t);
+    sol += arma::dot(U.col(i),rh)*invs * V.col(i);
+#else
+    // Just cut out the problematic part
+    if(std::abs(sval(i))>DBL_EPSILON)
+      sol += arma::dot(U.col(i),rh)/sval(i) * V.col(i);
+#endif
   }
+  // Normalize solution
+  //printf("Sum of weights is %e\n",arma::sum(sol));
+  sol/=arma::sum(sol);
 
   return sol;
 }

--- a/src/diis.h
+++ b/src/diis.h
@@ -75,11 +75,19 @@ bool operator<(const diis_unpol_entry_t & lhs, const diis_unpol_entry_t & rhs);
  * P. Pulay, "Improved SCF Convergence Acceleration", J. Comp. Chem. 3
  * (1982), pp. 556 - 560.
  *
- * Using C1-DIIS is, however, not recommended. What is used by
- * default, instead, is C2-DIIS, which is documented in the article
+ * Using C1-DIIS is, however, not recommended. An improved method that
+ * yields better convergence was suggested in
  *
  * H. Sellers, "The C2-DIIS convergence acceleration algorithm",
  * Int. J. Quant. Chem. 45 (1993), pp. 31 - 41
+ *
+ * which used to be the default method in ERKALE. However, C2-DIIS is
+ * still problematic when linear dependencies exist in the basis. The
+ * current implementation employs a singular value decomposition as
+ * suggested in
+ *
+ * Hans Henrik B. Sørensen, and Ole Østerby, "On One-Point Iterations
+ * and DIIS", AIP Conference Proceedings 1168 (2009), pp. 468 - 472.
  *
  *
  * The ADIIS algorithm is described in
@@ -101,8 +109,6 @@ class DIIS {
 
   /// Use DIIS?
   bool usediis;
-  /// C1-DIIS?
-  bool c1diis;
   /// Use ADIIS?
   bool useadiis;
   /// Verbose operation?
@@ -144,7 +150,7 @@ class DIIS {
 
  public:
   /// Constructor
-  DIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, bool c1diis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
+  DIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
   /// Destructor
   virtual ~DIIS();
 
@@ -173,17 +179,17 @@ class rDIIS: protected DIIS {
 
  public:
   /// Constructor
-  rDIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, bool c1diis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
+  rDIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
   /// Destructor
   ~rDIIS();
 
   /// Add matrices to stack
   void update(const arma::mat & F, const arma::mat & P, double E, double & error);
 
-  /// Compute new Fock matrix, use C1-DIIS if wanted
+  /// Compute new Fock matrix
   void solve_F(arma::mat & F);
 
-  /// Compute new density matrix, use C1-DIIS if wanted
+  /// Compute new density matrix
   void solve_P(arma::mat & P);
 
   /// Clear Fock matrices and errors
@@ -204,19 +210,22 @@ class uDIIS: protected DIIS {
   /// ADIIS update
   void PiF_update();
 
+  /// Combine alpha and beta errors?
+  bool combine;
+
  public:
   /// Constructor
-  uDIIS(const arma::mat & S, const arma::mat & Sinvh, bool usediis, bool c1diis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
+  uDIIS(const arma::mat & S, const arma::mat & Sinvh, bool combine, bool usediis, double diiseps, double diisthr, bool useadiis, bool verbose, size_t imax);
   /// Destructor
   ~uDIIS();
 
   /// Add matrices to stack
   void update(const arma::mat & Fa, const arma::mat & Fb, const arma::mat & Pa, const arma::mat & Pb, double E, double & error);
 
-  /// Compute new Fock matrix, use C1-DIIS if wanted
+  /// Compute new Fock matrix
   void solve_F(arma::mat & Fa, arma::mat & Fb);
 
-  /// Compute new density matrix, use C1-DIIS if wanted
+  /// Compute new density matrix
   void solve_P(arma::mat & Pa, arma::mat & Pb);
 
   /// Clear Fock matrices and errors

--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -81,10 +81,10 @@ SCF::SCF(const BasisSet & basis, const Settings & set, Checkpoint & chkpt) {
   dimcalc=set.get_bool("DimerSymmetry");
 
   usediis=set.get_bool("UseDIIS");
-  diis_c1=set.get_bool("C1-DIIS");
   diisorder=set.get_int("DIISOrder");
   diiseps=set.get_double("DIISEps");
   diisthr=set.get_double("DIISThr");
+  diiscomb=set.get_bool("DIISComb");
   useadiis=set.get_bool("UseADIIS");
   usebroyden=set.get_bool("UseBroyden");
   usetrrh=set.get_bool("UseTRRH");

--- a/src/scf-solvers.cpp.in
+++ b/src/scf-solvers.cpp.in
@@ -138,7 +138,7 @@ size_t XRSSCF::half_hole(uscf_t & sol, double convthr, dft_t dft0)
 
 #ifdef RESTRICTED
   // DIIS iterator
-  rDIIS diis(S,Sinvh,usediis,diis_c1,diiseps,diisthr,useadiis,verbose,diisorder);
+  rDIIS diis(S,Sinvh,usediis,diiseps,diisthr,useadiis,verbose,diisorder);
   // Broyden
   Broyden broyd(verbose);
 
@@ -148,7 +148,7 @@ size_t XRSSCF::half_hole(uscf_t & sol, double convthr, dft_t dft0)
   K.zeros();
 #else
   // DIIS iterator
-  uDIIS diis(S,Sinvh,usediis,diis_c1,diiseps,diisthr,useadiis,verbose,diisorder);
+  uDIIS diis(S,Sinvh,diiscomb,usediis,diiseps,diisthr,useadiis,verbose,diisorder);
 
   // Broyden
   Broyden broyd_sum(verbose);

--- a/src/scf.h
+++ b/src/scf.h
@@ -228,14 +228,14 @@ class SCF {
 
   /// Use DIIS?
   bool usediis;
-  /// Use C1-DIIS instead of C2-DIIS?
-  bool diis_c1;
   /// Number of DIIS matrices to use
   int diisorder;
   /// Threshold of enabling use of DIIS
   double diiseps;
   /// Threshold of enabling full use of DIIS
   double diisthr;
+  /// Combine alpha and beta errors in unrestricted calcs?
+  bool diiscomb;
 
   /// Dimer calculation?
   bool dimcalc;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -68,14 +68,14 @@ void Settings::add_scf_settings() {
 
   // Use DIIS.
   add_bool("UseDIIS", "Use Pulay's Direct Inversion in the Iterative Subspace?", true);
-  // Use old version of DIIS?
-  add_bool("C1-DIIS", "Use older version of DIIS (C1-DIIS instead of C2-DIIS)?", false);
   // Number of DIIS matrices to use?
   add_int("DIISOrder", "How many DIIS iterations to keep in memory?", 10);
   // DIIS threshold
   add_double("DIISEps", "Start mixing in DIIS when error is", 0.1);
   // DIIS threshold
   add_double("DIISThr", "DIIS error threshold for DIIS updates", 0.01);
+  // DIIS threshold
+  add_bool("DIISComb", "Combine alpha and beta errors in unrestricted calcs?", false);
   // Use ADIIS?
   add_bool("UseADIIS", "Use ADIIS for Fock matrix interpolation?", true);
 


### PR DESCRIPTION
This pull changes the DIIS routine from C2-DIIS, to an SVD based implementation of C1-DIIS. The SVD is able to handle linear dependencies better close to convergence, which may substantially decrease the number of iterations necessary for convergence.

Furthermore, the DIIS routine no longer combines the alpha and beta error vectors by default, which helps convergence in hard unrestricted cases.