### PR TITLE
Switch to using global settings

### DIFF
--- a/src/atom/atomtable.cpp
+++ b/src/atom/atomtable.cpp
@@ -46,7 +46,7 @@ void AtomTable::fill(const std::vector<bf_t> & basis, bool verbose) {
   try {
     ints.reserve(N);
     ints.resize(N);
-  } catch(std::bad_alloc err) {
+  } catch(std::bad_alloc & err) {
     std::ostringstream oss;
 
     ERROR_INFO();

--- a/src/atom/main.cpp
+++ b/src/atom/main.cpp
@@ -22,6 +22,7 @@
 #include "../mathf.h"
 #include "../scf.h"
 #include "../timer.h"
+#include "../settings.h"
 #include "solvers.h"
 #include <armadillo>
 
@@ -142,6 +143,7 @@ void test() {
   printf("F (2s  2pz|2s  2pz) %.12f\n",ERI(F2s,F2pz,F2s,F2pz));
 }
 
+Settings settings;
 
 int main_guarded(int argc, char **argv) {
 #ifdef _OPENMP
@@ -159,16 +161,19 @@ int main_guarded(int argc, char **argv) {
   init_libint_base();
   //  test();
 
-  if(argc!=3) {
-    printf("Usage: %s Z basisfile\n",argv[0]);
-    printf("Basis set is read in in ADF format.\n");
+  settings.add_int("Z","Nucleus to study",0);
+  settings.add_string("Basis","Basis set file in ADF format","");
+  settings.add_double("LinDepThresh","Linear dependence threshold",1e-5);
+  if(argc!=2) {
+    printf("Usage: %s runfile\n",argv[0]);
+    settings.print();
     return 1;
   }
 
-  int Z=atoi(argv[1]);
+  int Z=settings.get_int("Z");
 
   // Construct basis set
-  std::vector<bf_t> basis=construct_basis(argv[2]);
+  std::vector<bf_t> basis=construct_basis(settings.get_string("Basis"));
 
   // Print out basis set
   printf("Basis set\n");

--- a/src/basis.h
+++ b/src/basis.h
@@ -212,7 +212,7 @@ class BasisSet {
   /// Dummy constructor
   BasisSet();
   /// Construct basis set with Nat atoms, using given settings
-  BasisSet(size_t Nat, const Settings & set);
+  BasisSet(size_t Nat);
   /// Destructor
   ~BasisSet();
 
@@ -655,9 +655,9 @@ GaussianShell dummyshell();
 std::vector<size_t> i_idx(size_t N);
 
 /// Construct basis set from input
-void construct_basis(BasisSet & basis, const std::vector<atom_t> & atoms, const BasisSetLibrary & baslib, const Settings & set);
+void construct_basis(BasisSet & basis, const std::vector<atom_t> & atoms, const BasisSetLibrary & baslib);
 /// Constuct basis set from input
-void construct_basis(BasisSet & basis, const std::vector<nucleus_t> & nuclei, const BasisSetLibrary & baslib, const Settings & set);
+void construct_basis(BasisSet & basis, const std::vector<nucleus_t> & nuclei, const BasisSetLibrary & baslib);
 
 /// Compute values of orbitals at given point
 arma::vec compute_orbitals(const arma::mat & C, const BasisSet & bas, const coords_t & r);

--- a/src/basistool/main.cpp
+++ b/src/basistool/main.cpp
@@ -17,6 +17,7 @@
 #include "../basislibrary.h"
 #include "../stringutil.h"
 #include "../eriworker.h"
+#include "../settings.h"
 #include "../completeness/completeness_profile.h"
 #ifdef SVNRELEASE
 #include "../version.h"
@@ -30,6 +31,8 @@ void help() {
   for(size_t i=0;i<sizeof(cmds)/sizeof(cmds[0]);i++)
     printf("\t%s\n",cmds[i].c_str());
 }
+
+Settings settings;
 
 int main_guarded(int argc, char **argv) {
   printf("ERKALE - Basis set tools from Hel.\n");

--- a/src/casida/casida.h
+++ b/src/casida/casida.h
@@ -113,7 +113,7 @@ class Casida {
    *
    * To save memory, the result is stored in the K matrix.
    */
-  void Kcoul(const BasisSet & basis, const Settings & set);
+  void Kcoul(const BasisSet & basis);
 
   /**
    * This routine constructs the exchange-correlation coupling matrix
@@ -135,7 +135,7 @@ class Casida {
   double fe(states_pair_t ip, bool ispin) const;
 
   /// Form pairs and occupations
-  void form_pairs(const Settings & set, const std::vector< std::vector<double> > occs);
+  void form_pairs(const std::vector< std::vector<double> > occs);
 
   /// Transform given AO matrix to MO
   arma::mat matrix_transform(bool ispin, const arma::mat & m) const;
@@ -144,13 +144,13 @@ class Casida {
 
 
   /// Common routines for constructors
-  void parse_coupling(const Settings & set);
+  void parse_coupling();
 
   /// Construct the K matrices
-  void calc_K(const Settings & set, const BasisSet & bas);
+  void calc_K(const BasisSet & bas);
 
   /// Compute the Coulomb fitting integrals \f$ (\mu \nu | a) \f$ and the matrix \f$ (a|b)^{-1} \f$
-  void coulomb_fit(const BasisSet & basis, std::vector<arma::mat> & munu, arma::mat & ab_inv, const Settings & set) const;
+  void coulomb_fit(const BasisSet & basis, std::vector<arma::mat> & munu, arma::mat & ab_inv) const;
 
   /// Solve the Casida equation
   void solve();
@@ -164,9 +164,9 @@ class Casida {
   /// Dummy constructor
   Casida();
   /// Constructor for spin-unpolarized calculation
-  Casida(const Settings & set, const BasisSet & basis, const arma::vec & E, const arma::mat & C, const arma::mat & P, const std::vector<double> & occs);
+  Casida(const BasisSet & basis, const arma::vec & E, const arma::mat & C, const arma::mat & P, const std::vector<double> & occs);
   /// Constructor for spin-polarized calculation
-  Casida(const Settings & set, const BasisSet & basis, const arma::vec & Ea, const arma::vec & Eb, const arma::mat & Ca, const arma::mat & Cb, const arma::mat & Pa, const arma::mat & Pb, const std::vector<double> & occa, const std::vector<double> & occb);
+  Casida(const BasisSet & basis, const arma::vec & Ea, const arma::vec & Eb, const arma::mat & Ca, const arma::mat & Cb, const arma::mat & Pa, const arma::mat & Pb, const std::vector<double> & occa, const std::vector<double> & occb);
   /// Destructor
   ~Casida();
 

--- a/src/completeness/main.cpp
+++ b/src/completeness/main.cpp
@@ -18,6 +18,7 @@
 #include "optimize_completeness.h"
 #include "../basislibrary.h"
 #include "../global.h"
+#include "../settings.h"
 
 #ifdef _OPENMP
 #include <omp.h>
@@ -26,6 +27,8 @@
 #ifdef SVNRELEASE
 #include "../version.h"
 #endif
+
+Settings settings;
 
 int main_guarded(int argc, char **argv) {
 #ifdef _OPENMP
@@ -40,41 +43,50 @@ int main_guarded(int argc, char **argv) {
 #endif
   print_hostname();
 
-  if(argc!=7 && argc!=8) {
-    printf("Usage:   %s am n min max Nf/tol nfull (coulomb)\n",argv[0]);
-    printf("am:      angular momentum of shell to optimize for\n");
-    printf("n:       moment to optimize for.\n");
-    printf("         1 for maximal area, 2 for minimal rms deviation from unity.\n");
-    printf("min:     lower limit of exponent range to optimize, in log10\n");
-    printf("max:     upper limit of exponent range to optimize, in log10\n");
-    printf("Nf/tol:  number of functions to place on shell, or wanted tolerance.\n");
-    printf("nfull:   number of outermost functions to fully optimize\n");
-    printf("coulomb: use Coulomb metric?\n");
+  settings.add_int("am","angular momentum of shell to optimize for",0);
+  settings.add_int("n","moment to optimize for: 1 for maximal area, 2 for minimal rms deviation",0);
+  settings.add_double("min","lower limit of exponent range in log10",-2);
+  settings.add_double("max","upper limit of exponent range in log10",6);
+  settings.add_double("tol","Optimize and add functions until tolerance is achieved",0.0);
+  settings.add_int("nfunc","Fixed number of functions to optimize",0);
+  settings.add_int("nfull","Number of functions at each side to fully optimize",4);
+  settings.add_bool("coulomb","Use Coulomb metric? (Use only for RI basis sets)",false);
+  settings.add_double("LinDepThresh","Basis set linear dependence threshold",1e-5);
+
+  if(argc!=2) {
+    printf("Usage: %s runfile\n",argv[0]);
+    settings.print();
     return 1;
   }
+  settings.parse(std::string(argv[1]),true);
+  settings.print();
 
   // Get parameters
-  int am=atoi(argv[1]);
-  int n=atoi(argv[2]);
-  double min=atof(argv[3]);
-  double max=atof(argv[4]);
+  int am=settings.get_int("am");
+  int n=settings.get_int("n");
+  double min=settings.get_double("min");
+  double max=settings.get_double("max");
 
   // Form optimized set of primitives
   arma::vec exps;
 
   // Did we get a tolerance, or a number of functions?
-  double tol=atof(argv[5]);
-  int nfull=atoi(argv[6]);
-  bool coulomb=false;
-  if(argc==8)
-    coulomb=atoi(argv[7]);
-
+  double tol=settings.get_double("tol");
+  int nfunc=settings.get_int("nfunc");
+  int nfull=settings.get_int("nfull");
+  bool coulomb=settings.get_bool("coulomb");
   // The Coulomb metric is equivalent to the normal metric with am-1
   if(coulomb)
     am--;
 
   double tau;
-  if(tol<1) {
+
+  if(tol != 0.0 && nfunc != 0)
+    throw std::logic_error("Can't specify both wanted tolerance and number of functions!\n");
+  if(tol == 0.0 && nfunc == 0)
+    throw std::logic_error("Neither wanted tolerance or number of functions was given!\n");
+
+  if(tol!=0.0) {
     exps=get_exponents(am,min,max,tol,n,true,nfull);
   } else {
     // Number of functions given.

--- a/src/contrib/densproj.cpp
+++ b/src/contrib/densproj.cpp
@@ -60,6 +60,8 @@ void print_header() {
   print_hostname();
 }
 
+Settings settings;
+
 int main_guarded(int argc, char **argv) {
   print_header();
 
@@ -75,17 +77,16 @@ int main_guarded(int argc, char **argv) {
   t.print_time();
 
   // Parse settings
-  Settings set;
-  set.add_string("LoadChk","File to load old results from","");
-  set.add_string("LoadChk2","File to load old results from","");
-  set.parse(std::string(argv[1]),true);
-  set.print();
+  settings.add_string("LoadChk","File to load old results from","");
+  settings.add_string("LoadChk2","File to load old results from","");
+  settings.parse(std::string(argv[1]),true);
+  settings.print();
 
   // Get checkpoint files
-  std::string chk1f(set.get_string("LoadChk"));
+  std::string chk1f(settings.get_string("LoadChk"));
   Checkpoint chk1(chk1f,false);
 
-  std::string chk2f(set.get_string("LoadChk2"));
+  std::string chk2f(settings.get_string("LoadChk2"));
   Checkpoint chk2(chk2f,false);
 
   BasisSet basis1, basis2;

--- a/src/contrib/dumpxc.cpp
+++ b/src/contrib/dumpxc.cpp
@@ -31,6 +31,8 @@
 #include "../version.h"
 #endif
 
+Settings settings;
+
 int main(int argc, char **argv) {
 
 #ifdef _OPENMP
@@ -53,18 +55,17 @@ int main(int argc, char **argv) {
   Timer t;
 
   // Parse settings
-  Settings set;
-  set.add_string("LoadChk","Checkpoint file to load density from","erkale.chk");
-  set.add_string("Method","Functional to dump data for","mgga_x_tpss");
-  set.add_double("GridTol","DFT grid tolerance to use",1e-3);
-  set.add_string("DFTGrid","DFT grid to use","Auto");
+  settings.add_string("LoadChk","Checkpoint file to load density from","erkale.chk");
+  settings.add_string("Method","Functional to dump data for","mgga_x_tpss");
+  settings.add_double("GridTol","DFT grid tolerance to use",1e-3);
+  settings.add_string("DFTGrid","DFT grid to use","Auto");
   if(argc==2)
-    set.parse(argv[1]);
+    settings.parse(argv[1]);
   else printf("Using default settings.\n\n");
-  set.print();
+  settings.print();
 
   // Load checkpoint
-  Checkpoint chkpt(set.get_string("LoadChk"),false);
+  Checkpoint chkpt(settings.get_string("LoadChk"),false);
 
   // Load basis set
   BasisSet basis;
@@ -80,7 +81,7 @@ int main(int argc, char **argv) {
 
   // Functional id
   int x_func, c_func;
-  parse_xc_func(x_func,c_func,set.get_string("Method"));
+  parse_xc_func(x_func,c_func,settings.get_string("Method"));
 
   // DFT grid, verbose operation
   DFTGrid grid(&basis,true);
@@ -91,10 +92,10 @@ int main(int argc, char **argv) {
   double gridtol;
 
   // Determine grid
-  std::string dftgrid=set.get_string("DFTGrid");
+  std::string dftgrid=settings.get_string("DFTGrid");
   if(stricmp(dftgrid,"Auto")==0) {
     adaptive=true;
-    gridtol=set.get_double("GridTol");
+    gridtol=settings.get_double("GridTol");
   } else {
     adaptive=false;
     std::vector<std::string> gridsize=splitline(dftgrid);

--- a/src/contrib/formchk.cpp
+++ b/src/contrib/formchk.cpp
@@ -37,6 +37,8 @@
 #include "../version.h"
 #endif
 
+Settings settings;
+
 int main_guarded(int argc, char **argv) {
 #ifdef _OPENMP
   printf("ERKALE - Checkpoints from Hel, OpenMP version, running on %i cores.\n",omp_get_max_threads());
@@ -61,24 +63,23 @@ int main_guarded(int argc, char **argv) {
   Timer t;
 
   // Parse settings
-  Settings set;
-  set.add_string("LoadChk","Checkpoint file that contains basis set etc","erkale.chk");
-  set.add_string("SaveChk","Checkpoint to which orbitals are saved","chkpt.chk");
-  set.add_string("Model","Model from which orbitals are","");
-  set.add_bool("Binary","Use binary I/O?",true);
-  set.add_string("Deleted","Add in deleted orbitals from file","");
-  set.add_bool("NO","Are these natural orbitals?",false);
+  settings.add_string("LoadChk","Checkpoint file that contains basis set etc","erkale.chk");
+  settings.add_string("SaveChk","Checkpoint to which orbitals are saved","chkpt.chk");
+  settings.add_string("Model","Model from which orbitals are","");
+  settings.add_bool("Binary","Use binary I/O?",true);
+  settings.add_string("Deleted","Add in deleted orbitals from file","");
+  settings.add_bool("NO","Are these natural orbitals?",false);
 
-  set.parse(argv[1]);
-  set.print();
+  settings.parse(argv[1]);
+  settings.print();
 
   // Load checkpoint
-  std::string loadchk(set.get_string("LoadChk"));
-  std::string savechk(set.get_string("SaveChk"));
-  std::string model(set.get_string("Model"));
-  std::string del(set.get_string("Deleted"));
-  bool binary(set.get_bool("Binary"));
-  bool NO(set.get_bool("NO"));
+  std::string loadchk(settings.get_string("LoadChk"));
+  std::string savechk(settings.get_string("SaveChk"));
+  std::string model(settings.get_string("Model"));
+  std::string del(settings.get_string("Deleted"));
+  bool binary(settings.get_bool("Binary"));
+  bool NO(settings.get_bool("NO"));
 
   if(savechk.size()) {
     // Copy checkpoint data

--- a/src/contrib/oovl.cpp
+++ b/src/contrib/oovl.cpp
@@ -31,6 +31,8 @@ std::string getlegend(size_t i, size_t n) {
     throw std::logic_error("Should have not ended up here.\n");
 }
 
+Settings settings;
+
 int main_guarded(int argc, char **argv) {
   if(argc!=3) {
     printf("Usage: %s chkpt1 chkpt2",argv[0]);

--- a/src/erifit.cpp
+++ b/src/erifit.cpp
@@ -23,6 +23,8 @@
 #include "settings.h"
 #include "eriworker.h"
 
+extern Settings settings;
+
 namespace ERIfit {
 
   bool operator<(const bf_pair_t & lhs, const bf_pair_t & rhs) {
@@ -31,11 +33,11 @@ namespace ERIfit {
 
   void get_basis(BasisSet & basis, const BasisSetLibrary & blib, const ElementBasisSet & orbel) {
     // Settings needed to form basis set
-    Settings set;
-    set.add_scf_settings();
-    set.set_bool("BasisRotate", false);
-    set.set_string("Decontract", "");
-    set.set_bool("UseLM", true);
+    Settings settings0(settings);
+    settings.add_scf_settings();
+    settings.set_bool("BasisRotate", false);
+    settings.set_string("Decontract", "");
+    settings.set_bool("UseLM", true);
 
     // Atoms
     std::vector<atom_t> atoms(1);
@@ -45,7 +47,7 @@ namespace ERIfit {
     atoms[0].Q=0;
 
     // Form basis set
-    construct_basis(basis,atoms,blib,set);
+    construct_basis(basis,atoms,blib);
   }
 
   void orthonormal_ERI_trans(const ElementBasisSet & orbel, double linthr, arma::mat & trans) {

--- a/src/external/adf/main.cpp
+++ b/src/external/adf/main.cpp
@@ -17,6 +17,7 @@
 #include "../../emd/emd_sto.h"
 #include "../../mathf.h"
 #include "../../stringutil.h"
+#include "../../settings.h"
 #include "../../lmgrid.h"
 #include "../../timer.h"
 #include "../storage.h"
@@ -334,6 +335,8 @@ arma::mat form_density() {
 
   return P;
 }
+
+Settings settings;
 
 int main_guarded(int argc, char **argv) {
 #ifdef _OPENMP

--- a/src/external/fchkpt.cpp
+++ b/src/external/fchkpt.cpp
@@ -273,14 +273,15 @@ void write_basis(const BasisSet & basis, FILE *out) {
   print("Contraction coefficients",contr,out);
 }
 
+Settings settings;
 
-void load_fchk(const Settings & set, double tol) {
+void load_fchk(double tol) {
   Timer t;
 
   // Read in checkpoint
   printf("Read in formatted checkpoint ... ");
   fflush(stdout);
-  Storage stor=parse_fchk(set.get_string("LoadFchk"));
+  Storage stor=parse_fchk(settings.get_string("LoadFchk"));
   printf("done (%s)\n",t.elapsed().c_str());
   //  stor.print(false);
 
@@ -383,7 +384,7 @@ void load_fchk(const Settings & set, double tol) {
 
 
   // Renormalize
-  if(set.get_bool("Renormalize")) {
+  if(settings.get_bool("Renormalize")) {
     P*=Nel/nelnum;
 
     if(!restr) {
@@ -392,7 +393,7 @@ void load_fchk(const Settings & set, double tol) {
     }
   }
 
-  if(set.get_bool("Reorthonormalize")) {
+  if(settings.get_bool("Reorthonormalize")) {
     printf("\nReorthonormalizing orbitals ... ");
     fflush(stdout);
     t.set();
@@ -434,7 +435,7 @@ void load_fchk(const Settings & set, double tol) {
 
   // Save the result
   t.set();
-  Checkpoint chkpt(set.get_string("SaveChk"),true);
+  Checkpoint chkpt(settings.get_string("SaveChk"),true);
   chkpt.write(basis);
   chkpt.write("P",P);
 
@@ -479,11 +480,11 @@ void load_fchk(const Settings & set, double tol) {
   printf("\nERKALE checkpoint saved in %s.\n",t.elapsed().c_str());
 }
 
-void save_fchk(const Settings & set) {
+void save_fchk() {
   Timer t;
 
   // Load checkpoint
-  Checkpoint chkpt(set.get_string("LoadChk"),false);
+  Checkpoint chkpt(settings.get_string("LoadChk"),false);
 
   // Construct basis
   BasisSet basis;
@@ -491,7 +492,7 @@ void save_fchk(const Settings & set) {
   //  basis.print(true);
 
   // File to save
-  std::string savename=set.get_string("SaveFchk");
+  std::string savename=settings.get_string("SaveFchk");
 
   // Handle also compressed files
   std::string gzcmd="gzip ";
@@ -515,7 +516,7 @@ void save_fchk(const Settings & set) {
     uselzma=true;
 
   // Open output file.
-  FILE *out=fopen(set.get_string("SaveFchk").c_str(),"w");
+  FILE *out=fopen(settings.get_string("SaveFchk").c_str(),"w");
 
   // Write comment
   fprintf(out,"%-80s\n","ERKALE formatted checkpoint for visualization purposes");
@@ -666,29 +667,28 @@ int main_guarded(int argc, char **argv) {
     return 1;
   }
 
-  Settings set;
-  set.add_string("LoadFchk","Gaussian formatted checkpoint file to load","");
-  set.add_string("SaveFchk","Gaussian formatted checkpoint file to load","");
-  set.add_double("FchkTol","Tolerance for deviation in orbital orthonormality and density matrix",1e-8);
-  set.add_bool("Renormalize","Renormalize density matrix?",false);
-  set.add_bool("Reorthonormalize","Reorthonormalize orbitals?",false);
-  set.add_string("LoadChk","Save results to ERKALE checkpoint","");
-  set.add_string("SaveChk","Save results to ERKALE checkpoint","");
+  settings.add_string("LoadFchk","Gaussian formatted checkpoint file to load","");
+  settings.add_string("SaveFchk","Gaussian formatted checkpoint file to load","");
+  settings.add_double("FchkTol","Tolerance for deviation in orbital orthonormality and density matrix",1e-8);
+  settings.add_bool("Renormalize","Renormalize density matrix?",false);
+  settings.add_bool("Reorthonormalize","Reorthonormalize orbitals?",false);
+  settings.add_string("LoadChk","Save results to ERKALE checkpoint","");
+  settings.add_string("SaveChk","Save results to ERKALE checkpoint","");
 
   // Parse settings
-  set.parse(argv[1]);
-  set.print();
+  settings.parse(argv[1]);
+  settings.print();
 
-  bool loadfchk=(set.get_string("LoadFchk")!="");
-  bool savefchk=(set.get_string("SaveFchk")!="");
-  bool loadchk=(set.get_string("LoadChk")!="");
-  bool savechk=(set.get_string("SaveChk")!="");
-  double tol=set.get_double("FchkTol");
+  bool loadfchk=(settings.get_string("LoadFchk")!="");
+  bool savefchk=(settings.get_string("SaveFchk")!="");
+  bool loadchk=(settings.get_string("LoadChk")!="");
+  bool savechk=(settings.get_string("SaveChk")!="");
+  double tol=settings.get_double("FchkTol");
 
   if(loadfchk && savechk && !loadchk && !savefchk)
-    load_fchk(set,tol);
+    load_fchk(tol);
   else if(!loadfchk && !savechk && loadchk && savefchk)
-    save_fchk(set);
+    save_fchk();
   else
     throw std::runtime_error("Conflicting settings!\n");
 

--- a/src/global.h
+++ b/src/global.h
@@ -106,9 +106,6 @@
 // Tolerance when screening is only wrt absolute value of integrals
 #define STRICTTOL 1e-16
 
-// Threshold for linear independence
-#define LINTHRES 1e-5
-
 // Shorthands
 #define COMPLEX1 std::complex<double>(1.0,0.0)
 #define COMPLEXI std::complex<double>(0.0,1.0)

--- a/src/guess.h
+++ b/src/guess.h
@@ -19,7 +19,6 @@
 
 #include "global.h"
 class BasisSet;
-class Settings;
 
 #include <vector>
 #include <armadillo>
@@ -36,25 +35,30 @@ class Settings;
  *
  * Optional charge can be given as input.
  */
-arma::mat sad_guess(const BasisSet & basis, Settings set);
+arma::mat sad_guess(const BasisSet & basis);
 
 /// Same, but do SAP guess by projecting Fock matrices. Not as good as the real-space version
-arma::mat sap_guess(const BasisSet & basis, Settings set);
+arma::mat sap_guess(const BasisSet & basis);
 
 /**
- * Form starting guess from a Huckel type calculation
+ * Form starting guess from a Huckel type calculation. See
+ *
+ * "An assessment of initial guesses for self-consistent field
+ * calculations. Superposition of Atomic Potentials: simple yet
+ * efficient" by S. Lehtola, J. Chem. Theory Comput. (2019), 
+ * DOI: 10.1021/acs.jctc.8b01089.
  *
  * "Phosphorescence parameters for platinum (II) organometallic
  * chromophores: A study at the non-collinear four-component Kohn–Sham
  * level of theory" by P. Norman and H. J. Aa. Jensen,
  * Chem. Phys. Lett. 531 (2012), pp. 229-235.
  */
-arma::mat huckel_guess(const BasisSet & basis, Settings set, double Kgwh);
+arma::mat huckel_guess(const BasisSet & basis, double Kgwh);
 
 /**
  * Forms a projection to a minimal atomic basis set.
  */
-arma::mat minimal_basis_projection(const BasisSet & basis, Settings set);
+arma::mat minimal_basis_projection(const BasisSet & basis);
 
 /**
  * Worker routine - perform guess for inuc:th atom in basis, using given method.

--- a/src/linalg.h
+++ b/src/linalg.h
@@ -17,7 +17,6 @@
 
 
 #include "global.h"
-class Settings;
 
 #ifndef ERKALE_LINALG
 #define ERKALE_LINALG
@@ -101,17 +100,17 @@ arma::mat SymmetricOrth(const arma::mat & S);
 /// Same, but use computed decomoposition
 arma::mat SymmetricOrth(const arma::mat & Svec, const arma::vec & Sval);
 /// Canonical orthogonalization of basis set
-arma::mat CanonicalOrth(const arma::mat & S, double cutoff=LINTHRES);
+arma::mat CanonicalOrth(const arma::mat & S, double cutoff);
 /// Same, but use computed decomposition
 arma::mat CanonicalOrth(const arma::mat & Svec, const arma::vec & Sval, double cutoff);
 
 /// Automatic orthonormalization.
 arma::mat BasOrth(const arma::mat & S, bool verbose);
 /// Orthogonalize basis
-arma::mat BasOrth(const arma::mat & S, const Settings & set);
+arma::mat BasOrth(const arma::mat & S);
 
-/// Form matrices S^1/2 and S^-1/2. By default matrices are computed in symmetric form, but canonical form is also available.
-void S_half_invhalf(const arma::mat & S, arma::mat & Shalf, arma::mat & Sinvhalf, bool canonical=false, double cutoff=LINTHRES);
+/// Form matrices S^1/2 and S^-1/2.
+void S_half_invhalf(const arma::mat & S, arma::mat & Shalf, arma::mat & Sinvhalf, double cutoff);
 
 /// Transform matrix to vector
 arma::vec MatToVec(const arma::mat & v);

--- a/src/localization.cpp
+++ b/src/localization.cpp
@@ -28,6 +28,7 @@
 #include "localization.h"
 #include "mathf.h"
 #include "properties.h"
+#include "settings.h"
 #include "stringutil.h"
 #include "stockholder.h"
 #include "timer.h"
@@ -853,6 +854,8 @@ static std::string pipek_filename(size_t iat) {
   return oss.str();
 }
 
+extern Settings settings;
+
 Pipek::Pipek(enum chgmet chgv, const BasisSet & basis, const arma::mat & C, const arma::mat & P, double pv, bool ver, bool delocalize) : UnitaryFunction(2*pv,!delocalize) {
   // Store used method
   chg=chgv;
@@ -1018,7 +1021,7 @@ Pipek::Pipek(enum chgmet chgv, const BasisSet & basis, const arma::mat & C, cons
     arma::mat S(basis.overlap());
     // Get S^1/2 (and S^-1/2)
     arma::mat Sh, Sinvh;
-    S_half_invhalf(S,Sh,Sinvh);
+    S_half_invhalf(S,Sh,Sinvh,settings.get_double("LinDepThresh"));
 
     // Get shells
     for(size_t iat=0;iat<N;iat++) {

--- a/src/localize.cpp
+++ b/src/localize.cpp
@@ -405,6 +405,8 @@ void print_header() {
   print_hostname();
 }
 
+Settings settings;
+
 int main_guarded(int argc, char **argv) {
   print_header();
 
@@ -416,42 +418,41 @@ int main_guarded(int argc, char **argv) {
   // Initialize libint
   init_libint_base();
 
-  Settings set;
-  set.add_string("LoadChk","Checkpoint to load","erkale.chk");
-  set.add_string("SaveChk","Checkpoint to save results to","erkale.chk");
-  set.add_string("Method","Localization method: FB, FB2, FM, FM2, MU, MU2, LO, LO2, BA, BA2, BE, BE2, HI, HI2, IHI, IHI2, IAO, IAO2, ST, ST2, VO, VO2, ER","FB");
-  set.add_bool("Virtual","Localize virtual orbitals as well?",false);
-  set.add_string("Logfile","File to store output in","");
-  set.add_string("Accelerator","Accelerator to use: SDSA, CGPR, CGFR, CGHS","CGPR");
-  set.add_string("LineSearch","Line search to use: poly_df, poly_f, poly_fdf, armijo, fourier_df","poly_df");
-  set.add_string("StartingPoint","Starting point to use: CAN, NAT, CHOL, ORTH, UNIT?","ORTH");
-  set.add_bool("Delocalize","Run delocalization instead of localization",false);
-  set.add_string("SizeDistribution","File to save orbital size distribution in","");
-  set.add_double("GThreshold","Threshold for convergence: norm of Riemannian gradient",1e-7);
-  set.add_double("FThreshold","Threshold for convergence: absolute change in function",DBL_MAX);
-  set.add_int("Maxiter","Maximum number of iterations",50000);
-  set.add_int("Seed","Random number seed",0);
-  set.add_bool("Debug","Print out line search every iteration",false);
-  set.parse(argv[1]);
-  set.print();
+  settings.add_string("LoadChk","Checkpoint to load","erkale.chk");
+  settings.add_string("SaveChk","Checkpoint to save results to","erkale.chk");
+  settings.add_string("Method","Localization method: FB, FB2, FM, FM2, MU, MU2, LO, LO2, BA, BA2, BE, BE2, HI, HI2, IHI, IHI2, IAO, IAO2, ST, ST2, VO, VO2, ER","FB");
+  settings.add_bool("Virtual","Localize virtual orbitals as well?",false);
+  settings.add_string("Logfile","File to store output in","");
+  settings.add_string("Accelerator","Accelerator to use: SDSA, CGPR, CGFR, CGHS","CGPR");
+  settings.add_string("LineSearch","Line search to use: poly_df, poly_f, poly_fdf, armijo, fourier_df","poly_df");
+  settings.add_string("StartingPoint","Starting point to use: CAN, NAT, CHOL, ORTH, UNIT?","ORTH");
+  settings.add_bool("Delocalize","Run delocalization instead of localization",false);
+  settings.add_string("SizeDistribution","File to save orbital size distribution in","");
+  settings.add_double("GThreshold","Threshold for convergence: norm of Riemannian gradient",1e-7);
+  settings.add_double("FThreshold","Threshold for convergence: absolute change in function",DBL_MAX);
+  settings.add_int("Maxiter","Maximum number of iterations",50000);
+  settings.add_int("Seed","Random number seed",0);
+  settings.add_bool("Debug","Print out line search every iteration",false);
+  settings.parse(argv[1]);
+  settings.print();
 
   printf("Please read and cite the reference:\n%s\n%s\n%s\n\n", \
 	 "S. Lehtola and H. Jónsson",         \
 	 "Unitary Optimization of Localized Molecular Orbitals", \
 	 "J. Chem. Theory Comput. 9 (2013), pp. 5365 - 5372.");
 
-  std::string logfile=set.get_string("Logfile");
-  bool virt=set.get_bool("Virtual");
-  int seed=set.get_int("Seed");
+  std::string logfile=settings.get_string("Logfile");
+  bool virt=settings.get_bool("Virtual");
+  int seed=settings.get_int("Seed");
 
-  std::string loadname(set.get_string("LoadChk"));
-  std::string savename(set.get_string("SaveChk"));
-  std::string sizedist(set.get_string("SizeDistribution"));
+  std::string loadname(settings.get_string("LoadChk"));
+  std::string savename(settings.get_string("SaveChk"));
+  std::string sizedist(settings.get_string("SizeDistribution"));
   bool size=stricmp(sizedist,"");
-  bool debug=set.get_bool("Debug");
+  bool debug=settings.get_bool("Debug");
 
   // Determine method
-  enum locmet method(parse_locmet(set.get_string("Method")));
+  enum locmet method(parse_locmet(settings.get_string("Method")));
 
   if(method>=PIPEK_MULLIKENH && method<=PIPEK_VORONOI4) {
     printf("Please read and cite the reference:\n%s\n%s\n%s\n\n",	\
@@ -462,7 +463,7 @@ int main_guarded(int argc, char **argv) {
 
   // Determine accelerator
   enum unitacc acc;
-  std::string accs=set.get_string("Accelerator");
+  std::string accs=settings.get_string("Accelerator");
   if(stricmp(accs,"SDSA")==0)
     acc=SDSA;
   else if(stricmp(accs,"CGPR")==0)
@@ -475,7 +476,7 @@ int main_guarded(int argc, char **argv) {
 
   // Determine line search
   enum unitmethod umet;
-  std::string umets=set.get_string("LineSearch");
+  std::string umets=settings.get_string("LineSearch");
   if(stricmp(umets,"poly_df")==0)
     umet=POLY_DF;
   else if(stricmp(umets,"poly_f")==0)
@@ -498,12 +499,12 @@ int main_guarded(int argc, char **argv) {
   }
 
   // Delocalize orbitals?
-  bool delocalize=set.get_bool("Delocalize");
+  bool delocalize=settings.get_bool("Delocalize");
   // Iteration count
-  int maxiter=set.get_int("Maxiter");
+  int maxiter=settings.get_int("Maxiter");
 
   // Starting point
-  std::string startp=set.get_string("StartingPoint");
+  std::string startp=settings.get_string("StartingPoint");
   enum startingpoint start;
   if(stricmp(startp,"CAN")==0)
     start=CANORB;
@@ -521,8 +522,8 @@ int main_guarded(int argc, char **argv) {
   }
 
   // Convergence threshold
-  double Gthr=set.get_double("GThreshold");
-  double Fthr=set.get_double("FThreshold");
+  double Gthr=settings.get_double("GThreshold");
+  double Fthr=settings.get_double("FThreshold");
 
   // Open checkpoint in read-write mode, don't truncate
   Checkpoint chkpt(savename,true,false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,11 +60,13 @@ void print_header() {
   print_hostname();
 }
 
+Settings settings;
+
 int main_guarded(int argc, char **argv) {
   print_header();
 
   if(argc!=2) {
-    printf("Usage: $ %s runfile\n",argv[0]);
+    printf("Usage: %s runfile\n",argv[0]);
     return 0;
   }
 
@@ -75,16 +77,15 @@ int main_guarded(int argc, char **argv) {
   t.print_time();
 
   // Parse settings
-  Settings set;
-  set.add_scf_settings();
-  set.add_string("SaveChk","File to use as checkpoint","erkale.chk");
-  set.add_string("LoadChk","File to load old results from","");
-  set.add_bool("ForcePol","Force polarized calculation",false);
-  set.parse(std::string(argv[1]),true);
-  set.print();
+  settings.add_scf_settings();
+  settings.add_string("SaveChk","File to use as checkpoint","erkale.chk");
+  settings.add_string("LoadChk","File to load old results from","");
+  settings.add_bool("ForcePol","Force polarized calculation",false);
+  settings.parse(std::string(argv[1]),true);
+  settings.print();
 
   // Redirect output?
-  std::string logfile=set.get_string("Logfile");
+  std::string logfile=settings.get_string("Logfile");
   if(stricmp(logfile,"stdout")!=0) {
     // Redirect stdout to file
     FILE *outstream=freopen(logfile.c_str(),"w",stdout);
@@ -100,10 +101,10 @@ int main_guarded(int argc, char **argv) {
 
   // Basis set
   BasisSet basis;
-  std::string basfile(set.get_string("Basis"));
+  std::string basfile(settings.get_string("Basis"));
   if(stricmp(basfile,"Read")==0) {
     // Get checkpoint file
-    std::string chkf(set.get_string("LoadChk"));
+    std::string chkf(settings.get_string("LoadChk"));
     if(!chkf.size())
       throw std::runtime_error("Must specify LoadChk for Basis Read\n");
     if(!file_exists(chkf))
@@ -116,16 +117,16 @@ int main_guarded(int argc, char **argv) {
   } else {
     // Read in atoms.
     std::vector<atom_t> atoms;
-    std::string atomfile=set.get_string("System");
+    std::string atomfile=settings.get_string("System");
     if(file_exists(atomfile))
-      atoms=load_xyz(atomfile,!set.get_bool("InputBohr"));
+      atoms=load_xyz(atomfile,!settings.get_bool("InputBohr"));
     else {
       // Check if a directory has been set
       char * libloc=getenv("ERKALE_SYSDIR");
       if(libloc) {
 	std::string filename=std::string(libloc)+"/"+atomfile;
 	if(file_exists(filename))
-	  atoms=load_xyz(filename,!set.get_bool("InputBohr"));
+	  atoms=load_xyz(filename,!settings.get_bool("InputBohr"));
 	else
 	  throw std::runtime_error("Unable to open xyz input file!\n");
       } else
@@ -137,13 +138,13 @@ int main_guarded(int argc, char **argv) {
     baslib.load_basis(basfile);
 
     // Construct basis set
-    construct_basis(basis,atoms,baslib,set);
+    construct_basis(basis,atoms,baslib);
   }
 
   // Do the calculation
-  calculate(basis,set);
+  calculate(basis);
 
-  if(set.get_bool("Verbose")) {
+  if(settings.get_bool("Verbose")) {
     printf("\nRunning program took %s.\n",t.elapsed().c_str());
     t.print_time();
   }

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -35,6 +35,8 @@
 #include "version.h"
 #endif
 
+Settings settings;
+
 int main_guarded(int argc, char **argv) {
 #ifdef _OPENMP
   printf("ERKALE - population from Hel, OpenMP version, running on %i cores.\n",omp_get_max_threads());
@@ -54,38 +56,37 @@ int main_guarded(int argc, char **argv) {
   }
 
   // Parse settings
-  Settings set;
-  set.add_string("LoadChk","Checkpoint file to load density from","erkale.chk");
-  set.add_bool("Bader", "Run Bader analysis?", false);
-  set.add_bool("Becke", "Run Becke analysis?", false);
-  set.add_bool("Mulliken", "Run Mulliken analysis?", false);
-  set.add_bool("Lowdin", "Run Löwdin analysis?", false);
-  set.add_bool("IAO", "Run Intrinsic Atomic Orbital analysis?", false);
-  set.add_string("IAOBasis", "Minimal basis set for IAO analysis", "MINAO.gbs");
-  set.add_bool("Hirshfeld", "Run Hirshfeld analysis?", false);
-  set.add_string("HirshfeldMethod", "Method to use for Hirshfeld(-I) analysis", "HF");
-  set.add_bool("IterativeHirshfeld", "Run iterative Hirshfeld analysis?", false);
-  set.add_bool("Stockholder", "Run Stockholder analysis?", false);
-  set.add_bool("Voronoi", "Run Voronoi analysis?", false);
-  set.add_double("Tol", "Grid tolerance to use for the charges", 1e-5);
-  set.add_bool("OrbThr", "Compute orbital density thresholds", false);
-  set.add_bool("VirtThr", "Also do the virtual orbitals?", false);
-  set.add_bool("SICThr", "Compute SIC orbital density thresholds", false);
-  set.add_bool("DensThr", "Compute total density thresholds", false);
-  set.add_double("OrbThrVal", "Which density threshold to calculate", 0.85);
-  set.add_double("OrbThrGrid", "Accuracy of orbital density threshold integration grid", 1e-3);
+  settings.add_string("LoadChk","Checkpoint file to load density from","erkale.chk");
+  settings.add_bool("Bader", "Run Bader analysis?", false);
+  settings.add_bool("Becke", "Run Becke analysis?", false);
+  settings.add_bool("Mulliken", "Run Mulliken analysis?", false);
+  settings.add_bool("Lowdin", "Run Löwdin analysis?", false);
+  settings.add_bool("IAO", "Run Intrinsic Atomic Orbital analysis?", false);
+  settings.add_string("IAOBasis", "Minimal basis set for IAO analysis", "MINAO.gbs");
+  settings.add_bool("Hirshfeld", "Run Hirshfeld analysis?", false);
+  settings.add_string("HirshfeldMethod", "Method to use for Hirshfeld(-I) analysis", "HF");
+  settings.add_bool("IterativeHirshfeld", "Run iterative Hirshfeld analysis?", false);
+  settings.add_bool("Stockholder", "Run Stockholder analysis?", false);
+  settings.add_bool("Voronoi", "Run Voronoi analysis?", false);
+  settings.add_double("Tol", "Grid tolerance to use for the charges", 1e-5);
+  settings.add_bool("OrbThr", "Compute orbital density thresholds", false);
+  settings.add_bool("VirtThr", "Also do the virtual orbitals?", false);
+  settings.add_bool("SICThr", "Compute SIC orbital density thresholds", false);
+  settings.add_bool("DensThr", "Compute total density thresholds", false);
+  settings.add_double("OrbThrVal", "Which density threshold to calculate", 0.85);
+  settings.add_double("OrbThrGrid", "Accuracy of orbital density threshold integration grid", 1e-3);
 
   // Parse settings
-  set.parse(argv[1]);
+  settings.parse(argv[1]);
 
   // Print settings
-  set.print();
+  settings.print();
 
   // Initialize libint
   init_libint_base();
 
   // Load checkpoint
-  Checkpoint chkpt(set.get_string("LoadChk"),false);
+  Checkpoint chkpt(settings.get_string("LoadChk"),false);
 
   // Load basis set
   BasisSet basis;
@@ -102,40 +103,40 @@ int main_guarded(int argc, char **argv) {
     chkpt.read("Pb",Pb);
   }
 
-  double tol=set.get_double("Tol");
+  double tol=settings.get_double("Tol");
 
-  if(set.get_bool("Bader")) {
+  if(settings.get_bool("Bader")) {
     if(restr)
       bader_analysis(basis,P,tol);
     else
       bader_analysis(basis,Pa,Pb,tol);
   }
 
-  if(set.get_bool("Becke")) {
+  if(settings.get_bool("Becke")) {
     if(restr)
       becke_analysis(basis,P,tol);
     else
       becke_analysis(basis,Pa,Pb,tol);
   }
 
-  std::string hmet=set.get_string("HirshfeldMethod");
+  std::string hmet=settings.get_string("HirshfeldMethod");
 
-  if(set.get_bool("Hirshfeld")) {
+  if(settings.get_bool("Hirshfeld")) {
     if(restr)
       hirshfeld_analysis(basis,P,hmet,tol);
     else
       hirshfeld_analysis(basis,Pa,Pb,hmet,tol);
   }
 
-  if(set.get_bool("IterativeHirshfeld")) {
+  if(settings.get_bool("IterativeHirshfeld")) {
     if(restr)
       iterative_hirshfeld_analysis(basis,P,hmet,tol);
     else
       iterative_hirshfeld_analysis(basis,Pa,Pb,hmet,tol);
   }
 
-  if(set.get_bool("IAO")) {
-    std::string minbas=set.get_string("IAOBasis");
+  if(settings.get_bool("IAO")) {
+    std::string minbas=settings.get_string("IAOBasis");
 
     if(restr) {
       // Get amount of occupied orbitals
@@ -174,44 +175,44 @@ int main_guarded(int argc, char **argv) {
     }
   }
 
-  if(set.get_bool("Lowdin")) {
+  if(settings.get_bool("Lowdin")) {
     if(restr)
       lowdin_analysis(basis,P);
     else
       lowdin_analysis(basis,Pa,Pb);
   }
 
-  if(set.get_bool("Mulliken")) {
+  if(settings.get_bool("Mulliken")) {
     if(restr)
       mulliken_analysis(basis,P);
     else
       mulliken_analysis(basis,Pa,Pb);
   }
 
-  if(set.get_bool("Stockholder")) {
+  if(settings.get_bool("Stockholder")) {
     if(restr)
       stockholder_analysis(basis,P,tol);
     else
       stockholder_analysis(basis,Pa,Pb,tol);
   }
 
-  if(set.get_bool("Voronoi")) {
+  if(settings.get_bool("Voronoi")) {
     if(restr)
       voronoi_analysis(basis,P,tol);
     else
       voronoi_analysis(basis,Pa,Pb,tol);
   }
 
-  if(set.get_bool("OrbThr")) {
+  if(settings.get_bool("OrbThr")) {
     // Calculate orbital density thresholds
 
     // Integration grid
     DFTGrid intgrid(&basis,true);
-    intgrid.construct_becke(set.get_double("OrbThrGrid"));
+    intgrid.construct_becke(settings.get_double("OrbThrGrid"));
 
     // Threshold is
-    double thr=set.get_double("OrbThrVal");
-    bool virt=set.get_bool("VirtThr");
+    double thr=settings.get_double("OrbThrVal");
+    bool virt=settings.get_bool("VirtThr");
 
     if(restr) {
       // Get amount of occupied orbitals
@@ -274,15 +275,15 @@ int main_guarded(int argc, char **argv) {
     }
   }
 
-  if(set.get_bool("SICThr")) {
+  if(settings.get_bool("SICThr")) {
     // Calculate SIC orbital density thresholds
 
     // Integration grid
     DFTGrid intgrid(&basis,true);
-    intgrid.construct_becke(set.get_double("OrbThrGrid"));
+    intgrid.construct_becke(settings.get_double("OrbThrGrid"));
 
     // Threshold is
-    double thr=set.get_double("OrbThrVal");
+    double thr=settings.get_double("OrbThrVal");
 
     if(restr) {
       // Get orbital coefficients
@@ -331,15 +332,15 @@ int main_guarded(int argc, char **argv) {
     }
   }
 
-  if(set.get_bool("DensThr")) {
+  if(settings.get_bool("DensThr")) {
     // Calculate total density thresholds
 
     // Integration grid
     DFTGrid intgrid(&basis,true);
-    intgrid.construct_becke(set.get_double("OrbThrGrid"));
+    intgrid.construct_becke(settings.get_double("OrbThrGrid"));
 
     // Threshold is
-    double thr=set.get_double("OrbThrVal");
+    double thr=settings.get_double("OrbThrVal");
 
     Timer t;
 

--- a/src/properties.cpp
+++ b/src/properties.cpp
@@ -22,6 +22,7 @@
 #include "stockholder.h"
 #include "hirshfeldi.h"
 #include "linalg.h"
+#include "settings.h"
 
 void print_analysis(const BasisSet & basis, const std::string & msg, const arma::vec & q) {
   printf("\n%s charges\n",msg.c_str());
@@ -272,13 +273,15 @@ void lowdin_analysis(const BasisSet & basis, const arma::mat & Pa, const arma::m
   print_analysis(basis,"Löwdin spin",qs);
 }
 
+extern Settings settings;
+
 arma::vec lowdin_charges(const BasisSet & basis, const arma::mat & P) {
   // Get overlap matrix
   arma::mat S=basis.overlap();
 
   // Get half overlap
   arma::mat Sh, Sinvh;
-  S_half_invhalf(S,Sh,Sinvh);
+  S_half_invhalf(S,Sh,Sinvh,settings.get_double("LinDepThresh"));
 
   // Compute ShPSh
   arma::mat SPS=Sh*P*Sh;
@@ -311,7 +314,7 @@ arma::mat lowdin_charges(const BasisSet & basis, const arma::mat & Pa, const arm
 
   // Get half overlap
   arma::mat Sh, Sinvh;
-  S_half_invhalf(S,Sh,Sinvh);
+  S_half_invhalf(S,Sh,Sinvh,settings.get_double("LinDepThresh"));
 
   // Compute ShPSh
   arma::mat SPaS=Sh*Pa*Sh;

--- a/src/scf.h
+++ b/src/scf.h
@@ -28,7 +28,6 @@ class DFTGrid;
 #include "eriscreen.h"
 #include "erichol.h"
 #include "density_fitting.h"
-class Settings;
 
 class Checkpoint;
 
@@ -331,7 +330,7 @@ class SCF {
 
  public:
   /// Constructor
-  SCF(const BasisSet & basis, const Settings & set, Checkpoint & chkpt);
+  SCF(const BasisSet & basis, Checkpoint & chkpt);
   ~SCF();
 
   /// Calculate restricted Hartree-Fock solution
@@ -476,9 +475,9 @@ arma::mat purify_density_NO(const arma::mat & P, arma::mat & C, const arma::mat 
 /// Get atomic occupancy (fractional occupation of full valence shell)
 std::vector<double> atomic_occupancy(double Nalpha, int Nbf);
 /// Generate orbital occupancies
-std::vector<double> get_restricted_occupancy(const Settings & set, const BasisSet & basis);
+std::vector<double> get_restricted_occupancy(const BasisSet & basis);
 /// Generate orbital occupancies
-void get_unrestricted_occupancy(const Settings & set, const BasisSet & basis, std::vector<double> & occa, std::vector<double> & occb);
+void get_unrestricted_occupancy(const BasisSet & basis, std::vector<double> & occa, std::vector<double> & occb);
 
 /// Compute magnitude of dipole moment
 double dip_mom(const arma::mat & P, const BasisSet & basis);
@@ -491,10 +490,10 @@ double electron_spread(const arma::mat & P, const BasisSet & basis);
 void get_Nel_alpha_beta(int Nel, int mult, int & Nel_alpha, int & Nel_beta);
 
 /// Parse DFT grid settings
-dft_t parse_dft(const Settings & set, bool init);
+dft_t parse_dft(bool init);
 
 /// Run the calculation
-void calculate(const BasisSet & basis, const Settings & set, bool doforce=false);
+void calculate(const BasisSet & basis, bool doforce=false);
 
 /// Helper for sorting orbitals into maximum overlap
 typedef struct {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -41,7 +41,7 @@ void Settings::add_scf_settings() {
   // Default basis set
   add_string("Basis", "Basis set used in calculation", "aug-cc-pVTZ");
   // Rotate basis set to drop out redundant functions?
-  add_bool("BasisRotate", "Rotate basis set to remove redundant functions?", true);
+  add_bool("BasisRotate", "Rotate basis set to remove redundant functions?", false);
   // Cutoff for redundant functions
   add_double("BasisCutoff", "Cutoff for dropping out small primitives from contraction", 1e-8);
 
@@ -114,6 +114,8 @@ void Settings::add_scf_settings() {
 
   // Default orthogonalization method
   add_string("BasisOrth", "Method of orthonormalization of basis set", "Auto");
+  // Linear dependence threshold
+  add_double("LinDepThresh", "Basis set linear dependency threshold", 1e-5);
 
   // Convergence criterion
   add_double("ConvThr", "Orbital gradient convergence threshold", 1e-6);
@@ -137,9 +139,7 @@ void Settings::add_scf_settings() {
   add_int("FittingMemory", "Amount of memory in MB to use for exchange fitting",1000);
   // Threshold for screening eigenvectors
   add_double("FittingThreshold", "Linear dependence threshold for Coulomb integrals in density fitting",1e-8);
-}
 
-void Settings::add_dft_settings() {
   // Use Lobatto quadrature?
   add_bool("DFTLobatto", "Use Lobatto quadrature instead of Lebedev quadrature?", false);
 
@@ -442,12 +442,6 @@ void Settings::parse(std::string filename, bool scf) {
 	  set_string("Method","ROHF");
 	  set_bool("DensityFitting",false);
 	} else {
-	  // Add dft related settings
-	  try {
-	    add_dft_settings();
-	  } catch(std::runtime_error &) {
-	    // Settings already added, as e.g. in xrs executable.
-	  }
 	  set_string("Method",words[1]);
 
 	  // Hybrid functional? Do we turn off density fitting by default?

--- a/src/settings.h
+++ b/src/settings.h
@@ -89,8 +89,6 @@ class Settings {
 
   /// Add SCF related settings
   void add_scf_settings();
-  /// Add DFT related settings
-  void add_dft_settings();
 
   /// Add a double valued setting
   void add_double(std::string name, std::string comment, double val, bool negative=false);

--- a/src/slaterfit/main.cpp
+++ b/src/slaterfit/main.cpp
@@ -16,11 +16,14 @@
 
 #include "form_exponents.h"
 #include "solve_coefficients.h"
+#include "settings.h"
 #include "../basis.h"
 
 #ifdef SVNRELEASE
 #include "../version.h"
 #endif
+
+Settings settings;
 
 int main_guarded(int argc, char **argv) {
   print_copyright();
@@ -30,20 +33,24 @@ int main_guarded(int argc, char **argv) {
 #endif
   print_hostname();
 
-  if(argc!=5) {
-    printf("Usage: %s zeta l Nf method\n",argv[0]);
-    printf("zeta is the STO exponent to fit\n");
-    printf("l is angular momentum to use\n");
-    printf("Nf is number of exponents to use\n");
-    printf("method is 0 for even-tempered, 1 for well-tempered and 2 for full optimization, or 3 for midpoint quadrature.\n");
+  settings.add_double("zeta","STO exponent to fit",1.0);
+  settings.add_int("l","angular momentum",0);
+  settings.add_int("nfunc","number of functions to use",3);
+  settings.add_int("method","method to use: 0 even-tempered, 1 well-tempered, 2 full optimization, 3 midpoint quadrature",3);
+
+  if(argc!=2) {
+    printf("Usage: %s runfile\n",argv[0]);
+    settings.print();
     return 1;
   }
+  settings.parse(std::string(argv[1]),true);
+  settings.print();
 
   // Read parameteres
-  double zeta=atof(argv[1]);
-  double am=atoi(argv[2]);
-  int Nf=atoi(argv[3]);
-  int method=atoi(argv[4]);
+  double zeta=settings.get_double("zeta");
+  double am=settings.get_int("l");
+  int Nf=settings.get_int("nfunc");
+  int method=settings.get_int("method");
 
   // Do the optimization
   std::vector<contr_t> contr;

--- a/src/test/basictests.cpp
+++ b/src/test/basictests.cpp
@@ -18,6 +18,7 @@
 #include "../checkpoint.h"
 #include "../linalg.h"
 #include "../mathf.h"
+#include "../settings.h"
 
 /// Check orthogonality of spherical harmonics up to
 const int Lmax=10;
@@ -193,7 +194,10 @@ void test_checkpoint() {
   remove(tmpfile.c_str());
 }
 
+Settings settings;
+
 int main(void) {
+  settings.add_scf_settings();
   // Test indices
   testind();
   // Then, check norms of spherical harmonics.

--- a/src/test/chkcompare.cpp
+++ b/src/test/chkcompare.cpp
@@ -18,6 +18,7 @@
 #include "../mathf.h"
 #include "../emd/emd_gto.h"
 #include "../stringutil.h"
+#include "../settings.h"
 
 /// Absolute tolerance for normalization of basis functions
 const double normtol=1e-10;
@@ -92,6 +93,8 @@ double E_diff(const arma::mat & Er, const arma::vec & Ec) {
 
   return arma::max(arma::abs((Er-Ec)/Enorm));
 }
+
+Settings settings;
 
 int main(int argc, char ** argv) {
   // Get reference directory

--- a/src/test/integraltest.cpp
+++ b/src/test/integraltest.cpp
@@ -1,6 +1,9 @@
 #include "../eriworker.h"
 #include "../integrals.h"
 #include "../checkpoint.h"
+#include "../settings.h"
+
+Settings settings;
 
 int main(int argc, char **argv) {
   if(argc!=2) {

--- a/src/xrs/xrsscf-base.cpp
+++ b/src/xrs/xrsscf-base.cpp
@@ -31,11 +31,13 @@
 #include "../trrh.h"
 #include "../lmgrid.h"
 
-XRSSCF::XRSSCF(const BasisSet & basis, const Settings & set, Checkpoint & chkpt, bool sp) : SCF(basis,set,chkpt) {
+extern Settings settings;
+
+XRSSCF::XRSSCF(const BasisSet & basis, Checkpoint & chkpt, bool sp) : SCF(basis,chkpt) {
   spin=sp;
 
   // Get number of alpha and beta electrons
-  get_Nel_alpha_beta(basis.Ztot()-set.get_int("Charge"),set.get_int("Multiplicity"),nocca,noccb);
+  get_Nel_alpha_beta(basis.Ztot()-settings.get_int("Charge"),settings.get_int("Multiplicity"),nocca,noccb);
 }
 
 XRSSCF::~XRSSCF() {

--- a/src/xrs/xrsscf.h
+++ b/src/xrs/xrsscf.h
@@ -44,7 +44,7 @@ class XRSSCF : public SCF {
 
  public:
   /// Constructor
-  XRSSCF(const BasisSet & basis, const Settings & set, Checkpoint & chkpt, bool spin);
+  XRSSCF(const BasisSet & basis, Checkpoint & chkpt, bool spin);
   /// Destructor
   ~XRSSCF();
 


### PR DESCRIPTION
This PR changes how ERKALE passes around various parameters inside the code. Instead of carrying the Setting object around in function calls, now a global variable is used instead. Although this is a bit ugly, it is much more convenient and is the way other programs do it as well.

The main reason for the change is that the linear dependence threshold used to be hardcoded in ERKALE, since it was complicated to pass around. Now, the user can choose the threshold with the ```LinDepThresh``` keyword.