### PR TITLE
Fix Coulomb overlap in auxiliary basis generator and implement other methods

### DIFF
--- a/src/basislibrary.h
+++ b/src/basislibrary.h
@@ -201,7 +201,7 @@ class ElementBasisSet {
   ElementBasisSet product_set(int lmaxinc, double fsam) const;
 
   /// Form compact or full Cholesky set
-  ElementBasisSet cholesky_set(double cholthr, bool full, bool overlap) const;
+  ElementBasisSet cholesky_set(double cholthr, bool full, int metric) const;
 
   /// Augment the basis with steep functions
   void augment_steep(int naug);
@@ -298,8 +298,8 @@ class BasisSetLibrary {
   BasisSetLibrary density_fitting(int lvalinc, double fsam) const;
   /// Generate product set
   BasisSetLibrary product_set(int lvalinc, double fsam) const;
-  /// Generate compact Cholesky set
-  BasisSetLibrary cholesky_set(double thr, bool full, bool overlap) const;
+  /// Generate compact Cholesky set. Metrics: 0 for Coulomb, 1 for overlap, 2 for nuclear attraction integral
+  BasisSetLibrary cholesky_set(double thr, bool full, int metric) const;
 
   /**
    * P-orthogonalization [F. Jensen, JCTC 10, 1074 (2014)].

--- a/src/basislibrary.h
+++ b/src/basislibrary.h
@@ -200,10 +200,8 @@ class ElementBasisSet {
    */
   ElementBasisSet product_set(int lmaxinc, double fsam) const;
 
-  /// Form compact Cholesky set
-  ElementBasisSet cholesky_set(double cholthr) const;
-  /// Form Cholesky set from full set of products
-  ElementBasisSet cholesky_full_set(double cholthr) const;
+  /// Form compact or full Cholesky set
+  ElementBasisSet cholesky_set(double cholthr, bool full, bool overlap) const;
 
   /// Augment the basis with steep functions
   void augment_steep(int naug);
@@ -301,9 +299,7 @@ class BasisSetLibrary {
   /// Generate product set
   BasisSetLibrary product_set(int lvalinc, double fsam) const;
   /// Generate compact Cholesky set
-  BasisSetLibrary cholesky_set(double thr) const;
-  /// Generate Cholesky set from all orbital products
-  BasisSetLibrary cholesky_full_set(double thr) const;
+  BasisSetLibrary cholesky_set(double thr, bool full, bool overlap) const;
 
   /**
    * P-orthogonalization [F. Jensen, JCTC 10, 1074 (2014)].

--- a/src/basistool/main.cpp
+++ b/src/basistool/main.cpp
@@ -25,7 +25,7 @@
 #include "../version.h"
 #endif
 
-std::string cmds[]={"augdiffuse", "augsteep", "choleskyaux", "fullcholeskyaux", "choleskybasis", "completeness", "composition", "daug", "decontract", "densityfit", "dump", "dumpdec", "fiterr", "genbas", "gendecbas", "merge", "norm", "orth", "overlap", "Porth", "prodset", "save", "savecfour", "savedalton", "savemolpro", "sort", "taug"};
+std::string cmds[]={"augdiffuse", "augsteep", "choleskyaux", "fullcholeskyaux", "choleskydens", "choleskybasis", "completeness", "composition", "daug", "decontract", "densityfit", "dump", "dumpdec", "fiterr", "genbas", "gendecbas", "merge", "norm", "orth", "overlap", "Porth", "prodset", "save", "savecfour", "savedalton", "savemolpro", "sort", "taug"};
 
 void help() {
   printf("Valid commands:\n");
@@ -109,7 +109,9 @@ int main_guarded(int argc, char **argv) {
     settings.add_bool("BasisRotate","",false);
     settings.add_double("BasisCutoff","",0.0);
 
-    BasisSetLibrary ret=bas.cholesky_set(thr);
+    bool full=false;
+    bool overlap=false;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,overlap);
     ret.save_gaussian94(outfile);
 
   } else if(stricmp(cmd,"fullcholeskyaux")==0) {
@@ -134,7 +136,37 @@ int main_guarded(int argc, char **argv) {
     settings.add_bool("BasisRotate","",false);
     settings.add_double("BasisCutoff","",0.0);
 
-    BasisSetLibrary ret=bas.cholesky_full_set(thr);
+    bool full=true;
+    bool overlap=false;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,overlap);
+    ret.save_gaussian94(outfile);
+
+  } else if(stricmp(cmd,"choleskydens")==0) {
+    // Form Cholesky fitting basis set
+
+    if(argc!=5) {
+      printf("\nUsage: %s input.gbs choleskydens thr output.gbs\n",argv[0]);
+      return 1;
+    }
+
+    printf("Forming density fitting auxiliary basis using pivoted Cholesky decomposition\n");
+    printf("See J. Chem. Theory Comput. 17, 6886 (2021). DOI: 10.1021/acs.jctc.1c00607\n");
+    printf("NOTE: using overlap metric instead of Coulomb metric!\n\n");
+
+    double thr(atof(argv[3]));
+    std::string outfile(argv[4]);
+
+    init_libint_base();
+
+    settings.add_bool("UseLM","",true);
+    settings.add_bool("OptLM","",false);
+    settings.add_string("Decontract","","");
+    settings.add_bool("BasisRotate","",false);
+    settings.add_double("BasisCutoff","",0.0);
+
+    bool full=true;
+    bool overlap=true;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,overlap);
     ret.save_gaussian94(outfile);
 
   } else if(stricmp(cmd,"choleskybasis")==0) {

--- a/src/basistool/main.cpp
+++ b/src/basistool/main.cpp
@@ -110,8 +110,8 @@ int main_guarded(int argc, char **argv) {
     settings.add_double("BasisCutoff","",0.0);
 
     bool full=false;
-    bool overlap=false;
-    BasisSetLibrary ret=bas.cholesky_set(thr,full,overlap);
+    int metric=0;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,metric);
     ret.save_gaussian94(outfile);
 
   } else if(stricmp(cmd,"fullcholeskyaux")==0) {
@@ -137,8 +137,8 @@ int main_guarded(int argc, char **argv) {
     settings.add_double("BasisCutoff","",0.0);
 
     bool full=true;
-    bool overlap=false;
-    BasisSetLibrary ret=bas.cholesky_set(thr,full,overlap);
+    int metric=0;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,metric);
     ret.save_gaussian94(outfile);
 
   } else if(stricmp(cmd,"choleskydens")==0) {
@@ -165,8 +165,36 @@ int main_guarded(int argc, char **argv) {
     settings.add_double("BasisCutoff","",0.0);
 
     bool full=true;
-    bool overlap=true;
-    BasisSetLibrary ret=bas.cholesky_set(thr,full,overlap);
+    int metric=1;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,metric);
+    ret.save_gaussian94(outfile);
+
+  } else if(stricmp(cmd,"choleskynuc")==0) {
+    // Form Cholesky fitting basis set
+
+    if(argc!=5) {
+      printf("\nUsage: %s input.gbs choleskynuc thr output.gbs\n",argv[0]);
+      return 1;
+    }
+
+    printf("Forming density fitting auxiliary basis using pivoted Cholesky decomposition\n");
+    printf("See J. Chem. Theory Comput. 17, 6886 (2021). DOI: 10.1021/acs.jctc.1c00607\n");
+    printf("NOTE: using nuclear attraction integrals instead of Coulomb metric!\n\n");
+
+    double thr(atof(argv[3]));
+    std::string outfile(argv[4]);
+
+    init_libint_base();
+
+    settings.add_bool("UseLM","",true);
+    settings.add_bool("OptLM","",false);
+    settings.add_string("Decontract","","");
+    settings.add_bool("BasisRotate","",false);
+    settings.add_double("BasisCutoff","",0.0);
+
+    bool full=true;
+    int metric=2;
+    BasisSetLibrary ret=bas.cholesky_set(thr,full,metric);
     ret.save_gaussian94(outfile);
 
   } else if(stricmp(cmd,"choleskybasis")==0) {


### PR DESCRIPTION
It turns out that even though the equations are correct in the paper, the Coulomb overlap was not computed according to these equations in the code. This PR fixes the computation of the Coulomb overlap in the code.

In addition, this PR implements two new methods for generating auxiliary basis sets:

1. sets for reproducing the density; this is achieved by a Cholesky decomposition of the overlap matrix
2. sets for reproducing nuclear attraction integrals; this is achieved by a Cholesky decomposition of a nuclear attraction integral matrix