### PR TITLE
Catching C++ exceptions is now a compile time option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ else()
  message("Using default location for basis set repository.")
 endif()
 
+# Catch C++ exceptions?
+option(CATCH_EXCEPTIONS "Catch C++ exceptions?" OFF)
+if(CATCH_EXCEPTIONS)
+  add_definitions(-DCATCH_EXCEPTIONS)
+endif()
+
 # Compile SMP version?
 option(USE_OPENMP "Compile OpenMP enabled version (for parallel calculations)?" ON)
 # Find OpenMP support

--- a/src/atom/main.cpp
+++ b/src/atom/main.cpp
@@ -203,10 +203,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/basistool/main.cpp
+++ b/src/basistool/main.cpp
@@ -735,10 +735,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/casida/main.cpp
+++ b/src/casida/main.cpp
@@ -372,10 +372,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/completeness/main.cpp
+++ b/src/completeness/main.cpp
@@ -121,10 +121,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/co-optimize.cpp
+++ b/src/contrib/co-optimize.cpp
@@ -2650,10 +2650,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/combineranges.cpp
+++ b/src/contrib/combineranges.cpp
@@ -154,10 +154,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/densproj.cpp
+++ b/src/contrib/densproj.cpp
@@ -145,10 +145,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/formchk.cpp
+++ b/src/contrib/formchk.cpp
@@ -248,10 +248,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/guessbench.cpp
+++ b/src/contrib/guessbench.cpp
@@ -333,10 +333,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/moints.cpp
+++ b/src/contrib/moints.cpp
@@ -724,10 +724,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/oovl.cpp
+++ b/src/contrib/oovl.cpp
@@ -209,10 +209,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/contrib/rimp2.cpp
+++ b/src/contrib/rimp2.cpp
@@ -292,10 +292,14 @@ int main_guarded(void) {
 }
 
 int main() {
+#ifdef CATCH_EXCEPTIONS
   try {
-    return main_guarded();
+    return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/cube.cpp
+++ b/src/cube.cpp
@@ -1132,10 +1132,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/emd/main.cpp
+++ b/src/emd/main.cpp
@@ -349,10 +349,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1193,10 +1193,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/localize.cpp
+++ b/src/localize.cpp
@@ -604,10 +604,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,10 +153,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/population.cpp
+++ b/src/population.cpp
@@ -369,10 +369,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/slaterfit/main.cpp
+++ b/src/slaterfit/main.cpp
@@ -84,10 +84,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }

--- a/src/xrs/main.cpp
+++ b/src/xrs/main.cpp
@@ -1196,10 +1196,14 @@ int main_guarded(int argc, char **argv) {
 }
 
 int main(int argc, char **argv) {
+#ifdef CATCH_EXCEPTIONS
   try {
     return main_guarded(argc, argv);
   } catch (const std::exception &e) {
     std::cerr << "error: " << e.what() << std::endl;
     return 1;
   }
+#else
+  return main_guarded(argc, argv);
+#endif
 }


### PR DESCRIPTION
When the exception is caught there is no core dump, making debugging harder. This is why the catching is now controlled by a CMake option.