### PR TITLE
Fix LOW-severity correctness bugs from #102

### DIFF
--- a/src/atom/integrals.cpp
+++ b/src/atom/integrals.cpp
@@ -16,6 +16,7 @@
 
 #include "../eriworker.h"
 #include "../gaunt.h"
+#include <sstream>
 #include "../linalg.h"
 #include "../mathf.h"
 #include "integrals.h"
@@ -24,6 +25,17 @@
 
 /// A. Kumar and P. C. Mishra, Pramana 29 (1987), pp. 385-390.
 double Ul(int l, int n12, int n34, double z12, double z34) {
+  // The closed-form integrand requires n12 > l (so that n12-l-1 is a
+  // non-negative factorial argument) and n34 > l (similar role in the
+  // term3 prefactor fact(n34-l-1)). Reject earlier than the implicit
+  // fact() throw so callers get a clearly-attributable error.
+  if(n12 <= l || n34 <= l) {
+    std::ostringstream oss;
+    oss << "Ul: requires n12 > l and n34 > l, but got l=" << l
+        << ", n12=" << n12 << ", n34=" << n34 << ".\n";
+    throw std::runtime_error(oss.str());
+  }
+
   // Prefactor
   double prefac=fact(n34+l)/pow(z34,n34+l+1);
 

--- a/src/casida/casida.cpp
+++ b/src/casida/casida.cpp
@@ -593,11 +593,14 @@ void Casida::coulomb_fit(const BasisSet & basis, std::vector<arma::mat> & munu, 
       eri.compute(&orbshells[is],&orbshells[js],&orbshells[is],&orbshells[js]);
       erip=eri.getp();
 
-      // Find out maximum value
+      // Find out maximum absolute value. The previous version compared
+      // fabs but stored the raw signed integral, so a large-magnitude
+      // negative integral landed in `max` as a negative number and the
+      // subsequent sqrt produced NaN.
       double max=0.0;
       for(size_t i=0;i<(*erip).size();i++)
 	if(fabs((*erip)[i])>max)
-	  max=(*erip)[i];
+	  max=fabs((*erip)[i]);
       max=sqrt(max);
 
       // Store value

--- a/src/external/fchkpt.cpp
+++ b/src/external/fchkpt.cpp
@@ -498,26 +498,25 @@ void save_fchk() {
   // File to save
   std::string savename=settings.get_string("SaveFchk");
 
-  // Handle also compressed files
+  // Handle also compressed files. Match the actual filename suffix
+  // rather than any substring; otherwise a path like `proj.gz/out.fchk`
+  // would be misidentified as a gz target.
+  auto ends_with = [&](const char * suffix) {
+    const size_t slen = std::strlen(suffix);
+    return savename.size() >= slen &&
+           savename.compare(savename.size() - slen, slen, suffix) == 0;
+  };
   std::string gzcmd="gzip ";
-  bool usegz=false;
-  if(strstr(savename.c_str(),".gz")!=NULL)
-    usegz=true;
+  bool usegz=ends_with(".gz");
 
   std::string xzcmd="xz ";
-  bool usexz=false;
-  if(strstr(savename.c_str(),".xz")!=NULL)
-    usexz=true;
+  bool usexz=ends_with(".xz");
 
   std::string bz2cmd="bzip2 ";
-  bool usebz2=false;
-  if(strstr(savename.c_str(),".bz2")!=NULL)
-    usebz2=true;
+  bool usebz2=ends_with(".bz2");
 
   std::string lzmacmd="lzma ";
-  bool uselzma=false;
-  if(strstr(savename.c_str(),".lzma")!=NULL)
-    uselzma=true;
+  bool uselzma=ends_with(".lzma");
 
   // Open output file.
   const std::string savefchk = settings.get_string("SaveFchk");

--- a/src/external/fchkpt_tools.cpp
+++ b/src/external/fchkpt_tools.cpp
@@ -25,6 +25,7 @@
 
 #include "../checkpoint.h"
 #include "../elements.h"
+#include <cstring>
 #include "../mathf.h"
 #include "../stringutil.h"
 #include "../timer.h"
@@ -39,6 +40,14 @@
 #endif
 
 
+/// True iff `s` ends with `suffix`. Replaces strstr-based extension
+/// detection that would also match the suffix anywhere in the path
+/// (e.g. a directory named `proj.gz/`).
+static bool ends_with(const std::string & s, const char * suffix) {
+  const size_t slen = std::strlen(suffix);
+  return s.size() >= slen && s.compare(s.size() - slen, slen, suffix) == 0;
+}
+
 /// Parse formatted checkpoint file
 Storage parse_fchk(const std::string & name) {
   // Returned storage
@@ -47,26 +56,20 @@ Storage parse_fchk(const std::string & name) {
   // Input file
   FILE *in;
 
-  // Handle also compressed files
+  // Handle also compressed files. Match the actual filename suffix
+  // rather than any substring; otherwise a path like `proj.gz/bin.fchk`
+  // would be misidentified as a gz-compressed file.
   const char gzcmd[]="zcat ";
-  bool usegz=false;
-  if(strstr(name.c_str(),".gz")!=NULL)
-    usegz=true;
+  bool usegz=ends_with(name, ".gz");
 
   const char xzcmd[]="xzcat ";
-  bool usexz=false;
-  if(strstr(name.c_str(),".xz")!=NULL)
-    usexz=true;
+  bool usexz=ends_with(name, ".xz");
 
   const char bz2cmd[]="bzcat ";
-  bool usebz2=false;
-  if(strstr(name.c_str(),".bz2")!=NULL)
-    usebz2=true;
+  bool usebz2=ends_with(name, ".bz2");
 
   const char lzmacmd[]="lzcat ";
-  bool uselzma=false;
-  if(strstr(name.c_str(),".lzma")!=NULL)
-    uselzma=true;
+  bool uselzma=ends_with(name, ".lzma");
 
   /* Open the file */
   if(usegz) {

--- a/src/hirshfeld.cpp
+++ b/src/hirshfeld.cpp
@@ -256,12 +256,19 @@ void Hirshfeld::print_densities() const {
     std::ostringstream fname;
     fname << "hirshfeld_" << i << ".dat";
     FILE *out=fopen(fname.str().c_str(),"w");
+    if(!out) {
+      std::ostringstream oss;
+      oss << "Could not open \"" << fname.str() << "\" for writing.\n";
+      throw std::runtime_error(oss.str());
+    }
 
     // Spacing to use
     double dr=0.001;
     // Amount of points
     size_t N=1+ (size_t) round(atoms[i].get_range()/dr);
-    for(size_t ir=0;ir<=N;ir++)
+    // Iterate ir=0..N-1; the previous `<=N` upper bound walked one
+    // point past the radial range, where atoms[i].get returns 0.
+    for(size_t ir=0;ir<N;ir++)
       fprintf(out,"%e %e\n",ir*dr,atoms[i].get(ir*dr));
     fclose(out);
   }


### PR DESCRIPTION
Fixes the LOW-severity items catalogued in #102, completing the bug-tracker work in this series. Companion to #104 (HIGH) and #105 (MED).

`make -j8 && ./src/test/basictests_omp` is green; `ctest -E "b97m_v|wb97m_v|wb97x_v"` running at PR-creation time.

## Changes

- **`hirshfeld.cpp::print_densities`** — Loop bound was `for(ir=0; ir<=N; ir++)` with `N` already pre-incremented to `1 + round(range/dr)`. The `<=N` walked one point past the radial range, where `atoms[i].get(N*dr)` silently returned `0`, producing one trailing zero row in every `hirshfeld_<i>.dat` dump. Switch to `<N`. Also add the missing `fopen` NULL check while we're here.

- **`casida.cpp` screening-max loop** — `if(fabs(x) > max) max = x` compared the absolute value but stored the raw signed integral. A strongly-negative ERI with the largest magnitude landed in `max` as a negative number; the subsequent `sqrt(max)` then produced NaN, contaminating the screening matrix. Store `fabs()` consistently.

- **`external/fchkpt.cpp` + `external/fchkpt_tools.cpp` compressed-file routing** — `strstr(name, ".gz")` (and the `.xz`/`.bz2`/`.lzma` analogues) matched the suffix anywhere in the path. A path like `proj.gz/out.fchk` was falsely identified as gz-compressed and run through `zcat`/`gzip`, producing nonsense output (or empty input on the read path). Switch to a proper end-of-string suffix match via a small `ends_with` helper.

- **`atom/integrals.cpp::Ul`** — The Kumar-Mishra closed form requires `n12 > l` and `n34 > l` (so that `fact(n12-l-1)` and `fact(n34-l-1)` are well-defined). Without an explicit guard, callers passing `n12 <= l` hit the implicit `fact(negative)` throw deep in `mathf.cpp` with no context. Add a precondition check at the top of `Ul` that names the offending values.

## Notes

- `boys.cpp:88` from the original #102 review was deemed a false positive in the MED PR (#105) and is not addressed here.
- This closes the LOW items from #102. The remaining open work in #102 is a re-verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)