### PR TITLE
Possibility to start Perdew-Zunger calculations from canonical orbitals

### DIFF
--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -2195,6 +2195,7 @@ void calculate(const BasisSet & basis, bool force) {
       int pzprec=settings.get_int("PZprec");
       bool pzov=settings.get_bool("PZov");
       bool pzoo=settings.get_bool("PZoo");
+      bool pzrand=settings.get_bool("PZrand");
       int pzloc=parse_pzimag(settings.get_string("PZloc"),"PZloc");
       enum locmet pzlocmet=parse_locmet(settings.get_string("PZlocmet"));
       double pzw=settings.get_double("PZw");
@@ -2268,9 +2269,8 @@ void calculate(const BasisSet & basis, bool force) {
 	  }
 	} else { // No entry in checkpoint
 	  sol.cC=sol.C*COMPLEX1;
-	  if(!pzoo) {
-	    W.eye(Nel_alpha,Nel_alpha);
-	  } else {
+          W.eye(Nel_alpha,Nel_alpha);
+	  if(pzoo && pzrand) {
 	    if(pzimag!=1)
 	      W=real_orthogonal(Nel_alpha,seed)*std::complex<double>(1.0,0.0);
 	    else
@@ -2573,6 +2573,7 @@ void calculate(const BasisSet & basis, bool force) {
       int pzprec=settings.get_int("PZprec");
       bool pzov=settings.get_bool("PZov");
       bool pzoo=settings.get_bool("PZoo");
+      bool pzrand=settings.get_bool("PZrand");
       int pzloc=parse_pzimag(settings.get_string("PZloc"),"PZloc");
       enum locmet pzlocmet=parse_locmet(settings.get_string("PZlocmet"));
       double pzw=settings.get_double("PZw");
@@ -2649,9 +2650,8 @@ void calculate(const BasisSet & basis, bool force) {
 	  }
 	} else { // No entry in checkpoint
 	  sol.cCa=sol.Ca*COMPLEX1;
-	  if(!pzoo) {
-	    Wa.eye(Nel_alpha,Nel_alpha);
-	  } else {
+          Wa.eye(Nel_alpha,Nel_alpha);
+	  if(pzoo && pzrand) {
 	    if(pzimag!=1)
 	      Wa=real_orthogonal(Nel_alpha,seed)*std::complex<double>(1.0,0.0);
 	    else
@@ -2729,10 +2729,8 @@ void calculate(const BasisSet & basis, bool force) {
 	  }
 	} else { // No entry in checkpoint
 	  sol.cCb=sol.Cb*COMPLEX1;
-
-	  if(!pzoo) {
-	    Wb.eye(Nel_beta,Nel_beta);
-	  } else {
+          Wb.eye(Nel_beta,Nel_beta);
+          if(pzoo && pzrand) {
 	    if(pzimag!=1)
 	      Wb=real_orthogonal(Nel_beta,seed)*std::complex<double>(1.0,0.0);
 	    else

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -174,6 +174,7 @@ void Settings::add_scf_settings() {
   add_int("PZprec", "Precondition OV block? 0: no, 1: unified, 2: orbital",1);
   add_bool("PZoo", "Optimize OO block?",true);
   add_bool("PZov", "Optimize OV block?",true);
+  add_bool("PZrand", "Apply random rotation in PZ initialization? (Should be true)",true);
   add_double("PZIthr", "Threshold for initialization convergence (not too small!)",1e-2);
   add_double("PZOOthr", "Gradient threshold for OO optimization",1e-4);
   add_double("PZOVthr", "Gradient threshold for OV optimization",1e-5);


### PR DESCRIPTION
Perdew-Zunger calculations can now be started from canonical orbitals by setting `PZloc false` and `PZrand false`.

This is mainly for debugging purposes; it is highly recommended to randomize the orbitals as this breaks the symmetries which typically lead to convergence to saddle point solutions.