### PR TITLE
Use Gershgorin theorem to initialize partial Cholesky.

### DIFF
--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -119,8 +119,13 @@ arma::mat PartialCholeskyOrth(const arma::mat & S, double cholcut, double scut) 
     throw std::runtime_error(oss.str());
   }
 
+  // Off-diagonal S
+  arma::mat odS(arma::abs(S));
+  odS.diag().zeros();
+  // Column sum
+  arma::vec odSs(arma::sum(S).t());
+  arma::uvec pivot = arma::stable_sort_index(odSs,"ascend");
   // Find suitable basis by partial Cholesky decomposition
-  arma::uvec pivot;
   pivoted_cholesky(S,cholcut,pivot);
 
   // Canonical orthogonalization of subbasis
@@ -532,7 +537,7 @@ arma::mat pivoted_cholesky(const arma::mat & A, double eps, arma::uvec & pivot) 
   double error(arma::max(d));
 
   // Pivot index
-  arma::uvec pi(arma::linspace<arma::uvec>(0,d.n_elem-1,d.n_elem));
+  arma::uvec pi=pivot;
 
   while(error>eps && m<d.n_elem) {
     // Errors in pivoted order

--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -239,8 +239,6 @@ SCF::SCF(const BasisSet & basis, Checkpoint & chkpt) {
     t.set();
   }
 
-  // Basis function spatial extents
-  arma::vec Rsq(basisp->get_bf_Rsquared());
   if(lincalc) {
     // Basis set m values
     arma::ivec mval(basisp->get_m_values());
@@ -257,7 +255,7 @@ SCF::SCF(const BasisSet & basis, Checkpoint & chkpt) {
     size_t nmo=0;
     for(size_t i=0;i<muni.n_elem;i++) {
       m_idx[i]=basisp->m_indices(muni[i]);
-      Sinvhs[i]=orthogonalization_helper(Rsq(m_idx[i]),S.submat(m_idx[i],m_idx[i]));
+      Sinvhs[i]=BasOrth(S(m_idx[i],m_idx[i]));
       nmo+=Sinvhs[i].n_cols;
     }
 
@@ -270,7 +268,7 @@ SCF::SCF(const BasisSet & basis, Checkpoint & chkpt) {
       imo+=Sinvhs[i].n_cols;
     }
   } else {
-    Sinvh=orthogonalization_helper(Rsq,S);
+    Sinvh=BasOrth(S);
   }
   chkptp->write("Sinvh",Sinvh);
 
@@ -425,22 +423,6 @@ SCF::SCF(const BasisSet & basis, Checkpoint & chkpt) {
 }
 
 SCF::~SCF() {
-}
-
-arma::mat SCF::orthogonalization_helper(const arma::vec & Rsq, const arma::mat & Smat) const {
-  // Sort basis functions from tight to diffuse
-  arma::uvec i_sort=arma::stable_sort_index(Rsq,"ascend");
-  // Inverse sort
-  arma::uvec i_inv=i_sort;
-  for(size_t i=0;i<i_sort.n_elem;i++)
-    i_inv[i_sort[i]]=i;
-
-  // Overlap matrix in the order from tight to diffuse
-  arma::mat S_sort(Smat(i_sort,i_sort));
-  // Run orthonormalization, e.g. with Cholesky
-  arma::mat Sinvh_sort(BasOrth(S_sort));
-  // Return the matrix in the original order
-  return Sinvh_sort.rows(i_inv);
 }
 
 void SCF::set_frozen(const arma::mat & C, size_t ind) {


### PR DESCRIPTION
This PR switches to the use of the Gershgorin theorem for initializing the partial Cholesky approach instead of ordering the basis functions from tight to diffuse.