### PR TITLE
Automatically generated fitting basis should always use spherical functions.

### DIFF
--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -326,7 +326,10 @@ SCF::SCF(const BasisSet & basis, Checkpoint & chkpt) {
       fitlib.load_basis(settings.get_string("FittingBasis"));
 
       // Construct fitting basis
+      bool uselm=settings.get_bool("UseLM");
+      settings.set_bool("UseLM",true);
       construct_basis(dfitbas,basisp->get_nuclei(),fitlib);
+      settings.set_bool("UseLM",uselm);
     }
 
     // Compute memory estimate


### PR DESCRIPTION
It may be that when the code was run with `UseLM false` that automatically generated fitting basis sets would end up using Cartesian basis functions. This patch should eliminate that possibility.