### PR TITLE
Fix includes such that system Armadillo can be used

### DIFF
--- a/src/atom/integrals.h
+++ b/src/atom/integrals.h
@@ -17,6 +17,7 @@
 #ifndef INTEGRALS_H
 #define INTEGRALS_H
 
+#include "global.h"
 #include <armadillo>
 
 /// Basis function

--- a/src/basistool/pivoted_cholesky_basis.cpp
+++ b/src/basistool/pivoted_cholesky_basis.cpp
@@ -14,6 +14,7 @@
  * of the License, or (at your option) any later version.
  */
 
+#include "global.h"
 #include <armadillo>
 
 #include "../basislibrary.h"

--- a/src/casida/casida.h
+++ b/src/casida/casida.h
@@ -44,6 +44,7 @@
 class BasisSet;
 class Settings;
 
+#include "global.h"
 #include <armadillo>
 #include <cstdio>
 #include <cstdlib>

--- a/src/gdm.h
+++ b/src/gdm.h
@@ -19,6 +19,7 @@
 #ifndef ERKALE_GDM
 #define ERKALE_GDM
 
+#include "global.h"
 #include <armadillo>
 
 class GDM {

--- a/src/localization.cpp
+++ b/src/localization.cpp
@@ -14,6 +14,7 @@
  * of the License, or (at your option) any later version.
  */
 
+#include "global.h"
 #include <armadillo>
 #include <cstdio>
 #include <cfloat>
@@ -21,7 +22,6 @@
 #include "elements.h"
 #include "dftfuncs.h"
 #include "dftgrid.h"
-#include "global.h"
 #include "guess.h"
 #include "hirshfeldi.h"
 #include "linalg.h"

--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -14,6 +14,7 @@
  * of the License, or (at your option) any later version.
  */
 
+#include "global.h"
 #include <armadillo>
 #include <cstdio>
 #include <cfloat>
@@ -26,7 +27,6 @@
 #include "elements.h"
 #include "dftfuncs.h"
 #include "dftgrid.h"
-#include "global.h"
 #include "guess.h"
 #include "lebedev.h"
 #include "linalg.h"


### PR DESCRIPTION
The global definitions were not included in all files before Armadillo, meaning that compile failed on systems where Armadillo defaulted to use of the system wrapper library.