### PR TITLE
Fix correctness bugs surfaced by code review

### DIFF
--- a/src/casida/casida.cpp
+++ b/src/casida/casida.cpp
@@ -167,9 +167,11 @@ void Casida::form_pairs(const std::vector< std::vector<double> > occs) {
   nvirt.resize(occs.size());
 
   for(size_t ispin=0;ispin<nocc.size();ispin++) {
-    // Count number of occupied states.
+    // Count number of occupied states. Bound the walk by the actual
+    // occupation array size in case every entry is positive (no zero
+    // sentinel is guaranteed at the tail).
     nocc[ispin]=0;
-    while(occs[ispin][nocc[ispin]]>0)
+    while(nocc[ispin]<occs[ispin].size() && occs[ispin][nocc[ispin]]>0)
       nocc[ispin]++;
 
     // Check that all values are equal.
@@ -239,7 +241,7 @@ void Casida::form_pairs(const std::vector< std::vector<double> > occs) {
 	newC.col(i)=C[ispin].col(idx[i]);
       C[ispin]=newC;
 
-      arma::vec newE(C[ispin].n_elem);
+      arma::vec newE(idx.size());
       for(size_t i=0;i<idx.size();i++)
 	newE(i)=E[ispin](idx[i]);
       E[ispin]=newE;

--- a/src/casida/casida_grid.cpp
+++ b/src/casida/casida_grid.cpp
@@ -93,9 +93,6 @@ void CasidaShell::eval_fxc(int x_func, int c_func) {
       throw std::runtime_error(oss.str());
     }
 
-    // Initialize the functional
-    xc_func_init(&xfunc, x_func, nspin);
-
     if(xfunc.info->family!=XC_FAMILY_LDA) {
       ERROR_INFO();
       throw std::runtime_error("Casida only supports LDA functionals.\n");
@@ -121,7 +118,6 @@ void CasidaShell::eval_fxc(int x_func, int c_func) {
       throw std::runtime_error(oss.str());
     }
 
-    xc_func_init(&cfunc, c_func, nspin);
     if(cfunc.info->family!=XC_FAMILY_LDA) {
       ERROR_INFO();
       throw std::runtime_error("Casida only supports LDA functionals.\n");
@@ -184,16 +180,19 @@ void CasidaShell::Kxc(const std::vector< std::vector<states_pair_t> > & pairs, a
 	  // Factor in common for all orbitals
 	  wxc=grid[ip].w*(fx[3*ip+1]+fc[3*ip+1]); // up-down and down-up
 
-	  // Loop over pairs
+	  // Cross-spin (ispin != jspin) block is rectangular: iterate
+	  // jpair over the full pairs[jspin] range, not the lower
+	  // triangle (which would be correct only for ispin == jspin).
 	  for(size_t ipair=0;ipair<pairs[ispin].size();ipair++) {
-	    for(size_t jpair=0;jpair<ipair;jpair++) {
+	    for(size_t jpair=0;jpair<pairs[jspin].size();jpair++) {
 	      double term=wxc*orbs[ispin][ip][pairs[ispin][ipair].i]*orbs[ispin][ip][pairs[ispin][ipair].f]
-		*orbs[ispin][ip][pairs[jspin][jpair].i]*orbs[ispin][ip][pairs[jspin][jpair].f];
+		*orbs[jspin][ip][pairs[jspin][jpair].i]*orbs[jspin][ip][pairs[jspin][jpair].f];
 	      K(ioff+ipair,joff+jpair)+=term;
 	      K(joff+jpair,ioff+ipair)+=term;
 	    }
-	    K(ioff+ipair,ioff+ipair)+=wxc*orbs[ispin][ip][pairs[ispin][ipair].i]*orbs[ispin][ip][pairs[ispin][ipair].f]
-	      *orbs[ispin][ip][pairs[ispin][ipair].i]*orbs[ispin][ip][pairs[ispin][ipair].f];
+	    // (No same-spin diagonal contribution from the cross-spin
+	    // block: K[i_σ a_σ, i_σ a_σ] is built from f^(σσ) only,
+	    // which is added in the ispin==jspin branch above.)
 	  }
 	}
       }

--- a/src/contrib/energy-opt.cpp
+++ b/src/contrib/energy-opt.cpp
@@ -326,8 +326,11 @@ arma::mat EnergyOptimizer::calcH(const arma::vec & x, bool check) {
   // Get energies
   std::vector<double> Etr=calcE(trials);
 
-  // Hessian
-  arma::vec h(idx.n_elem,idx.n_elem);
+  // Hessian. The two-argument constructor on arma::vec is interpreted
+  // as (n_rows, n_cols) for the underlying arma::Col, with n_cols=1 silently
+  // dropping the second argument; the loop below then writes h(i,j)
+  // out of bounds when j>0. Use arma::mat so the (i,j) indexing matches.
+  arma::mat h(idx.n_elem,idx.n_elem);
   for(arma::uword i=0;i<idx.n_elem;i++)
     for(arma::uword j=0;j<=i;j++) {
       // Offset is 4 * i(i+1)/2

--- a/src/contrib/guessbench.cpp
+++ b/src/contrib/guessbench.cpp
@@ -161,11 +161,14 @@ int main_guarded(int argc, char **argv) {
 
   } else if(stricmp(guess,"gwh")==0) {
 
-    // Form GWH matrix
+    // Form GWH matrix. The diagonal is the bare core-Hamiltonian
+    // diagonal; off-diagonal entries are H_ij = 1/2 K S_ij (H_ii + H_jj).
+    // The previous implementation overwrote H(i,i) inside the inner
+    // loop (when j==i) with the GWH off-diagonal formula, so the
+    // diagonal ended up scaled by K*S(i,i) instead of being preserved.
     arma::mat Hgwh(Hcore);
     for(size_t i=0;i<Hcore.n_rows;i++) {
-      Hgwh(i,i)=Hcore(i,i);
-      for(size_t j=0;j<Hcore.n_cols;j++) {
+      for(size_t j=i+1;j<Hcore.n_cols;j++) {
         Hgwh(i,j)=0.5*K*S(i,j)*(Hcore(i,i)+Hcore(j,j));
         Hgwh(j,i)=Hgwh(i,j);
       }

--- a/src/contrib/hneoci.cpp
+++ b/src/contrib/hneoci.cpp
@@ -358,7 +358,7 @@ int main_guarded(int argc, char **argv) {
   arma::mat H0_mo = Xe_bo.t() * H0 * Xe_bo;
   arma::mat H0p_mo = Xp_bo.t() * H0p * Xp_bo;
 
-  arma::mat H0_ci(V_ci.n_rows, V_ci.n_cols);
+  arma::mat H0_ci(V_ci.n_rows, V_ci.n_cols, arma::fill::zeros);
   for(size_t i=0; i<e_nmo; i++)
     for(size_t j=0; j<e_nmo; j++)
       for(size_t I=0; I<p_nmo; I++) {

--- a/src/contrib/neosp.cpp
+++ b/src/contrib/neosp.cpp
@@ -332,9 +332,9 @@ int main_guarded(int argc, char **argv) {
   E.print("Protonic orbital energies");
 
   if(E.n_elem >= navg)
-    printf("State average of %i first states is % .14e\n",arma::mean(E.subvec(0,navg-1)));
+    printf("State average of %i first states is % .14e\n",(int) navg,arma::mean(E.subvec(0,navg-1)));
   else
-    printf("State average of %i first states is % .14e\n",E.n_elem,arma::mean(E));
+    printf("State average of %i first states is % .14e\n",(int) E.n_elem,arma::mean(E));
 
   printf("\nRunning program took %s.\n",t.elapsed().c_str());
   return 0;

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -322,13 +322,16 @@ void DensityFit::digest_K_incore(const arma::cx_mat & C, const arma::vec & occs,
     throw std::logic_error(oss.str());
   }
 
-  // Reshape B
-  const arma::mat Breshape((double *) B.memptr(), Nbf, Nbf*Naux, false, true);
-  arma::cx_mat Awork(Nbf,Naux);
-  
+  // Reshape B. After PartialCholeskyOrth in fill(), B has B.n_cols
+  // linearly independent auxiliary columns (≤ Naux); using raw Naux
+  // here would read past the end of B's storage.
+  const size_t Na = B.n_cols;
+  const arma::mat Breshape((double *) B.memptr(), Nbf, Nbf*Na, false, true);
+  arma::cx_mat Awork(Nbf,Na);
+
   for(size_t i=0;i<C.n_cols;i++) {
     // A(s,Q) = B(r;sQ) C(r;i)
-    Awork = arma::reshape(arma::trans(Breshape)*C.col(i),Nbf,Naux);
+    Awork = arma::reshape(arma::trans(Breshape)*C.col(i),Nbf,Na);
     K+=occs[i]*arma::conj(Awork)*arma::strans(Awork);
   }
 }

--- a/src/diis.cpp
+++ b/src/diis.cpp
@@ -301,13 +301,18 @@ arma::vec DIIS::get_w() {
         if(verbose) printf("Weight on last matrix too small, dropping the oldest matrix.\n");
         erase_last();
         PiF_update();
-      } else {
+      } else if(sol.n_elem == 2) {
         if(verbose) printf("Weight on last matrix still too small; switching to damping.\n");
         sol.zeros();
 
         double damp=0.1;
         sol(0)=1-damp;
         sol(1)=damp;
+        break;
+      } else {
+        // Single matrix in the stack: the only valid weight is 1.0,
+        // damping has no second matrix to mix with.
+        sol.ones();
         break;
       }
     } else

--- a/src/hirshfeld.cpp
+++ b/src/hirshfeld.cpp
@@ -88,8 +88,9 @@ double HirshfeldAtom::get(double r) const {
   // Index of entry is
   size_t i=(size_t) floor(rdr);
 
-  // Check limit
-  if(i>=rho.size()-1)
+  // Check limit. Test against rho.size() rather than rho.size()-1 so
+  // that an empty rho (size 0) doesn't wrap on the unsigned subtraction.
+  if(i+1>=rho.size())
     return 0.0;
 
   // Perform linear intepolation

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -585,8 +585,13 @@ arma::mat pivoted_cholesky(const arma::mat & A, double eps, arma::uvec & pivot) 
   if(m<L.n_cols)
     L.shed_cols(m,L.n_cols-1);
 
-  // Store pivot
-  pivot=pi.subvec(0,m-1);
+  // Store pivot. If m==0 (initial residual already below eps, no
+  // columns chosen), arma::vec::subvec(0, -1) wraps on size_t and
+  // throws or reads OOB; return an empty pivot vector instead.
+  if(m>0)
+    pivot=pi.subvec(0,m-1);
+  else
+    pivot.reset();
 
   return L;
 }

--- a/src/mathf.cpp
+++ b/src/mathf.cpp
@@ -398,6 +398,14 @@ arma::vec find_minima(const arma::vec & x, const arma::vec & y, size_t runave, d
     throw std::runtime_error("Input vectors are of inconsistent size!\n");
   }
 
+  // The running average eats runave points off each end; bail out if
+  // the input is too short to leave at least 2 averaged samples (the
+  // boundary checks below dereference yave(0)..yave(1) and the last two
+  // entries; with size_t the 2*runave subtraction also wraps when the
+  // input is shorter).
+  if(x.n_elem < 2*runave + 2)
+    return arma::vec();
+
   // Create averaged vectors
   arma::vec xave(x.n_elem-2*runave);
   arma::vec yave(y.n_elem-2*runave);
@@ -416,7 +424,7 @@ arma::vec find_minima(const arma::vec & x, const arma::vec & y, size_t runave, d
   if(yave(0)<yave(1))
     minloc.push_back(0);
 
-  for(arma::uword i=1;i<yave.n_elem-1;i++)
+  for(arma::uword i=1;i+1<yave.n_elem;i++)
     if(yave(i)<yave(i-1) && yave(i)<yave(i+1))
       minloc.push_back(i);
 

--- a/src/scf-solvers.cpp.in
+++ b/src/scf-solvers.cpp.in
@@ -628,7 +628,7 @@ size_t XRSSCF::half_hole(uscf_t & sol, double convthr, dft_t dft0)
 
     // Convergence checked against
     double maxdiff_cvd(maxdiff);
-    double rmsdiff_cvd(maxdiff);
+    double rmsdiff_cvd(rmsdiff);
 
 #ifndef RESTRICTED
     maxdiffa=max_abs(deltaPa);

--- a/src/slaterfit/form_exponents.cpp
+++ b/src/slaterfit/form_exponents.cpp
@@ -164,23 +164,22 @@ std::vector<contr_t> slater_fit_f(double zeta, int am, int nf, bool verbose, int
 
   int maxiter=1000;
 
-  // Degrees of freedom
+  // Degrees of freedom. The original code overwrote par.method to 2
+  // in the first else-branch unconditionally, so the second check for
+  // par.method==1 could never match and well-tempered fitting was
+  // silently degenerated into full optimisation. Use a single
+  // if/else-if chain so each method is considered against its own
+  // applicability condition.
   int dof;
-  if(par.method==0 && nf>=2)
+  if(par.method==0 && nf>=2) {
     dof=2;
-  else
-    // Full optimization
-    par.method=2;
-
-  if(par.method==1 && nf>=4)
+  } else if(par.method==1 && nf>=4) {
     dof=4;
-  else
+  } else {
     // Full optimization
     par.method=2;
-
-  // Full optimization
-  if(par.method==2)
     dof=par.Nf;
+  }
 
   gsl_multimin_function minfunc;
   minfunc.n=dof;
@@ -294,23 +293,22 @@ std::vector<contr_t> slater_fit(double zeta, int am, int nf, bool verbose, int m
 
   int maxiter=1000;
 
-  // Degrees of freedom
+  // Degrees of freedom. The original code overwrote par.method to 2
+  // in the first else-branch unconditionally, so the second check for
+  // par.method==1 could never match and well-tempered fitting was
+  // silently degenerated into full optimisation. Use a single
+  // if/else-if chain so each method is considered against its own
+  // applicability condition.
   int dof;
-  if(par.method==0 && nf>=2)
+  if(par.method==0 && nf>=2) {
     dof=2;
-  else
-    // Full optimization
-    par.method=2;
-
-  if(par.method==1 && nf>=4)
+  } else if(par.method==1 && nf>=4) {
     dof=4;
-  else
+  } else {
     // Full optimization
     par.method=2;
-
-  // Full optimization
-  if(par.method==2)
     dof=par.Nf;
+  }
 
   gsl_multimin_function_fdf minfunc;
   minfunc.n=dof;

--- a/src/stockholder.cpp
+++ b/src/stockholder.cpp
@@ -159,8 +159,12 @@ void StockholderAtom::fill_adaptive(const BasisSet & basis, const arma::mat & P,
     int lnext;
     double avgnext;
 
-    std::vector<double> oldrho, oldweights;
-    std::vector<coords_t> oldgrid;
+    // Seed with the current grid so that an early loop exit (e.g. the
+    // initial Lebedev rule already meets lmax) doesn't revert to empty
+    // vectors below.
+    std::vector<double> oldrho(rho[irad]);
+    std::vector<double> oldweights(weights[irad]);
+    std::vector<coords_t> oldgrid(grid[irad]);
 
     while(l<lmax) {
       // Get old rho, weight and grid

--- a/src/unitary.cpp
+++ b/src/unitary.cpp
@@ -883,6 +883,8 @@ void UnitaryOptimizer::fourier_step_df(UnitaryFunction* & f) {
       if(minval==fv(i)) {
 	delete f;
 	f=fs[i];
+	// Detach from fs so the cleanup below doesn't free the new f.
+	fs[i]=nullptr;
 	break;
       }
   }

--- a/src/xrs/lmtrans.cpp
+++ b/src/xrs/lmtrans.cpp
@@ -30,7 +30,12 @@ lmtrans::lmtrans() {
 lmtrans::lmtrans(const arma::mat & C, const BasisSet & bas, const coords_t & cen, size_t Nrad, int l, int lquad) {
   exp=expand_orbitals(C,bas,cen,true,Nrad,l,lquad);
 
-  // Compute maximum value of l
+  // Compute maximum value of l. Bail out cleanly if the orbital
+  // expansion produced no angular components: lmax-- on 0 would
+  // underflow and the Gaunt table would be constructed with a
+  // negative size below.
+  if(exp.clm.empty() || exp.clm[0].size()==0)
+    throw std::runtime_error("lmtrans: orbital expansion has no angular components.\n");
   lmax=0;
   while(lmind(lmax,lmax)<exp.clm[0].size())
     lmax++;


### PR DESCRIPTION
Fixes the HIGH-severity correctness bugs catalogued in #102, grouped into three commits by area for review-friendliness. All entries are real defects (not stylistic / API concerns); each is a write past array bounds, an uninitialised read, a use-after-free, or a wrong-result computation that produces no diagnostic.

`ctest -E "b97m_v|wb97m_v|wb97x_v"` (170/170, fast subset excluding the slow VV10 tests) passes with no failures on this branch.

## Commit 1: `Core library: fix correctness bugs surfaced by code review`

- **`diis.cpp`** — Damping fallback was running for any DIIS stack of size ≤ 2 but always wrote `sol(1)=damp`; that's an OOB write past the end when the stack contains a single Fock matrix. Split the fallback so the singleton case returns `sol={1.0}` and the genuine 2-element case keeps the damping path.
- **`linalg.cpp::pivoted_cholesky`** — When the residual is already below `eps` before any column is chosen (`m == 0`), `pi.subvec(0, m-1)` wraps on `size_t`. Return an empty pivot vector in that case.
- **`mathf.cpp::find_minima`** — Two issues. (1) When `x.n_elem ≤ 2*runave`, the running-average length wraps; short-circuit to an empty result. (2) `i < yave.n_elem - 1` wraps when `yave` is empty/short; use `i + 1 < yave.n_elem`.
- **`hirshfeld.cpp::HirshfeldAtom::get`** — `i ≥ rho.size() - 1` evaluated `rho.size() - 1` against unsigned, so an empty `rho` gave `SIZE_MAX - 1`, the bound check passed, and `rho[0]` was read off an empty vector. Compare `i + 1 ≥ rho.size()` instead.
- **`stockholder.cpp::fill_adaptive`** — When the initial Lebedev rule already meets `lmax`, the while-loop body never runs and the unconditional revert wiped the existing radial grid with default-constructed (empty) `oldrho`/`oldweights`/`oldgrid`. Seed those with the current grid so an early exit is a no-op.
- **`scf-solvers.cpp.in`** — `rmsdiff_cvd` was initialised from `maxdiff` (typo). The unrestricted branch overwrote it, but for RHF/RDFT the "RMS dens" status column reported the max-abs density change instead.
- **`density_fitting.cpp::digest_K_incore(cx_mat)`** — The `Breshape` used `Nbf*Naux` as the column count, but `B` has `Nbf*B.n_cols` storage where `B.n_cols ≤ Naux` after `PartialCholeskyOrth` pruning. With linear dependencies dropped, the cx K build read past the end of B. Use `B.n_cols` consistently.
- **`unitary.cpp` Fourier line search** — When the minimum-fv branch fires, `f = fs[i]` is stored, then the unconditional `for(...) delete fs[i]` cleanup deletes the same pointer, leaving `f` dangling. Detach `fs[i]` (set to `nullptr`) before the cleanup loop.

## Commit 2: `Subdirectory tools: fix correctness bugs in casida / slaterfit / xrs`

- **`casida.cpp::form_pairs`** — Occupation scan walked `while occs[ispin][nocc[ispin]] > 0` with no length guard; an array with no zero sentinel walked past the end. Bound by `occs[ispin].size()`.
- **`casida.cpp` active-orbital block** — `arma::vec newE(C[ispin].n_elem)` allocated using the matrix size (`n_rows*n_cols`) instead of `idx.size()`; `E[ispin]` then carried mostly uninitialised entries.
- **`casida_grid.cpp::compute`** — `xc_func_init` was called twice in succession in both the `x_func` and `c_func` branches; the second call leaked the first's libxc state. Drop the redundant calls.
- **`casida_grid.cpp::Kxc` cross-spin block** — Three bugs in the same vicinity. (1) j-side orbital values were looked up in `orbs[ispin]` rather than `orbs[jspin]` (orbs is per-spin). (2) Inner `jpair` loop ran over `jpair < ipair`, leaving the rectangular cross-spin block of K only partially filled. (3) The trailing `K(ioff+ipair, ioff+ipair) += wxc·…` line wrote a same-spin diagonal entry weighted by the cross-spin kernel `f^(ud)`; same-spin diagonal entries are built from `f^(σσ)` only (in the `ispin==jspin` branch above), so this line was both spurious and (now that the inner loop visits the full rectangle) redundant.
- **`slaterfit/form_exponents.cpp::slater_fit`** — Two `if/else` blocks where each `else` unconditionally overwrote `par.method = 2`, so the second `if(par.method == 1)` could never match and well-tempered fitting silently degenerated to full optimisation. Replace with a single `if/else-if` chain that considers each method against its own applicability condition.
- **`xrs/lmtrans.cpp` constructor** — `lmax` was decremented after a while-loop that may not execute (when `exp.clm[0].size() == 0` or `exp.clm` is empty), giving `lmax = -1` and a `Gaunt(2*lmax, …)` constructor with negative size. Throw with a clear message instead.

## Commit 3: `contrib: fix correctness bugs in research executables`

- **`energy-opt.cpp`** — Hessian was declared `arma::vec h(N, N)`, treating the second size argument as a column count for the underlying `arma::Col` (silently ignored). The subsequent `h(i, j)` writes were OOB for `j > 0`. Use `arma::mat`.
- **`guessbench.cpp`** — GWH guess loop walked `j = 0..n-1` including `j == i`, so the diagonal entry got overwritten by the off-diagonal formula and each off-diagonal pair was written twice. Iterate `j = i+1..n-1` and let the prior `Hgwh(Hcore)` copy carry the correct diagonal.
- **`hneoci.cpp`** — `H0_ci` was constructed without `fill::zeros`, then `+=`'d into. Every accumulated entry was offset by uninitialised heap memory, and entries the loops never touched (where both `i != j` and `I != J`, which should be exactly 0) remained as pure garbage. Add `arma::fill::zeros`.
- **`neosp.cpp`** — `printf("…%i first states is % .14e", arma::mean(...))` had only one trailing argument when two were required; the `%i` specifier was reading the double bit pattern of `arma::mean` as an integer (UB on stdio). Pass the count explicitly.

## Notes

- MED-severity items from #102 (boundary off-by-ones, `popen` leaks on parse errors, `LinDepThresh` clamping edge cases, etc.) are deferred to a follow-up. They affect edge cases rather than routine paths and warrant per-bug verification.
- Each commit is independently buildable; `make -j8 && ./src/test/basictests_omp && ctest -E "b97m_v|wb97m_v|wb97x_v"` is green on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)