### PR TITLE
Adapt DFT code to up-to-date libxc

### DIFF
--- a/src/dftfuncs.cpp
+++ b/src/dftfuncs.cpp
@@ -375,7 +375,13 @@ void is_gga_mgga(int func_id, bool & gga, bool & mgga_t, bool & mgga_l) {
 #ifdef XC_FAMILY_HYB_MGGA
     case XC_FAMILY_HYB_MGGA:
 #endif
+
+#if defined(XC_FLAGS_NEEDS_TAU)
+      mgga_l=func.info->flags & XC_FLAGS_NEEDS_TAU;
+#else
       mgga_t=true;
+#endif
+
 #if defined(XC_FLAGS_NEEDS_LAPLACIAN)
       mgga_l=func.info->flags & XC_FLAGS_NEEDS_LAPLACIAN;
 #else
@@ -564,7 +570,7 @@ void range_separation(int func_id, double & omega, double & alpha, double & beta
       }
       xc_func_set_ext_params(&func, pars.memptr());
     }
-    
+
 #if XC_MAJOR_VERSION >= 6
     switch(xc_hyb_type(&func)) {
     case(XC_HYB_HYBRID):

--- a/src/dftgrid.cpp
+++ b/src/dftgrid.cpp
@@ -953,9 +953,9 @@ void AngularGrid::compute_xc(int func_id, bool pot) {
   if(has_exc(func_id)) {
     if(pot) {
       if(mgga_t || mgga_l) {// meta-GGA
-	double * laplp = mgga_t ? lapl.memptr() : NULL;
+	double * laplp = mgga_l ? lapl.memptr() : NULL;
 	double * taup = mgga_t ? tau.memptr() : NULL;
-	double * vlaplp = mgga_t ? vlapl_wrk.memptr() : NULL;
+	double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
 	double * vtaup = mgga_t ? vtau_wrk.memptr() : NULL;
 	xc_mgga_exc_vxc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, exc_wrk.memptr(), vxc_wrk.memptr(), vsigma_wrk.memptr(), vlaplp, vtaup);
       } else if(gga) // GGA
@@ -964,7 +964,7 @@ void AngularGrid::compute_xc(int func_id, bool pot) {
 	xc_lda_exc_vxc(&func, N, rho.memptr(), exc_wrk.memptr(), vxc_wrk.memptr());
     } else {
       if(mgga_t || mgga_l) { // meta-GGA
-	double * laplp = mgga_t ? lapl.memptr() : NULL;
+	double * laplp = mgga_l ? lapl.memptr() : NULL;
 	double * taup = mgga_t ? tau.memptr() : NULL;
 	xc_mgga_exc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, exc_wrk.memptr());
       } else if(gga) // GGA
@@ -976,9 +976,9 @@ void AngularGrid::compute_xc(int func_id, bool pot) {
   } else {
     if(pot) {
       if(mgga_t || mgga_l) { // meta-GGA
-	double * laplp = mgga_t ? lapl.memptr() : NULL;
+	double * laplp = mgga_l ? lapl.memptr() : NULL;
 	double * taup = mgga_t ? tau.memptr() : NULL;
-	double * vlaplp = mgga_t ? vlapl_wrk.memptr() : NULL;
+	double * vlaplp = mgga_l ? vlapl_wrk.memptr() : NULL;
 	double * vtaup = mgga_t ? vtau_wrk.memptr() : NULL;
 	xc_mgga_vxc(&func, N, rho.memptr(), sigma.memptr(), laplp, taup, vxc_wrk.memptr(), vsigma_wrk.memptr(), vlaplp, vtaup);
       } else if(gga) // GGA


### PR DESCRIPTION
The development version of libxc flags which functionals require tau. There was also a bug in the code: the handling of laplacians was controlled by the need for tau, but this did not affect results since tau was assumed to be always needed.