### PR TITLE
Implement Gaussian basis variant of SAP guess

### DIFF
--- a/src/contrib/guessbench.cpp
+++ b/src/contrib/guessbench.cpp
@@ -63,6 +63,8 @@ void print_header() {
 void diag(arma::vec & E, arma::mat & C, const arma::mat & H, const arma::mat & Sinvh) {
   arma::eig_sym(E,C,Sinvh.t()*H*Sinvh);
   C=Sinvh*C;
+
+  //E.print("Eigenvalues");
 }
 
 int main(int argc, char **argv) {
@@ -152,7 +154,7 @@ int main(int argc, char **argv) {
 
   } else if(stricmp(guess,"sad")==0 || stricmp(guess,"no")==0) {
     // Get SAD guess
-    Pguess=atomic_guess(basis,set);
+    Pguess=sad_guess(basis,set);
     // Normalize
     Pguess/=2.0;
     
@@ -163,7 +165,14 @@ int main(int argc, char **argv) {
       // Recreate guess
       Pguess=C.cols(0,Nela-1)*C.cols(0,Nela-1).t();
     }
-  }
+
+  } else if(stricmp(guess,"gsap")==0) {
+    // Get SAP guess
+    diag(E,C,Hcore+sap_guess(basis,set),Sinvh);
+    // Guess density is
+    Pguess=C.cols(0,Nela-1)*C.cols(0,Nela-1).t();
+  } else
+    throw std::logic_error("Unsupported guess!\n");
 
   // Calculate the projection
   double proj(arma::trace(P*S*Pguess*S));

--- a/src/guess.cpp
+++ b/src/guess.cpp
@@ -24,7 +24,7 @@
 #include "timer.h"
 #include <algorithm>
 
-void atomic_guess(const BasisSet & basis, size_t inuc, const std::string & method, std::vector<size_t> & shellidx, BasisSet & atbas, arma::vec & atE, arma::mat & atP, bool dropshells, bool sphave, int Q) {
+void atomic_guess(const BasisSet & basis, size_t inuc, const std::string & method, std::vector<size_t> & shellidx, BasisSet & atbas, arma::vec & atE, arma::mat & atP, arma::mat & atF, bool dropshells, bool sphave, int Q) {
   // Nucleus is
   nucleus_t nuc=basis.get_nucleus(inuc);
 
@@ -166,13 +166,29 @@ void atomic_guess(const BasisSet & basis, size_t inuc, const std::string & metho
 
     chkpt.read("Ea",atE);
     chkpt.read("P",atP);
+
+    int restr;
+    chkpt.read("Restricted",restr);
+    if (restr) {
+      chkpt.read("H",atF);
+    } else {
+      arma::mat Fa, Fb;
+      chkpt.read("Ha",Fa);
+      chkpt.read("Hb",Fb);
+      atF=(Fa+Fb)*0.5;
+    }
+    // Substract core Hamiltonian to leave only Coulomb and
+    // exchange-correlation part
+    arma::mat Hcore;
+    chkpt.read("Hcore",Hcore);
+    atF-=Hcore;
   }
 
   // Remove temporary file
   remove(tmpname.c_str());
 }
 
-arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells, bool sphave) {
+arma::mat atomic_guess_wrk(const BasisSet & basis, Settings set, bool dropshells, bool sphave, bool fock) {
   // First of all, we need to determine which atoms are identical in
   // the way that the basis sets coincide.
 
@@ -182,7 +198,7 @@ arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells, bo
   // Amount of basis functions is
   size_t Nbf=basis.get_Nbf();
 
-  // Density matrix
+  // Density or Fock matrix
   arma::mat P(Nbf,Nbf);
   P.zeros();
 
@@ -237,10 +253,11 @@ arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells, bo
     BasisSet atbas;
     arma::vec atE;
     arma::mat atP;
+    arma::mat atF;
     std::vector<size_t> shellidx;
 
     // Perform the guess
-    atomic_guess(basis,idnuc[i][0],method,shellidx,atbas,atE,atP,dropshells,sphave,basis.get_nucleus(idnuc[i][0]).Q);
+    atomic_guess(basis,idnuc[i][0],method,shellidx,atbas,atE,atP,atF,dropshells,sphave,basis.get_nucleus(idnuc[i][0]).Q);
     // Get the atomic shells
     std::vector<GaussianShell> shells=atbas.get_funcs(0);
 
@@ -253,9 +270,10 @@ arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells, bo
 	  // Get shells on nucleus
 	  std::vector<GaussianShell> idsh=basis.get_funcs(idnuc[i][iid]);
 
-	  // Store density
-	  P.submat(idsh[shellidx[ish]].get_first_ind(),idsh[shellidx[jsh]].get_first_ind(),idsh[shellidx[ish]].get_last_ind(),idsh[shellidx[jsh]].get_last_ind())=atP.submat(shells[ish].get_first_ind(),shells[jsh].get_first_ind(),shells[ish].get_last_ind(),shells[jsh].get_last_ind());
-	}
+	  // Store density / Fock matrix
+          const arma::mat & atM = fock ? atF : atP;
+          P.submat(idsh[shellidx[ish]].get_first_ind(),idsh[shellidx[jsh]].get_first_ind(),idsh[shellidx[ish]].get_last_ind(),idsh[shellidx[jsh]].get_last_ind())=atM.submat(shells[ish].get_first_ind(),shells[jsh].get_first_ind(),shells[ish].get_last_ind(),shells[jsh].get_last_ind());
+        }
       }
 
     if(verbose) {
@@ -279,6 +297,17 @@ arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells, bo
   }
 
   return P;
