### PR TITLE
Fix computation of completeness profiles

### DIFF
--- a/src/basislibrary.h
+++ b/src/basislibrary.h
@@ -26,8 +26,19 @@
 
 #include "basis.h"
 
+/// Compute overlap of unnormalized Gaussian primitives
+arma::mat primitive_overlap(const arma::vec & z, const arma::vec & zp, int am);
+/// Compute norm of Gaussian primitives
+arma::vec primitive_norm(const arma::vec & z, int am);
 /// Compute overlap of normalized Gaussian primitives
 arma::mat overlap(const arma::vec & z, const arma::vec & zp, int am);
+
+/// Compute Coulomb overlap of unnormalized Gaussian primitives
+arma::mat primitive_coulomb_overlap(const arma::vec & z, const arma::vec & zp, int am);
+/// Compute Coulomb norm of Gaussian primitives
+arma::vec primitive_coulomb_norm(const arma::vec & z, int am);
+/// Compute Coulomb overlap of normalized Gaussian primitives
+arma::mat coulomb_overlap(const arma::vec & z, const arma::vec & zp, int am);
 
 /// Find angular momentum
 int find_am(char am);

--- a/src/completeness/completeness_profile.cpp
+++ b/src/completeness/completeness_profile.cpp
@@ -50,17 +50,13 @@ compprof_t compute_completeness(const ElementBasisSet & bas, const arma::vec & s
 
     // Do we need to calculate something?
     if(exps.n_elem) {
-
-      int amval=am;
-      if(coulomb)
-	amval--;
-
       // Compute overlaps of scanning functions and primitives
-      arma::mat scanov=overlap(exps,scan_exp,amval);
+      arma::mat scanov = coulomb ? coulomb_overlap(exps,scan_exp,am) : overlap(exps,scan_exp,am);
+      arma::mat primov = coulomb ? coulomb_overlap(exps,exps,am) : overlap(exps,exps,am);
 
-      // Compute overlap matrix in used basis set
+      // Compute the overlap in the contracted basis
       arma::mat S;
-      S=arma::trans(contr)*overlap(exps,exps,amval)*contr;
+      S=arma::trans(contr)*primov*contr;
 
       // Helper: scan overlaps of contracted basis functions
       arma::mat hlp=arma::trans(scanov)*contr;


### PR DESCRIPTION
This was broken in a previous commit; also the Coulomb overlap was wrong in this part of the code.