### PR TITLE
Implement partial Cholesky orthonormalization (doi: 10.1063/1.5139948).

### DIFF
--- a/src/scf.h
+++ b/src/scf.h
@@ -200,8 +200,8 @@ enum pzham {
 enum pzham parse_pzham(const std::string & str);
 
 class SCF {
- protected:
- /// Overlap matrix
+protected:
+  /// Overlap matrix
   arma::mat S;
 
   /// Kinetic energy matrix
@@ -327,6 +327,8 @@ class SCF {
 
   /// List of frozen orbitals by symmetry group. index+1 is symmetry group, group 0 contains all non-frozen orbitals
   std::vector<arma::mat> freeze;
+  /// Helper for orthogonalization
+  arma::mat orthogonalization_helper(const arma::vec & Rsq, const arma::mat & S) const;
 
  public:
   /// Constructor

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -116,6 +116,8 @@ void Settings::add_scf_settings() {
   add_string("BasisOrth", "Method of orthonormalization of basis set", "Auto");
   // Linear dependence threshold
   add_double("LinDepThresh", "Basis set linear dependency threshold", 1e-5);
+  // Cholesky orthogonalization threshold
+  add_double("CholDepThresh", "Partial Cholesky decomposition threshold", 1e-7);
 
   // Convergence criterion
   add_double("ConvThr", "Orbital gradient convergence threshold", 1e-6);


### PR DESCRIPTION
This PR implements the simpler version of the partial Cholesky orthonormalization procedure; the optimized one is already available in the basis set tool.