+}
+
+arma::mat sad_guess(const BasisSet & basis, Settings set, bool dropshells, bool sphave) {
+  return atomic_guess_wrk(basis,set,dropshells,sphave,false);
+}
+
+arma::mat sap_guess(const BasisSet & basis, Settings set, bool dropshells, bool sphave) {
+  // It's a bad idea to drop shells for the potential guess - we want
+  // the Coulomb and exchange effects on those orbitals as
+  // well. Otherwise polarization shells have no screening!!
+  return atomic_guess_wrk(basis,set,false,sphave,true);
 }
 
 std::vector< std::vector<size_t> > identical_nuclei(const BasisSet & basis) {

--- a/src/guess.cpp
+++ b/src/guess.cpp
@@ -303,7 +303,7 @@ arma::mat sad_guess(const BasisSet & basis, Settings set, bool dropshells, bool 
   return atomic_guess_wrk(basis,set,dropshells,sphave,false);
 }
 
-arma::mat sap_guess(const BasisSet & basis, Settings set, bool dropshells, bool sphave) {
+arma::mat sap_guess(const BasisSet & basis, Settings set, bool sphave) {
   // It's a bad idea to drop shells for the potential guess - we want
   // the Coulomb and exchange effects on those orbitals as
   // well. Otherwise polarization shells have no screening!!

--- a/src/guess.h
+++ b/src/guess.h
@@ -40,8 +40,8 @@ class Settings;
  */
 arma::mat sad_guess(const BasisSet & basis, Settings set, bool dropshells=true, bool sphave=true);
 
-/// Same, but do SAP guess by projecting Fock matrices
-arma::mat sap_guess(const BasisSet & basis, Settings set, bool dropshells=true, bool sphave=true);
+/// Same, but do SAP guess by projecting Fock matrices. Not as good as the real-space version
+arma::mat sap_guess(const BasisSet & basis, Settings set, bool sphave=true);
 
 /**
  * Worker routine - perform guess for inuc:th atom in basis, using given method.

--- a/src/guess.h
+++ b/src/guess.h
@@ -38,7 +38,10 @@ class Settings;
  *
  * Optional charge given as input.
  */
-arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells=true, bool sphave=true);
+arma::mat sad_guess(const BasisSet & basis, Settings set, bool dropshells=true, bool sphave=true);
+
+/// Same, but do SAP guess by projecting Fock matrices
+arma::mat sap_guess(const BasisSet & basis, Settings set, bool dropshells=true, bool sphave=true);
 
 /**
  * Worker routine - perform guess for inuc:th atom in basis, using given method.
@@ -52,7 +55,7 @@ arma::mat atomic_guess(const BasisSet & basis, Settings set, bool dropshells=tru
  *
  * Optional charge given as input.
  */
-void atomic_guess(const BasisSet & basis, size_t inuc, const std::string & method, std::vector<size_t> & shellidx, BasisSet & atbas, arma::vec & atE, arma::mat & atP, bool dropshells, bool sphave, int Q);
+void atomic_guess(const BasisSet & basis, size_t inuc, const std::string & method, std::vector<size_t> & shellidx, BasisSet & atbas, arma::vec & atE, arma::mat & atP, arma::mat & atF, bool dropshells, bool sphave, int Q);
 
 /// Determine list of identical nuclei, determined by nucleus and basis set
 std::vector< std::vector<size_t> > identical_nuclei(const BasisSet & basis);

--- a/src/hirshfeld.cpp
+++ b/src/hirshfeld.cpp
@@ -139,10 +139,11 @@ void Hirshfeld::compute(const BasisSet & basis, std::string method) {
     // Perform guess
     arma::vec atE;
     arma::mat atP;
+    arma::mat atF;
     BasisSet atbas;
     std::vector<size_t> shellidx;
     // Don't drop polarization shells but do occupation smearing. Charge is 0
-    atomic_guess(basis,idnuc[i][0],method,shellidx,atbas,atE,atP,false,true,0);
+    atomic_guess(basis,idnuc[i][0],method,shellidx,atbas,atE,atP,atF,false,true,0);
 
     // Construct atom
     HirshfeldAtom at(atbas,atP);

--- a/src/hirshfeldi.cpp
+++ b/src/hirshfeldi.cpp
@@ -72,10 +72,11 @@ void HirshfeldI::compute(const BasisSet & basis, const arma::mat & P, std::strin
       // Perform guess
       arma::vec atE;
       arma::mat atP;
+      arma::mat atF;
       BasisSet atbas;
       std::vector<size_t> shellidx;
       // Don't drop polarization shells, but do occupation smearing
-      atomic_guess(basis,idnuc[i][0],method,shellidx,atbas,atE,atP,false,true,dq);
+      atomic_guess(basis,idnuc[i][0],method,shellidx,atbas,atE,atP,atF,false,true,dq);
 
       // Construct atom
       HirshfeldAtom at(atbas,atP,dr);

--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -53,6 +53,8 @@ enum guess_t parse_guess(const std::string & val) {
     return CORE_GUESS;
   else if(stricmp(val,"SAD")==0 || stricmp(val,"Atomic")==0)
     return SAD_GUESS;
+  else if(stricmp(val,"GSAP")==0)
+    return GSAP_GUESS;
   else if(stricmp(val,"SAP")==0)
     return SAP_GUESS;
   else if(stricmp(val,"NO")==0)
@@ -1861,9 +1863,6 @@ void calculate(const BasisSet & basis, const Settings & set, bool force) {
 
       // Orbitals
       basis.projectMOs(oldbas,Eold,Cold,sol.E,sol.C,Nel_alpha);
-
-    } else if((guess == SAD_GUESS) || (guess == NO_GUESS)) {
-      sol.P=atomic_guess(basis,set);
     }
 
     // Get orbital occupancies
@@ -1900,8 +1899,13 @@ void calculate(const BasisSet & basis, const Settings & set, bool force) {
 	solver.sap_guess(sol);
       else if(guess==GWH_GUESS)
 	solver.gwh_guess(sol);
-      else if((guess == SAD_GUESS) || (guess == NO_GUESS)) {
-	// Build Fock operator from SAD density matrix. Get natural orbitals
+      else if(guess == GSAP_GUESS) {
+        sol.H=solver.get_Hcore()+sap_guess(basis,set);
+        solver.diagonalize(sol);
+      } else if((guess == SAD_GUESS) || (guess == NO_GUESS)) {
+        sol.P=sad_guess(basis,set);
+
+        // Build Fock operator from SAD density matrix. Get natural orbitals
 	arma::vec occ;
 	form_NOs(sol.P,solver.get_S(),sol.C,occ);
 
@@ -2177,9 +2181,6 @@ void calculate(const BasisSet & basis, const Settings & set, bool force) {
 	basis.projectMOs(oldbas,Eaold,Caold,sol.Ea,sol.Ca,Nel_alpha);
 	basis.projectMOs(oldbas,Ebold,Cbold,sol.Eb,sol.Cb,Nel_beta);
       }
-
-    } else if(guess==SAD_GUESS || guess==NO_GUESS) {
-      sol.P=atomic_guess(basis,set);
     }
 
     // Get orbital occupancies
@@ -2217,7 +2218,14 @@ void calculate(const BasisSet & basis, const Settings & set, bool force) {
 	solver.sap_guess(sol);
       else if(guess==GWH_GUESS)
 	solver.gwh_guess(sol);
-      else if((guess==SAD_GUESS) || (guess==NO_GUESS)) {
+      else if(guess == GSAP_GUESS) {
+        sol.Ha=solver.get_Hcore()+sap_guess(basis,set);
+        sol.Hb=sol.Ha;
+        solver.diagonalize(sol);
+      } else if((guess == SAD_GUESS) || (guess == NO_GUESS)) {
+        // Form SAD density matrix
+        sol.P=sad_guess(basis,set);
+
 	// Build Fock operator from SAD density matrix. Get natural orbitals
 	arma::vec occ;
 	form_NOs(sol.P,solver.get_S(),sol.Ca,occ);

--- a/src/scf.h
+++ b/src/scf.h
@@ -164,6 +164,8 @@ enum guess_t {
   SAD_GUESS,
   /// Atomic potential guess
   SAP_GUESS,
+  /// Atomic potential guess, using SAD solver and gaussian basis
+  GSAP_GUESS,
   /// Natural orbitals from atomic guess
   NO_GUESS,
   /// Generalized Wolfsberg--Helmholz


### PR DESCRIPTION
By a simple modification it's possible to form a LCAO basis SAP guess, by using the SAD guess routine. However, the quality of the resulting guess doesn't appear to be as good as that of the real-space SAP.