### PR TITLE
Implement support for finite magnetic field for linear symmetry

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -4031,10 +4031,8 @@ arma::mat block_m(const arma::mat & F, const arma::ivec & mv) {
       // Indices for plus and minus values are
       arma::uvec pidx(arma::find(mv==m));
       arma::uvec nidx(arma::find(mv==-m));
-
-      // m=m and m=-m are equivalent
-      Fnew(pidx,pidx)=0.5*(F(pidx,pidx)+F(nidx,nidx));
-      Fnew(nidx,nidx)=Fnew(pidx,pidx);
+      Fnew(pidx,pidx)=F(pidx,pidx);
+      Fnew(nidx,nidx)=F(nidx,nidx);
     }
   }
 

--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -97,6 +97,7 @@ SCF::SCF(const BasisSet & basis, Checkpoint & chkpt) {
   if(readlinocc<0)
     readlinocc=INT_MAX;
   linoccfname=settings.get_string("LinearOccupationFile");
+  linB=settings.get_double("LinearB");
 
   usediis=settings.get_bool("UseDIIS");
   diisorder=settings.get_int("DIISOrder");

--- a/src/scf-fock.cpp.in
+++ b/src/scf-fock.cpp.in
@@ -809,6 +809,33 @@ void XRSSCF::Fock_half_hole(uscf_t & sol, dft_t dft, const std::vector<double> &
 #endif // end DFT clause
 #endif // End unrestricted case
 
+  if(lincalc && linB != 0.0) {
+    // Compute moment integrals around the origin
+    double cenx=0.0, ceny=0.0, cenz=0.0;
+    std::vector<arma::mat> momstack=basisp->moment(2,cenx,ceny,cenz);
+    arma::mat xymat=momstack[getind(2,0,0)]+momstack[getind(0,2,0)];
+
+    // Collect m values
+    arma::ivec mvals(basisp->get_m_values());
+
+    // Magnetic operator
+    arma::mat Hmag(Hcore.n_rows,Hcore.n_cols,arma::fill::zeros);
+    for(size_t i=0;i<Hmag.n_rows;i++)
+      for(size_t j=0;j<Hmag.n_cols;j++)
+        Hmag(i,j) = -0.5*linB*mvals(j)*S(i,j) + linB*linB*xymat(i,j)/8.0;
+
+#ifdef RESTRICTED
+    sol.H += Hmag;
+    sol.en.Emag = arma::trace(sol.P*Hmag);
+#else
+    double nela(arma::trace(S*sol.Pa));
+    double nelb(arma::trace(S*sol.Pb));
+
+    sol.Ha += Hmag - 0.5*linB*S;
+    sol.Hb += Hmag + 0.5*linB*S;
+    sol.en.Emag = arma::trace(sol.P*Hmag) - linB*0.5*(nela-nelb);
+#endif
+  }
 
 #if defined(FULLHOLE) || defined(HALFHOLE)
   if(freeze.size()>0) {
@@ -857,7 +884,7 @@ void XRSSCF::Fock_half_hole(uscf_t & sol, dft_t dft, const std::vector<double> &
   sol.en.Ecoul=0.5*arma::trace(sol.P*sol.J);
 
   // Compute total energies
-  sol.en.Eel=sol.en.Ecoul+sol.en.Exc+sol.en.Eone+sol.en.Enl;
+  sol.en.Eel=sol.en.Ecoul+sol.en.Exc+sol.en.Eone+sol.en.Enl+sol.en.Emag;
   sol.en.E=sol.en.Eel+sol.en.Enucr;
 
   // Sanity checks
@@ -930,6 +957,7 @@ void XRSSCF::Fock_half_hole(uscf_t & sol, dft_t dft, const std::vector<double> &
     printf("One-electron energy %e\n",sol.en.Eone);
     printf("Non-local    energy %e\n",sol.en.Enl);
     printf("Nuclear repulsion energy %e\n",sol.en.Enucr);
+    printf("Magnetic interaction energy %e\n",sol.en.Emag);
     fflush(stdout);
 #endif
 

--- a/src/scf-solvers.cpp.in
+++ b/src/scf-solvers.cpp.in
@@ -750,6 +750,8 @@ size_t XRSSCF::half_hole(uscf_t & sol, double convthr, dft_t dft0)
     printf("%-21s energy: % .16e\n","Total one-electron",sol.en.Eone);
     printf("%-21s energy: % .16e\n","Nuclear repulsion",sol.en.Enucr);
     printf("%-21s energy: % .16e\n","Coulomb",sol.en.Ecoul);
+    if(sol.en.Emag != 0.0)
+      printf("%-21s energy: % .16e\n","Magnetic interaction",sol.en.Emag);
 #ifndef DFT
     printf("%-21s energy: % .16e\n","Exchange",sol.en.Exc);
 #else

--- a/src/scf.h
+++ b/src/scf.h
@@ -89,6 +89,8 @@ typedef struct {
   double Enl;
   /// Self-interaction energy
   double Esic;
+  /// Magnetic interaction energy
+  double Emag;
 
   /// Total energy
   double E;
@@ -254,6 +256,8 @@ protected:
   int readlinocc;
   /// File where to read occupations from
   std::string linoccfname;
+  /// Magnetic field
+  double linB;
 
   /// Use ADIIS?
   bool useadiis;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -67,6 +67,7 @@ void Settings::add_scf_settings() {
   add_bool("LinearFreeze", "If using linear symmetry, freeze symmetry to input guess", false);
   add_int("LinearOccupations", "Read in occupations for linear molecule calculations?", 0, true);
   add_string("LinearOccupationFile", "File to read linear occupations from", "linoccs.dat");
+  add_double("LinearB", "Magnetic field along bond axis", 0.0);
 
   // Decontract basis set?
   add_string("Decontract","Indices of atoms to decontract basis set for","");


### PR DESCRIPTION
Finite magnetic field is now supported along the lines of
[Mol. Phys. 118, e1597989 (2020)](https://doi.org/10.1080/00268976.2019.1597989). Support is only included for linear molecules on z axis.