### PR TITLE
Allow customizing the DFT basis and density cutoffs

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -1586,6 +1586,10 @@ size_t BasisSet::get_Nbf() const {
     return 0;
 }
 
+void BasisSet::compute_shell_ranges() {
+  compute_shell_ranges(settings.get_double("DFTBasisThr"));
+}
+
 void BasisSet::compute_shell_ranges(double eps) {
   shell_ranges=get_shell_ranges(eps);
 }

--- a/src/basis.h
+++ b/src/basis.h
@@ -368,12 +368,13 @@ class BasisSet {
   /**
    * Get range of shell (distance at which functions have dropped below epsilon)
    *
-   * The default parameter is from the reference R. E. Stratmann,
-   * G. E. Scuseria, and M. J. Frisch, "Achieving linear scaling in
-   * exchage-correlation density functional quadratures",
-   * Chem. Phys. Lett. 257 (1993), pp. 213-223.
+   * See R. E. Stratmann, G. E. Scuseria, and M. J. Frisch, "Achieving
+   * linear scaling in exchage-correlation density functional
+   * quadratures", Chem. Phys. Lett. 257 (1993), pp. 213-223.
    */
-  void compute_shell_ranges(double eps=1e-10);
+  void compute_shell_ranges();
+  /// Function that actually computes the
+  void compute_shell_ranges(double eps);
   /// Get precomputed ranges of shells
   std::vector<double> get_shell_ranges() const;
   /// Get range of shells with given value of epsilon

--- a/src/dftgrid.cpp
+++ b/src/dftgrid.cpp
@@ -392,7 +392,9 @@ void AngularGrid::free() {
   VV10_arr.clear();
 }
 
-arma::uvec AngularGrid::screen_density(double thr) const {
+arma::uvec AngularGrid::screen_density() const {
+  double thr=settings.get_double("DFTDensityThr");
+
   // List of points
   std::vector<size_t> idx;
   // Loop over grid
@@ -928,6 +930,10 @@ void AngularGrid::compute_xc(int func_id, bool pot) {
     oss << "Functional "<<func_id<<" not found!";
     throw std::runtime_error(oss.str());
   }
+  // Set density threshold
+  double thr=settings.get_double("DFTDensityThr");
+  xc_func_set_dens_threshold(&func, thr);
+
   // Set parameters
   arma::vec pars;
   std::string functype;

--- a/src/dftgrid.h
+++ b/src/dftgrid.h
@@ -369,7 +369,7 @@ class AngularGrid {
   void free();
 
   /// Screen wrt small density, returns list of points with nonnegligible values
-  arma::uvec screen_density(double thr=1e-10) const;
+  arma::uvec screen_density() const;
 
   /// Update values of density, restricted calculation
   void update_density(const arma::mat & P, bool lapl=false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -160,6 +160,10 @@ void Settings::add_scf_settings() {
   // Override parameters of XC functional
   add_string("DFTXpars", "Override parameters of exchange functional (expert)", "");
   add_string("DFTCpars", "Override parameters of correlation functional (expert)", "");
+  // Basis set value threshold
+  add_double("DFTBasisThr", "Threshold for screening basis functions on grid", 1e-10);
+  // Density threshold
+  add_double("DFTDensityThr", "Threshold for screening density on grid", 1e-10);
 
   // VV10?
   add_string("VV10","Use VV10 non-local correlation?","Auto");


### PR DESCRIPTION
This PR replaces the hard-coded cutoff of 10e-10 for the basis functions and the electron density on the grid with adjustable thresholds. Based on initial tests, total energies only change in the sub-uEh range.