### PR TITLE
Fix MED-severity correctness bugs from #102

### DIFF
--- a/src/basistool/main.cpp
+++ b/src/basistool/main.cpp
@@ -240,6 +240,11 @@ int main_guarded(int argc, char **argv) {
 
     // Print profile in output file
     FILE *out=fopen(fileout.c_str(),"w");
+    if(!out) {
+      std::ostringstream oss;
+      oss << "Could not open output file \"" << fileout << "\" for writing.\n";
+      throw std::runtime_error(oss.str());
+    }
     for(size_t i=0;i<prof.lga.size();i++) {
       // Value of scanning exponent
       fprintf(out,"%13e",prof.lga[i]);

--- a/src/contrib/co-optimize.cpp
+++ b/src/contrib/co-optimize.cpp
@@ -395,9 +395,10 @@ arma::vec compute_value_psi(int Z, bool dimer, std::vector<coprof_t> & cpl, cons
 
   // Get the energy
   arma::vec ret(1);
-  int readval;
   FILE *in=fopen("result.dat","r");
-  readval=fscanf(in,"%le",&ret(0));
+  if(!in)
+    throw std::runtime_error("Could not open result.dat to read calculation result.\n");
+  int readval=fscanf(in,"%le",&ret(0));
   fclose(in);
 
   if(readval!=1)

--- a/src/contrib/densproj.cpp
+++ b/src/contrib/densproj.cpp
@@ -134,10 +134,19 @@ int main_guarded(int argc, char **argv) {
   double aproj(arma::trace(Pa1*S12*Pa2*S12.t()));
   double bproj(arma::trace(Pb1*S12*Pb2*S12.t()));
   if(std::abs(aproj-bproj)>=sqrt(DBL_EPSILON)) {
-    printf("Projection of alpha densities is %e i.e. %5.2f %%\n",aproj,aproj/Nela1*100.0);
-    printf("Projection of beta  densities is %e i.e. %5.2f %%\n",bproj,bproj/Nelb1*100.0);
+    if(Nela1)
+      printf("Projection of alpha densities is %e i.e. %5.2f %%\n",aproj,aproj/Nela1*100.0);
+    else
+      printf("Projection of alpha densities is %e\n",aproj);
+    if(Nelb1)
+      printf("Projection of beta  densities is %e i.e. %5.2f %%\n",bproj,bproj/Nelb1*100.0);
+    else
+      printf("Projection of beta  densities is %e\n",bproj);
   }
-  printf("Projection of density is %e i.e. %5.2f %%\n",aproj+bproj,(aproj+bproj)/(Nela1+Nelb1)*100.0);
+  if(Nela1+Nelb1)
+    printf("Projection of density is %e i.e. %5.2f %%\n",aproj+bproj,(aproj+bproj)/(Nela1+Nelb1)*100.0);
+  else
+    printf("Projection of density is %e\n",aproj+bproj);
 
   printf("\nRunning program took %s.\n",t.elapsed().c_str());
 

--- a/src/contrib/guessbench.cpp
+++ b/src/contrib/guessbench.cpp
@@ -269,7 +269,8 @@ int main_guarded(int argc, char **argv) {
     } else {
       occa.zeros();
       occb.zeros();
-      occa.subvec(0,Nela-1).ones();
+      if(Nela)
+        occa.subvec(0,Nela-1).ones();
       if(Nelb)
         occb.subvec(0,Nelb-1).ones();
     }
@@ -285,10 +286,19 @@ int main_guarded(int argc, char **argv) {
   double aproj(arma::trace(Pa*S*Pag*S));
   double bproj(arma::trace(Pb*S*Pbg*S));
   if(std::abs(aproj-bproj)>=sqrt(DBL_EPSILON)) {
-    printf("Alpha projection of guess onto SCF density is %e i.e. %5.2f %%\n",aproj,aproj/Nela*100.0);
-    printf("Beta  projection of guess onto SCF density is %e i.e. %5.2f %%\n",bproj,bproj/Nelb*100.0);
+    if(Nela)
+      printf("Alpha projection of guess onto SCF density is %e i.e. %5.2f %%\n",aproj,aproj/Nela*100.0);
+    else
+      printf("Alpha projection of guess onto SCF density is %e\n",aproj);
+    if(Nelb)
+      printf("Beta  projection of guess onto SCF density is %e i.e. %5.2f %%\n",bproj,bproj/Nelb*100.0);
+    else
+      printf("Beta  projection of guess onto SCF density is %e\n",bproj);
   }
-  printf("Projection of guess onto SCF density is %e i.e. %5.2f %%\n",aproj+bproj,(aproj+bproj)/(Nela+Nelb)*100.0);
+  if(Nela+Nelb)
+    printf("Projection of guess onto SCF density is %e i.e. %5.2f %%\n",aproj+bproj,(aproj+bproj)/(Nela+Nelb)*100.0);
+  else
+    printf("Projection of guess onto SCF density is %e\n",aproj+bproj);
 
   // Save result?
   if(savef.size()) {

--- a/src/contrib/moints.cpp
+++ b/src/contrib/moints.cpp
@@ -18,6 +18,7 @@
 
 #include "../checkpoint.h"
 #include "../density_fitting.h"
+#include <limits>
 #include "../erichol.h"
 #include "../localization.h"
 #include "../timer.h"
@@ -226,7 +227,12 @@ arma::mat sano_guess_failsafe(const arma::mat & Co, const arma::mat & Cv, const 
 
 arma::mat sano_guess(const arma::mat & Co, const arma::mat & Cv, const arma::mat & Bph) {
   arma::mat R;
-  double eval;
+  // Initialise to NaN so we can tell apart "sano_guess_orig assigned a
+  // real eigenvalue and then threw" (printed value will be a real
+  // number) from "sano_guess_orig threw before assigning eval"
+  // (printed as nan). The earlier code printed an uninitialised
+  // double in the latter case.
+  double eval=std::numeric_limits<double>::quiet_NaN();
   try {
     R=sano_guess_orig(Co,Cv,Bph,eval);
     printf("Default Sano guess was succesful, smallest eigenvalue of guess orbital overlap %e\n",eval);

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -16,6 +16,7 @@
 
 #include "basislibrary.h"
 #include "basis.h"
+#include <memory>
 #include "checkpoint.h"
 #include "dftgrid.h"
 #include "elements.h"
@@ -369,10 +370,13 @@ int main_guarded(int argc, char **argv) {
 #pragma omp parallel
 #endif
     {
-      // ERI worker
+      // ERI worker. Wrap in unique_ptr so a throw inside the loop
+      // doesn't leak the allocation; .get() is used at every call
+      // site inside the loop (legacy raw-pointer API).
       auto maxam = std::max(source_basis.get_max_am(),target_basis.get_max_am());
       auto maxncontr = std::max(source_basis.get_max_Ncontr(), target_basis.get_max_Ncontr());
-      ERIWorker *eri = (omega==0.0 && alpha==1.0 && beta==0.0) ? new ERIWorker(maxam, maxncontr) : new ERIWorker_srlr(maxam,maxncontr,omega,alpha,beta);
+      std::unique_ptr<ERIWorker> eri_owner((omega==0.0 && alpha==1.0 && beta==0.0) ? new ERIWorker(maxam, maxncontr) : new ERIWorker_srlr(maxam,maxncontr,omega,alpha,beta));
+      ERIWorker *eri = eri_owner.get();
 
 #ifndef _OPENMP
       int ith=0;
@@ -464,7 +468,7 @@ int main_guarded(int argc, char **argv) {
           Jt.submat(jt0,it0,jt0+Ntj-1,it0+Nti-1) = arma::trans(Jtij);
       }
 
-      delete eri;
+      // eri_owner releases automatically.
     }
 
     return Jt;

--- a/src/contrib/neosp.cpp
+++ b/src/contrib/neosp.cpp
@@ -16,6 +16,7 @@
 
 #include "basislibrary.h"
 #include "basis.h"
+#include <memory>
 #include "checkpoint.h"
 #include "dftgrid.h"
 #include "elements.h"
@@ -218,10 +219,13 @@ int main_guarded(int argc, char **argv) {
 #pragma omp parallel
 #endif
     {
-      // ERI worker
+      // ERI worker. Wrap in unique_ptr so a throw inside the loop
+      // doesn't leak the allocation; .get() is used at every call
+      // site inside the loop (legacy raw-pointer API).
       auto maxam = std::max(source_basis.get_max_am(),target_basis.get_max_am());
       auto maxncontr = std::max(source_basis.get_max_Ncontr(), target_basis.get_max_Ncontr());
-      ERIWorker *eri = (omega==0.0 && alpha==1.0 && beta==0.0) ? new ERIWorker(maxam, maxncontr) : new ERIWorker_srlr(maxam,maxncontr,omega,alpha,beta);
+      std::unique_ptr<ERIWorker> eri_owner((omega==0.0 && alpha==1.0 && beta==0.0) ? new ERIWorker(maxam, maxncontr) : new ERIWorker_srlr(maxam,maxncontr,omega,alpha,beta));
+      ERIWorker *eri = eri_owner.get();
 
 #ifndef _OPENMP
       int ith=0;
@@ -285,7 +289,7 @@ int main_guarded(int argc, char **argv) {
           Jt.submat(jt0,it0,jt0+Ntj-1,it0+Nti-1) = arma::trans(Jtij);
       }
 
-      delete eri;
+      // eri_owner releases automatically.
     }
 
     return Jt;
@@ -311,15 +315,24 @@ int main_guarded(int argc, char **argv) {
   if(M==1) {
     arma::mat C;
     load.read("C",C);
-    C = C.cols(0,Nela-1);
+    if(Nela>0)
+      C = C.cols(0,Nela-1);
+    else
+      C.set_size(C.n_rows, 0);
     Pe = 2 * C * C.t();
 
   } else {
     arma::mat Ca, Cb;
     load.read("Ca",Ca);
     load.read("Cb",Cb);
-    Ca = Ca.cols(0,Nela-1);
-    Cb = Cb.cols(0,Nelb-1);
+    if(Nela>0)
+      Ca = Ca.cols(0,Nela-1);
+    else
+      Ca.set_size(Ca.n_rows, 0);
+    if(Nelb>0)
+      Cb = Cb.cols(0,Nelb-1);
+    else
+      Cb.set_size(Cb.n_rows, 0);
     Pe = Ca*Ca.t() + Cb*Cb.t();
   }
 

--- a/src/emd/emd_similarity.cpp
+++ b/src/emd/emd_similarity.cpp
@@ -20,6 +20,7 @@
 #include "../lebedev.h"
 #include "../chebyshev.h"
 #include "../timer.h"
+#include <memory>
 
 // Debug routines?
 //#define DEBUGSIM
@@ -188,18 +189,18 @@ arma::cube emd_overlap(const BasisSet & basis_a, const arma::cx_mat & P_a, const
 std::vector<double> evaluate_projection(const BasisSet & basis, const arma::cx_mat & P, const std::vector<double> rad, int l, int m) {
   int Nel=round(std::real(arma::trace(P*basis.overlap())));
 
-  GaussianEMDEvaluator *poseval=new GaussianEMDEvaluator(basis,P,l,std::abs(m));
-  GaussianEMDEvaluator *negeval=NULL;
+  // Use unique_ptr so a throw from the second GaussianEMDEvaluator
+  // construction (or anywhere later in the function) won't leak the
+  // first allocation.
+  std::unique_ptr<GaussianEMDEvaluator> poseval(new GaussianEMDEvaluator(basis,P,l,std::abs(m)));
+  std::unique_ptr<GaussianEMDEvaluator> negeval;
   if(m!=0)
-    negeval=new GaussianEMDEvaluator(basis,P,l,-std::abs(m));
-  EMD emd(poseval, negeval, Nel, l, m);
+    negeval.reset(new GaussianEMDEvaluator(basis,P,l,-std::abs(m)));
+  EMD emd(poseval.get(), negeval.get(), Nel, l, m);
 
   std::vector<double> ret(rad.size());
   for(size_t i=0;i<rad.size();i++)
     ret[i]=emd.eval(rad[i]);
-
-  delete poseval;
-  if(m!=0) delete negeval;
 
   return ret;
 }

--- a/src/emd/emdcube.cpp
+++ b/src/emd/emdcube.cpp
@@ -29,6 +29,8 @@ void emd_cube(const BasisSet & bas, const arma::cx_mat & P, const std::vector<do
 
   // Open output file.
   FILE *out=fopen("emdcube.dat","w");
+  if(!out)
+    throw std::runtime_error("Could not open emdcube.dat for writing.\n");
 
   // Compute the norm (assumes evenly spaced grid!)
   double norm=0.0;

--- a/src/eri_digest.cpp
+++ b/src/eri_digest.cpp
@@ -267,6 +267,13 @@ arma::mat KDigestor::get_K() const {
 }
 
 cxKDigestor::cxKDigestor(const arma::cx_mat & P_) : P(P_) {
+  // The symmetrisation in digest() uses arma::trans (Hermitian
+  // conjugate) on the off-diagonal Kij blocks; this is correct only
+  // when P is Hermitian, which is the case for HF/hybrid exchange in
+  // ERKALE today. If you ever need to feed a non-Hermitian P here,
+  // the K(k,i)/K(k,j)/K(l,i)/K(l,j) blocks must be computed directly
+  // rather than recovered from arma::trans of the corresponding K(i,*)
+  // block.
   K.zeros(P.n_rows,P.n_cols);
 }
 

--- a/src/external/fchkpt.cpp
+++ b/src/external/fchkpt.cpp
@@ -367,14 +367,18 @@ void load_fchk(double tol) {
     double nelnumb=arma::trace(Pb*S);
     double neldiffb=nelnumb-Nelb;
 
-    if(fabs(neldiffa)/Nela>tol) {
+    // Use absolute tolerance when the corresponding electron count is
+    // zero (e.g. fully spin-polarised cation with no beta electrons),
+    // since the relative-error denominator would otherwise be zero
+    // and the test would fire on numerical noise (or NaN).
+    if((Nela > 0 ? fabs(neldiffa)/Nela : fabs(neldiffa)) > tol) {
       std::ostringstream oss;
       oss << "\nNumber of alpha electrons and trace of alpha density matrix differ by " << neldiffa << "!\n";
       throw std::runtime_error(oss.str());
     }
     printf("tr PaS - Nela = %.e\n",neldiffa);
 
-    if(fabs(neldiffb)/Nelb>tol) {
+    if((Nelb > 0 ? fabs(neldiffb)/Nelb : fabs(neldiffb)) > tol) {
       std::ostringstream oss;
       oss << "\nNumber of beta electrons and trace of beta density matrix differ by " << neldiffb << "!\n";
       throw std::runtime_error(oss.str());
@@ -516,12 +520,20 @@ void save_fchk() {
     uselzma=true;
 
   // Open output file.
-  FILE *out=fopen(settings.get_string("SaveFchk").c_str(),"w");
+  const std::string savefchk = settings.get_string("SaveFchk");
+  FILE *out=fopen(savefchk.c_str(),"w");
+  if(!out) {
+    std::ostringstream oss;
+    oss << "Could not open output file \"" << savefchk << "\" for writing.\n";
+    throw std::runtime_error(oss.str());
+  }
 
   // Write comment
   fprintf(out,"%-80s\n","ERKALE formatted checkpoint for visualization purposes");
+  // Bound the timestamp string so we can't overflow the line buffer
+  // even with an unusually long current_time() result.
   char line[80];
-  sprintf(line,"Created on %s.",t.current_time().c_str());
+  snprintf(line,sizeof(line),"Created on %s.",t.current_time().c_str());
   fprintf(out,"%-80s\n",line);
 
   // Write the basis set info.

--- a/src/external/fchkpt_tools.cpp
+++ b/src/external/fchkpt_tools.cpp
@@ -94,6 +94,16 @@ Storage parse_fchk(const std::string & name) {
     throw std::runtime_error(oss.str());
   }
 
+  // Wrap the rest of the parse in a try/catch so any throw from
+  // readint/readdouble/etc. (e.g. on a malformed checkpoint line) still
+  // closes the input stream before propagating.
+  auto close_input = [&]() {
+    if(usegz || usexz || usebz2 || uselzma)
+      pclose(in);
+    else
+      fclose(in);
+  };
+
   // Line number
   size_t iline=0;
 
@@ -110,6 +120,7 @@ Storage parse_fchk(const std::string & name) {
   bool doublevec=false;
   std::vector<double> dblv;
 
+  try {
   while(true) {
     // Input line
     std::string line;
@@ -132,10 +143,13 @@ Storage parse_fchk(const std::string & name) {
 
     // Read in numbers?
     if(intvec) {
-      for(size_t i=0;i<words.size();i++)
+      // Bound the consumed count to N so a stray line with extra
+      // tokens doesn't cause N to wrap on size_t.
+      const size_t take = std::min(words.size(), N);
+      for(size_t i=0;i<take;i++)
 	intv.push_back(readint(words[i]));
 
-      N-=words.size();
+      N-=take;
       if(N==0) {
 	intvec=false;
 	// Add to stack
@@ -147,9 +161,10 @@ Storage parse_fchk(const std::string & name) {
 	intv.clear();
       }
     } else if(doublevec) {
-      for(size_t i=0;i<words.size();i++)
+      const size_t take = std::min(words.size(), N);
+      for(size_t i=0;i<take;i++)
 	dblv.push_back(readdouble(words[i]));
-      N-=words.size();
+      N-=take;
       if(N==0) {
 	doublevec=false;
 	// Add to stack
@@ -215,11 +230,13 @@ Storage parse_fchk(const std::string & name) {
     }
   }
 
+  } catch(...) {
+    close_input();
+    throw;
+  }
+
   // Close input
-  if(usegz || usexz || usebz2 || uselzma)
-    pclose(in);
-  else
-    fclose(in);
+  close_input();
 
   return ret;
 }

--- a/src/find_molecules.cpp
+++ b/src/find_molecules.cpp
@@ -26,42 +26,44 @@ std::vector< std::vector<size_t> > find_molecules(const std::vector<atom_t> & at
   // Loop over atoms
   for(size_t i=0;i<atoms.size();i++) {
 
-    // Check first, if atom should belong to a molecule.
-    bool found=0;
+    // Collect every existing molecule that contains an atom bonding
+    // to atom i. The earlier version stopped at the first match and
+    // moved on, which left previously-disjoint molecules separate
+    // even when atom i bridges them.
+    std::vector<size_t> matching_mols;
     for(size_t imol=0;imol<ret.size();imol++) {
-      // Loop over atoms in molecule
       for(size_t iat=0;iat<ret[imol].size();iat++) {
-	// The index of the other atom is
 	size_t j=ret[imol][iat];
 
-	// Compute the distance between the atoms.
 	double d=0.0;
 	d+=(atoms[i].x-atoms[j].x)*(atoms[i].x-atoms[j].x);
 	d+=(atoms[i].y-atoms[j].y)*(atoms[i].y-atoms[j].y);
 	d+=(atoms[i].z-atoms[j].z)*(atoms[i].z-atoms[j].z);
 	d=sqrt(d)/ANGSTROMINBOHR;
 
-	// Check if bond exists
 	if(check_bonds(d,atoms[i].el,atoms[j].el)) {
-	  // Yes, add to molecule
-	  ret[imol].push_back(i);
-	  found=1;
-	  // Stop loop
-	  break;
+	  matching_mols.push_back(imol);
+	  break; // a single bond into the molecule is enough
 	}
       }
-
-      if(found)
-	// Atom was already added to a molecule
-	break;
     }
 
-    if(!found) {
-      // Need to add new molecule.
+    if(matching_mols.empty()) {
+      // No existing molecule bonds to atom i; start a new one.
       std::vector<size_t> hlp;
       hlp.push_back(i);
-      // Add it to the list
       ret.push_back(hlp);
+    } else {
+      // Add atom i to the first matching molecule and merge any other
+      // matching molecules into it. Erase merged-in entries from the
+      // back so the surviving indices don't shift under us.
+      size_t target = matching_mols[0];
+      ret[target].push_back(i);
+      for(size_t k=matching_mols.size(); k-->1; ) {
+	size_t src = matching_mols[k];
+	ret[target].insert(ret[target].end(), ret[src].begin(), ret[src].end());
+	ret.erase(ret.begin()+src);
+      }
     }
   }
 

--- a/src/linalg.cpp
+++ b/src/linalg.cpp
@@ -122,8 +122,13 @@ arma::mat PartialCholeskyOrth(const arma::mat & S, double cholcut, double scut) 
   // Off-diagonal S
   arma::mat odS(arma::abs(S));
   odS.diag().zeros();
-  // Column sum
-  arma::vec odSs(arma::sum(S).t());
+  // Column sum of |S| with the diagonal removed -- ranks columns by
+  // off-diagonal coupling strength so that the Cholesky pivot order
+  // tackles the most strongly coupled functions first. The earlier
+  // version summed raw S (with the diagonal retained), so the pivot
+  // ordering was dominated by S(i,i) ~ 1 rather than the off-diagonal
+  // structure odS was built to capture.
+  arma::vec odSs(arma::sum(odS).t());
   arma::uvec pivot = arma::stable_sort_index(odSs,"ascend");
   // Find suitable basis by partial Cholesky decomposition
   pivoted_cholesky(S,cholcut,pivot);

--- a/src/scf-fock.cpp.in
+++ b/src/scf-fock.cpp.in
@@ -929,7 +929,7 @@ void XRSSCF::Fock_half_hole(uscf_t & sol, dft_t dft, const std::vector<double> &
 #endif
 
   if(!std::isfinite(sol.en.E)) {
-#if DEBUGPRINTOUT
+#ifdef DEBUGPRINTOUT
     ERROR_INFO();
 
     // Print out hamiltonians

--- a/src/tempered.cpp
+++ b/src/tempered.cpp
@@ -51,6 +51,14 @@ arma::vec welltempered_set(double alpha, double beta, double gamma, double delta
 }
 
 arma::mat legendre_P_mat(int Nprim, int kmax) {
+  // Maps the integer index j=1..Nprim to a Legendre argument in [-1, 1].
+  // Requires Nprim >= 2 to avoid dividing by zero at the (j-1)*2/(Nprim-1)
+  // step; a single-primitive Legendre expansion isn't well-defined here.
+  if(Nprim<2) {
+    ERROR_INFO();
+    throw std::runtime_error("legendre_P_mat requires at least two primitives.\n");
+  }
+
   // Compute the Legendre polynomials
   arma::mat Pk(Nprim, kmax);
   for(int j=1;j<=Nprim;j++) { // Loop over exponents


### PR DESCRIPTION
Fixes the MED-severity items catalogued in #102, grouped into three commits by area. Companion to PR #104 (which addressed HIGH-severity items).

`ctest -E "b97m_v|wb97m_v|wb97x_v"` (170/170, fast subset) passes with no failures on this branch.

## Commit 1: Core library

- **`eri_digest.cpp::cxKDigestor`** — Document the Hermitian-P assumption explicitly. The `arma::trans` (Hermitian conjugate) symmetrisation in `digest()` is correct only when the input density matrix is Hermitian; today's callers (HF / hybrid exchange) always pass Hermitian P, but the contract was implicit. A constructor-side comment makes this explicit so future non-Hermitian use sites can avoid silent incorrectness.
- **`scf-fock.cpp.in:932`** — `#if DEBUGPRINTOUT` corrected to `#ifdef DEBUGPRINTOUT`. Inconsistent with the other three `DEBUGPRINTOUT` guards in the same file (lines 893, 904, 917); a user enabling the macro via `-DDEBUGPRINTOUT` (no value) made the energy-not-finite branch fail to compile.
- **`linalg.cpp::PartialCholeskyOrth`** — The pivot-ordering vector was `arma::sum(S)` (raw `S`, including the diagonal) instead of `arma::sum(odS)` (the explicitly built off-diagonal-only `|S|`). The diagonal dominated the column sum, so the pivot ordering reflected `S(i,i) ~ 1` rather than the off-diagonal coupling structure `odS` was intended to capture.
- **`tempered.cpp::legendre_P_mat`** — `(j-1)*2.0/(Nprim-1)` divides by zero when `Nprim==1`, producing NaN arguments to `std::legendre` and downstream NaN exponents. Reject `Nprim < 2` explicitly with a clear runtime error.
- **`find_molecules.cpp::find_molecules`** — When atom *i* bonded to atoms in two existing molecules, the loop took the first match and broke; the two molecules that should have merged remained separate connected components. Collect every matching molecule first, append atom *i* to the first, then merge the remainder in.

## Commit 2: Subdirectory tools

- **`emd/emd_similarity.cpp::evaluate_projection`** — Two raw-`new` `GaussianEMDEvaluator` allocations leaked if the second `new` or the `EMD` constructor threw. Switch to `std::unique_ptr` ownership.
- **`emd/emdcube.cpp::emd_cube`** — `fopen("emdcube.dat", "w")` was followed immediately by `fprintf` without a NULL check. Throw on failure.
- **`basistool/main.cpp` completeness-profile path** — Same unchecked `fopen` before `fprintf`.
- **`external/fchkpt.cpp::write_fchk`** — `fopen` for the output file was unchecked, and a fixed 80-byte `sprintf` line buffer for the timestamp could overflow with an unusually long `current_time()` string. Add the NULL check and switch `sprintf` to `snprintf`.
- **`external/fchkpt.cpp::read_fchk` electron-count consistency check** — `fabs(neldiff)/Nel > tol` divided by zero (and produced NaN comparison) for fully spin-polarised systems where `Nelb == 0`. Switch to absolute tolerance when the corresponding count is zero.
- **`external/fchkpt_tools.cpp::parse_fchk`** — Two issues. `N -= words.size()` consumed-token bookkeeping wraps on `size_t` if a stray line has more tokens than the remaining count; bound the consumed amount to `N`. Any throw from `readint`/`readdouble` after the `fopen`/`popen` leaked the input stream; wrap the parse loop in `try/catch` and close on the way out (or on rethrow).

## Commit 3: contrib research executables

- **`co-optimize.cpp::psi4_energy`** — `fopen("result.dat", "r")` was unchecked; if the upstream psi4 invocation succeeded but `result.dat` was missing or unreadable, `fscanf` dereferenced NULL.
- **`densproj.cpp` projection report** — `aproj/Nela1`, `bproj/Nelb1` and `(aproj+bproj)/(Nela1+Nelb1)` printed for fully-polarised / zero-electron systems divided by zero. Branch on whether the corresponding count is non-zero.
- **`guessbench.cpp` manual-occupation block** — `occa.subvec(0, Nela-1)` with `Nela == 0` walks past the end (`Nela-1` wraps on unsigned). Guard with `if(Nela)`. The companion projection-percentage prints had the same div-by-zero pattern; same fix.
- **`moints.cpp::sano_guess`** — `double eval` in the catch-block `printf` was uninitialised when the early consistency-check inside `sano_guess_orig` threw before assigning it. Initialise to `quiet_NaN()` so the failure log prints `nan` rather than reading unspecified stack memory.
- **`neo.cpp` / `neosp.cpp` ERI-Coulomb loops** — Raw `new ERIWorker` paired with a manual `delete eri` at the bottom of the OpenMP region leaked on exception from any compute / arma op in between. Wrap in `std::unique_ptr`; `.get()` preserves the raw-pointer call sites.
- **`neosp.cpp` orbital-extraction block** — `C.cols(0, Nela-1)` and `Cb.cols(0, Nelb-1)` underflowed when either count was zero. Guard each with an explicit zero-electron path yielding an empty column matrix.

## Notes

- LOW-severity items from #102 (substring extension match, `Hirshfeld::print_densities` overrun by one in dump output, `Ul` undefined in `atom/integrals.cpp` when `n12 == l`, `casida.cpp` screening-max sign artefact) are not addressed here. They affect cosmetic / very-edge-case behaviours.
- I also re-checked the `boys.cpp:88` boundary issue from #102 and concluded it isn't reachable: `N = ceil(xmax/dx + 1)` is sized so that `round(x/dx)` for `x < xmax` always lands in `[0, N-1]`. False positive in the original report.
- Each commit is independently buildable; `make -j8 && ./src/test/basictests_omp && ctest -E "b97m_v|wb97m_v|wb97x_v"` is green on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)