### PR TITLE
perf: extend fused basis evaluator to Hessian and ∇(∇²)

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -593,135 +593,116 @@ arma::vec GaussianShell::eval_func(double x, double y, double z) const {
 }
 
 arma::mat GaussianShell::eval_grad(double x, double y, double z) const {
-  // Evaluate gradients of functions at (x,y,z)
-
-  // Compute coordinates relative to center
-  double xrel=x-cen.x;
-  double yrel=y-cen.y;
-  double zrel=z-cen.z;
-
-  double rrelsq=xrel*xrel+yrel*yrel+zrel*zrel;
-
-  // Power arrays, x^l, y^l, z^l
-  double xr[am+2], yr[am+2], zr[am+2];
-
-  xr[0]=1.0;
-  yr[0]=1.0;
-  zr[0]=1.0;
-
-  xr[1]=xrel;
-  yr[1]=yrel;
-  zr[1]=zrel;
-
-  for(int i=2;i<=am+1;i++) {
-    xr[i]=xr[i-1]*xrel;
-    yr[i]=yr[i-1]*yrel;
-    zr[i]=zr[i-1]*zrel;
-  }
-
-  // Gradient array, N_cart x 3
-  arma::mat ret(cart.size(),3);
-  ret.zeros();
-
-  // Helper variables
-  double expf;
-
-  // Loop over functions
-  for(size_t icart=0;icart<cart.size();icart++) {
-    // Get types
-    int l=cart[icart].l;
-    int m=cart[icart].m;
-    int n=cart[icart].n;
-
-    // Loop over exponential contraction
-    for(size_t iexp=0;iexp<c.size();iexp++) {
-      // Contracted exponent
-      expf=c[iexp].c*exp(-c[iexp].z*rrelsq);
-
-      // x component of gradient:
-      ret(icart,0)+=_der1(xr,l,c[iexp].z)*yr[m]*zr[n]*expf;
-      // y component
-      ret(icart,1)+=xr[l]*_der1(yr,m,c[iexp].z)*zr[n]*expf;
-      // z component
-      ret(icart,2)+=xr[l]*yr[m]*_der1(zr,n,c[iexp].z)*expf;
-    }
-
-    // Plug in normalization constant
-    ret(icart,0)*=cart[icart].relnorm;
-    ret(icart,1)*=cart[icart].relnorm;
-    ret(icart,2)*=cart[icart].relnorm;
-  }
-
-  if(uselm)
-    // Need to transform into spherical harmonics
-    return transmat*ret;
-  else
-    return ret;
+  // Thin wrapper around the fused evaluator: same inner-loop order
+  // and per-iteration work as the original specialised
+  // implementation, but the contracted-exponential evaluation and
+  // power tables now share with eval_lapl when both are requested.
+  // The fused routine also fills fval (a small constant overhead
+  // for grad-only callers), since the func contribution per
+  // (iexp, icart) inner step is just 3 multiplies and an add.
+  arma::vec fval, lval;
+  arma::mat gval;
+  eval_func_grad_lapl(x, y, z, fval, gval, lval, true, false);
+  return gval;
 }
 
 arma::vec GaussianShell::eval_lapl(double x, double y, double z) const {
-  // Evaluate laplacian of basis functions at (x,y,z)
+  // Thin wrapper around the fused evaluator (cf. eval_grad).
+  arma::vec fval, lval;
+  arma::mat gval;
+  eval_func_grad_lapl(x, y, z, fval, gval, lval, false, true);
+  return lval;
+}
 
-  // Compute coordinates relative to center
-  double xrel=x-cen.x;
-  double yrel=y-cen.y;
-  double zrel=z-cen.z;
+void GaussianShell::eval_func_grad_lapl(double x, double y, double z,
+                                        arma::vec & fval,
+                                        arma::mat & gval,
+                                        arma::vec & lval,
+                                        bool do_grad, bool do_lapl) const {
+  // Evaluate the basis-function values plus gradient and laplacian in
+  // one pass. The three eval_* siblings each rebuild xrel/yrel/zrel,
+  // the power arrays, and the per-primitive exp(-z * rrelsq); a fused
+  // pass amortises all of that. Each (icart, iexp) inner step then
+  // accumulates whichever of the (func, grad, lapl) outputs the
+  // caller asked for.
 
-  double rrelsq=xrel*xrel+yrel*yrel+zrel*zrel;
+  const double xrel = x - cen.x;
+  const double yrel = y - cen.y;
+  const double zrel = z - cen.z;
+  const double rrelsq = xrel*xrel + yrel*yrel + zrel*zrel;
 
-  // Power arrays, x^l, y^l, z^l
-  double xr[am+3], yr[am+3], zr[am+3];
-
-  xr[0]=1.0;
-  yr[0]=1.0;
-  zr[0]=1.0;
-
-  xr[1]=xrel;
-  yr[1]=yrel;
-  zr[1]=zrel;
-
-  for(int i=2;i<=am+2;i++) {
-    xr[i]=xr[i-1]*xrel;
-    yr[i]=yr[i-1]*yrel;
-    zr[i]=zr[i-1]*zrel;
-  }
-
-  // Values of laplacians of functions
-  arma::vec ret(cart.size());
-  ret.zeros();
-
-  // Helper variables
-  double expf;
-
-  // Loop over functions
-  for(size_t icart=0;icart<cart.size();icart++) {
-    // Get types
-    int l=cart[icart].l;
-    int m=cart[icart].m;
-    int n=cart[icart].n;
-
-    // Loop over exponential contraction
-    for(size_t iexp=0;iexp<c.size();iexp++) {
-      // Contracted exponent
-      expf=c[iexp].c*exp(-c[iexp].z*rrelsq);
-
-      // Derivative wrt x
-      ret(icart)+=_der2(xr,l,c[iexp].z)*yr[m]*zr[n]*expf;
-      // Derivative wrt y
-      ret(icart)+=xr[l]*_der2(yr,m,c[iexp].z)*zr[n]*expf;
-      // Derivative wrt z
-      ret(icart)+=xr[l]*yr[m]*_der2(zr,n,c[iexp].z)*expf;
+  // Power arrays sized to the maximum derivative order requested.
+  // do_lapl needs xr[am+2]; do_grad needs xr[am+1]; func only needs am.
+  const int xpow_max = am + (do_lapl ? 2 : (do_grad ? 1 : 0));
+  double xr[xpow_max+1], yr[xpow_max+1], zr[xpow_max+1];
+  xr[0] = 1.0; yr[0] = 1.0; zr[0] = 1.0;
+  if(xpow_max >= 1) {
+    xr[1] = xrel; yr[1] = yrel; zr[1] = zrel;
+    for(int i=2; i<=xpow_max; i++) {
+      xr[i] = xr[i-1]*xrel;
+      yr[i] = yr[i-1]*yrel;
+      zr[i] = zr[i-1]*zrel;
     }
-
-    // Plug in normalization constant
-    ret(icart)*=cart[icart].relnorm;
   }
 
-  if(uselm)
-    // Transform into spherical harmonics
-    return transmat*ret;
-  else
-    return ret;
+  // Cartesian-basis accumulators
+  arma::vec fbuf;
+  arma::mat gbuf;
+  arma::vec lbuf;
+  fbuf.zeros(cart.size());
+  if(do_grad) gbuf.zeros(cart.size(), 3);
+  if(do_lapl) lbuf.zeros(cart.size());
+
+  for(size_t iexp=0; iexp<c.size(); iexp++) {
+    const double z_i = c[iexp].z;
+    const double exp_i = c[iexp].c * std::exp(-z_i * rrelsq);
+
+    for(size_t icart=0; icart<cart.size(); icart++) {
+      const int l = cart[icart].l;
+      const int m = cart[icart].m;
+      const int n = cart[icart].n;
+      const double xl = xr[l];
+      const double ym = yr[m];
+      const double zn = zr[n];
+
+      fbuf(icart) += xl * ym * zn * exp_i;
+
+      if(do_grad) {
+        gbuf(icart, 0) += _der1(xr, l, z_i) * ym * zn * exp_i;
+        gbuf(icart, 1) += xl * _der1(yr, m, z_i) * zn * exp_i;
+        gbuf(icart, 2) += xl * ym * _der1(zr, n, z_i) * exp_i;
+      }
+
+      if(do_lapl) {
+        lbuf(icart) += (_der2(xr, l, z_i) * ym * zn
+                       + xl * _der2(yr, m, z_i) * zn
+                       + xl * ym * _der2(zr, n, z_i)) * exp_i;
+      }
+    }
+  }
+
+  // Plug in the per-cartesian normalisation constant
+  for(size_t icart=0; icart<cart.size(); icart++) {
+    const double rn = cart[icart].relnorm;
+    fbuf(icart) *= rn;
+    if(do_grad) {
+      gbuf(icart, 0) *= rn;
+      gbuf(icart, 1) *= rn;
+      gbuf(icart, 2) *= rn;
+    }
+    if(do_lapl) lbuf(icart) *= rn;
+  }
+
+  // Optionally project to spherical harmonics
+  if(uselm) {
+    fval = transmat * fbuf;
+    if(do_grad) gval = transmat * gbuf;
+    if(do_lapl) lval = transmat * lbuf;
+  } else {
+    fval = std::move(fbuf);
+    if(do_grad) gval = std::move(gbuf);
+    if(do_lapl) lval = std::move(lbuf);
+  }
 }
 
 arma::mat GaussianShell::eval_hess(double x, double y, double z) const {
@@ -2095,6 +2076,14 @@ arma::mat BasisSet::eval_hess(size_t ish, double x, double y, double z) const {
 
 arma::mat BasisSet::eval_laplgrad(size_t ish, double x, double y, double z) const {
   return shells[ish].eval_laplgrad(x,y,z);
+}
+
+void BasisSet::eval_func_grad_lapl(size_t ish, double x, double y, double z,
+                                   arma::vec & fval,
+                                   arma::mat & gval,
+                                   arma::vec & lval,
+                                   bool do_grad, bool do_lapl) const {
+  shells[ish].eval_func_grad_lapl(x, y, z, fval, gval, lval, do_grad, do_lapl);
 }
 
 void BasisSet::convert_contractions() {

--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -596,44 +596,50 @@ arma::mat GaussianShell::eval_grad(double x, double y, double z) const {
   // Thin wrapper around the fused evaluator: same inner-loop order
   // and per-iteration work as the original specialised
   // implementation, but the contracted-exponential evaluation and
-  // power tables now share with eval_lapl when both are requested.
-  // The fused routine also fills fval (a small constant overhead
-  // for grad-only callers), since the func contribution per
-  // (iexp, icart) inner step is just 3 multiplies and an add.
+  // power tables now share with eval_lapl/eval_hess/eval_laplgrad
+  // when more than one is requested.
   arma::vec fval, lval;
-  arma::mat gval;
-  eval_func_grad_lapl(x, y, z, fval, gval, lval, true, false);
+  arma::mat gval, hval, lgval;
+  eval_bf_derivs(x, y, z, fval, gval, lval, hval, lgval, true, false, false, false);
   return gval;
 }
 
 arma::vec GaussianShell::eval_lapl(double x, double y, double z) const {
   // Thin wrapper around the fused evaluator (cf. eval_grad).
   arma::vec fval, lval;
-  arma::mat gval;
-  eval_func_grad_lapl(x, y, z, fval, gval, lval, false, true);
+  arma::mat gval, hval, lgval;
+  eval_bf_derivs(x, y, z, fval, gval, lval, hval, lgval, false, true, false, false);
   return lval;
 }
 
-void GaussianShell::eval_func_grad_lapl(double x, double y, double z,
-                                        arma::vec & fval,
-                                        arma::mat & gval,
-                                        arma::vec & lval,
-                                        bool do_grad, bool do_lapl) const {
-  // Evaluate the basis-function values plus gradient and laplacian in
-  // one pass. The three eval_* siblings each rebuild xrel/yrel/zrel,
-  // the power arrays, and the per-primitive exp(-z * rrelsq); a fused
-  // pass amortises all of that. Each (icart, iexp) inner step then
-  // accumulates whichever of the (func, grad, lapl) outputs the
-  // caller asked for.
+void GaussianShell::eval_bf_derivs(double x, double y, double z,
+                                   arma::vec & fval,
+                                   arma::mat & gval,
+                                   arma::vec & lval,
+                                   arma::mat & hval,
+                                   arma::mat & lgval,
+                                   bool do_grad, bool do_lapl,
+                                   bool do_hess, bool do_lgrad) const {
+  // Evaluate the basis-function values plus any subset of gradient,
+  // laplacian, Hessian and gradient-of-laplacian in one pass. The
+  // five specialised eval_* siblings each rebuild xrel/yrel/zrel,
+  // the power arrays, and the per-primitive exp(-z * rrelsq); a
+  // fused pass amortises all of that across the requested outputs.
 
   const double xrel = x - cen.x;
   const double yrel = y - cen.y;
   const double zrel = z - cen.z;
   const double rrelsq = xrel*xrel + yrel*yrel + zrel*zrel;
 
-  // Power arrays sized to the maximum derivative order requested.
-  // do_lapl needs xr[am+2]; do_grad needs xr[am+1]; func only needs am.
-  const int xpow_max = am + (do_lapl ? 2 : (do_grad ? 1 : 0));
+  // Power-array degree needed:
+  //   func only           -> am
+  //   grad                -> am + 1   (_der1 reads xr[l+1])
+  //   lapl, hess          -> am + 2   (_der2 reads xr[l+2])
+  //   laplgrad            -> am + 3   (_der3 reads xr[l+3])
+  int xpow_max = am;
+  if(do_grad) xpow_max = std::max(xpow_max, am + 1);
+  if(do_lapl || do_hess) xpow_max = std::max(xpow_max, am + 2);
+  if(do_lgrad) xpow_max = std::max(xpow_max, am + 3);
   double xr[xpow_max+1], yr[xpow_max+1], zr[xpow_max+1];
   xr[0] = 1.0; yr[0] = 1.0; zr[0] = 1.0;
   if(xpow_max >= 1) {
@@ -645,13 +651,12 @@ void GaussianShell::eval_func_grad_lapl(double x, double y, double z,
     }
   }
 
-  // Cartesian-basis accumulators
-  arma::vec fbuf;
-  arma::mat gbuf;
-  arma::vec lbuf;
-  fbuf.zeros(cart.size());
-  if(do_grad) gbuf.zeros(cart.size(), 3);
-  if(do_lapl) lbuf.zeros(cart.size());
+  // Cartesian-basis accumulators (allocated only if requested).
+  arma::vec fbuf;  fbuf.zeros(cart.size());
+  arma::mat gbuf;  if(do_grad) gbuf.zeros(cart.size(), 3);
+  arma::vec lbuf;  if(do_lapl) lbuf.zeros(cart.size());
+  arma::mat hbuf;  if(do_hess) hbuf.zeros(cart.size(), 9);
+  arma::mat lgbuf; if(do_lgrad) lgbuf.zeros(cart.size(), 3);
 
   for(size_t iexp=0; iexp<c.size(); iexp++) {
     const double z_i = c[iexp].z;
@@ -667,16 +672,64 @@ void GaussianShell::eval_func_grad_lapl(double x, double y, double z,
 
       fbuf(icart) += xl * ym * zn * exp_i;
 
+      // Pre-compute the first / second derivatives along each axis
+      // once if any of grad / lapl / hess / lgrad needs them. The
+      // compiler will fold dead-code paths away.
+      const bool need_d1 = do_grad || do_hess || do_lgrad;
+      const bool need_d2 = do_lapl || do_hess || do_lgrad;
+      const bool need_d3 = do_lgrad;
+      const double d1x = need_d1 ? _der1(xr, l, z_i) : 0.0;
+      const double d1y = need_d1 ? _der1(yr, m, z_i) : 0.0;
+      const double d1z = need_d1 ? _der1(zr, n, z_i) : 0.0;
+      const double d2x = need_d2 ? _der2(xr, l, z_i) : 0.0;
+      const double d2y = need_d2 ? _der2(yr, m, z_i) : 0.0;
+      const double d2z = need_d2 ? _der2(zr, n, z_i) : 0.0;
+      const double d3x = need_d3 ? _der3(xr, l, z_i) : 0.0;
+      const double d3y = need_d3 ? _der3(yr, m, z_i) : 0.0;
+      const double d3z = need_d3 ? _der3(zr, n, z_i) : 0.0;
+
       if(do_grad) {
-        gbuf(icart, 0) += _der1(xr, l, z_i) * ym * zn * exp_i;
-        gbuf(icart, 1) += xl * _der1(yr, m, z_i) * zn * exp_i;
-        gbuf(icart, 2) += xl * ym * _der1(zr, n, z_i) * exp_i;
+        gbuf(icart, 0) += d1x * ym * zn * exp_i;
+        gbuf(icart, 1) += xl  * d1y * zn * exp_i;
+        gbuf(icart, 2) += xl  * ym * d1z * exp_i;
       }
 
       if(do_lapl) {
-        lbuf(icart) += (_der2(xr, l, z_i) * ym * zn
-                       + xl * _der2(yr, m, z_i) * zn
-                       + xl * ym * _der2(zr, n, z_i)) * exp_i;
+        lbuf(icart) += (d2x * ym * zn
+                       + xl * d2y * zn
+                       + xl * ym * d2z) * exp_i;
+      }
+
+      if(do_hess) {
+        // Diagonal entries
+        hbuf(icart, 0) += d2x * ym * zn * exp_i;     // d/dx^2
+        hbuf(icart, 4) += xl * d2y * zn * exp_i;     // d/dy^2
+        hbuf(icart, 8) += xl * ym * d2z * exp_i;     // d/dz^2
+        // Off-diagonals (each appears twice by symmetry)
+        const double dxy = d1x * d1y * zn  * exp_i;
+        hbuf(icart, 1) += dxy;
+        hbuf(icart, 3) += dxy;
+        const double dxz = d1x * ym  * d1z * exp_i;
+        hbuf(icart, 2) += dxz;
+        hbuf(icart, 6) += dxz;
+        const double dyz = xl  * d1y * d1z * exp_i;
+        hbuf(icart, 5) += dyz;
+        hbuf(icart, 7) += dyz;
+      }
+
+      if(do_lgrad) {
+        // d^3/dx^3, d^2/dy^2 d/dx, d^2/dz^2 d/dx
+        lgbuf(icart, 0) += (d3x * ym * zn
+                           + d1x * d2y * zn
+                           + d1x * ym * d2z) * exp_i;
+        // d^2/dx^2 d/dy, d^3/dy^3, d^2/dz^2 d/dy
+        lgbuf(icart, 1) += (d2x * d1y * zn
+                           + xl * d3y * zn
+                           + xl * d1y * d2z) * exp_i;
+        // d^2/dx^2 d/dz, d^2/dy^2 d/dz, d^3/dz^3
+        lgbuf(icart, 2) += (d2x * ym * d1z
+                           + xl * d2y * d1z
+                           + xl * ym * d3z) * exp_i;
       }
     }
   }
@@ -685,185 +738,42 @@ void GaussianShell::eval_func_grad_lapl(double x, double y, double z,
   for(size_t icart=0; icart<cart.size(); icart++) {
     const double rn = cart[icart].relnorm;
     fbuf(icart) *= rn;
-    if(do_grad) {
-      gbuf(icart, 0) *= rn;
-      gbuf(icart, 1) *= rn;
-      gbuf(icart, 2) *= rn;
-    }
-    if(do_lapl) lbuf(icart) *= rn;
+    if(do_grad)  for(int k=0;k<3;k++) gbuf(icart, k)  *= rn;
+    if(do_lapl)  lbuf(icart) *= rn;
+    if(do_hess)  for(int k=0;k<9;k++) hbuf(icart, k)  *= rn;
+    if(do_lgrad) for(int k=0;k<3;k++) lgbuf(icart, k) *= rn;
   }
 
   // Optionally project to spherical harmonics
   if(uselm) {
     fval = transmat * fbuf;
-    if(do_grad) gval = transmat * gbuf;
-    if(do_lapl) lval = transmat * lbuf;
+    if(do_grad)  gval  = transmat * gbuf;
+    if(do_lapl)  lval  = transmat * lbuf;
+    if(do_hess)  hval  = transmat * hbuf;
+    if(do_lgrad) lgval = transmat * lgbuf;
   } else {
     fval = std::move(fbuf);
-    if(do_grad) gval = std::move(gbuf);
-    if(do_lapl) lval = std::move(lbuf);
+    if(do_grad)  gval  = std::move(gbuf);
+    if(do_lapl)  lval  = std::move(lbuf);
+    if(do_hess)  hval  = std::move(hbuf);
+    if(do_lgrad) lgval = std::move(lgbuf);
   }
 }
 
 arma::mat GaussianShell::eval_hess(double x, double y, double z) const {
-  // Evaluate gradients of functions at (x,y,z)
-
-  // Compute coordinates relative to center
-  double xrel=x-cen.x;
-  double yrel=y-cen.y;
-  double zrel=z-cen.z;
-
-  double rrelsq=xrel*xrel+yrel*yrel+zrel*zrel;
-
-  // Power arrays, x^l, y^l, z^l
-  double xr[am+3], yr[am+3], zr[am+3];
-
-  xr[0]=1.0;
-  yr[0]=1.0;
-  zr[0]=1.0;
-
-  xr[1]=xrel;
-  yr[1]=yrel;
-  zr[1]=zrel;
-
-  for(int i=2;i<=am+2;i++) {
-    xr[i]=xr[i-1]*xrel;
-    yr[i]=yr[i-1]*yrel;
-    zr[i]=zr[i-1]*zrel;
-  }
-
-  // Gradient array, Ncart x 9
-  arma::mat ret(cart.size(),9);
-  ret.zeros();
-
-  // Helper variables
-  double expf, tmp;
-
-  // Loop over functions
-  for(size_t icart=0;icart<cart.size();icart++) {
-    // Get types
-    int l=cart[icart].l;
-    int m=cart[icart].m;
-    int n=cart[icart].n;
-
-    // Loop over exponential contraction
-    for(size_t iexp=0;iexp<c.size();iexp++) {
-      // Contracted exponent
-      expf=c[iexp].c*exp(-c[iexp].z*rrelsq);
-
-      // d/dx^2
-      ret(icart,0)+=_der2(xr,l,c[iexp].z)*yr[m]*zr[n]*expf;
-      // d/dy^2
-      ret(icart,4)+=xr[l]*_der2(yr,m,c[iexp].z)*zr[n]*expf;
-      // d/dz^2
-      ret(icart,8)+=xr[l]*yr[m]*_der2(zr,n,c[iexp].z)*expf;
-
-      // dxdy = dydx
-      tmp=_der1(xr,l,c[iexp].z)*_der1(yr,m,c[iexp].z)*zr[n]*expf;
-      ret(icart,1)+=tmp;
-      ret(icart,3)+=tmp;
-
-      // dxdz = dzdx
-      tmp=_der1(xr,l,c[iexp].z)*yr[m]*_der1(zr,n,c[iexp].z)*expf;
-      ret(icart,2)+=tmp;
-      ret(icart,6)+=tmp;
-
-      // dydz = dzdy
-      tmp=xr[l]*_der1(yr,m,c[iexp].z)*_der1(zr,n,c[iexp].z)*expf;
-      ret(icart,5)+=tmp;
-      ret(icart,7)+=tmp;
-    }
-
-    // Plug in normalization constant
-    for(int ii=0;ii<9;ii++)
-      ret(icart,ii)*=cart[icart].relnorm;
-  }
-
-  if(uselm)
-    return transmat*ret;
-  else
-    return ret;
+  arma::vec fval, lval;
+  arma::mat gval, hval, lgval;
+  eval_bf_derivs(x, y, z, fval, gval, lval, hval, lgval,
+                 false, false, true, false);
+  return hval;
 }
 
 arma::mat GaussianShell::eval_laplgrad(double x, double y, double z) const {
-  // Evaluate laplacian of gradients of functions at (x,y,z)
-
-  // Compute coordinates relative to center
-  double xrel=x-cen.x;
-  double yrel=y-cen.y;
-  double zrel=z-cen.z;
-
-  double rrelsq=xrel*xrel+yrel*yrel+zrel*zrel;
-
-  // Power arrays, x^l, y^l, z^l
-  double xr[am+4], yr[am+4], zr[am+4];
-
-  xr[0]=1.0;
-  yr[0]=1.0;
-  zr[0]=1.0;
-
-  xr[1]=xrel;
-  yr[1]=yrel;
-  zr[1]=zrel;
-
-  for(int i=2;i<=am+3;i++) {
-    xr[i]=xr[i-1]*xrel;
-    yr[i]=yr[i-1]*yrel;
-    zr[i]=zr[i-1]*zrel;
-  }
-
-  // Returned array, N_cart x 3
-  arma::mat ret(cart.size(),3);
-  ret.zeros();
-
-  // Helper variables
-  double expf;
-
-  // Loop over functions
-  for(size_t icart=0;icart<cart.size();icart++) {
-    // Get types
-    int l=cart[icart].l;
-    int m=cart[icart].m;
-    int n=cart[icart].n;
-
-    // Loop over exponential contraction
-    for(size_t iexp=0;iexp<c.size();iexp++) {
-      // Contracted exponent
-      expf=c[iexp].c*exp(-c[iexp].z*rrelsq);
-
-      // dx^3
-      ret(icart,0)+=_der3(xr,l,c[iexp].z)*yr[m]*zr[n]*expf;
-      // dy^2 dx
-      ret(icart,0)+=_der1(xr,l,c[iexp].z)*_der2(yr,m,c[iexp].z)*zr[n]*expf;
-      // dz^2 dx
-      ret(icart,0)+=_der1(xr,l,c[iexp].z)*yr[m]*_der2(zr,n,c[iexp].z)*expf;
-
-      // dx^2 dy
-      ret(icart,1)+=_der2(xr,l,c[iexp].z)*_der1(yr,m,c[iexp].z)*zr[n]*expf;
-      // dy^3
-      ret(icart,1)+=xr[l]*_der3(yr,m,c[iexp].z)*zr[n]*expf;
-      // dz^2 dy
-      ret(icart,1)+=xr[l]*_der1(yr,m,c[iexp].z)*_der2(zr,n,c[iexp].z)*expf;
-
-      // dx^2 dz
-      ret(icart,2)+=_der2(xr,l,c[iexp].z)*yr[m]*_der1(zr,n,c[iexp].z)*expf;
-      // dy^2 dz
-      ret(icart,2)+=xr[l]*_der2(yr,m,c[iexp].z)*_der1(zr,n,c[iexp].z)*expf;
-      // dz^3
-      ret(icart,2)+=xr[l]*yr[m]*_der3(zr,n,c[iexp].z)*expf;
-    }
-
-    // Plug in normalization constant
-    ret(icart,0)*=cart[icart].relnorm;
-    ret(icart,1)*=cart[icart].relnorm;
-    ret(icart,2)*=cart[icart].relnorm;
-  }
-
-  if(uselm)
-    // Need to transform into spherical harmonics
-    return transmat*ret;
-  else
-    return ret;
+  arma::vec fval, lval;
+  arma::mat gval, hval, lgval;
+  eval_bf_derivs(x, y, z, fval, gval, lval, hval, lgval,
+                 false, false, false, true);
+  return lgval;
 }
 
 // Calculate overlaps between basis functions
@@ -2078,12 +1988,16 @@ arma::mat BasisSet::eval_laplgrad(size_t ish, double x, double y, double z) cons
   return shells[ish].eval_laplgrad(x,y,z);
 }
 
-void BasisSet::eval_func_grad_lapl(size_t ish, double x, double y, double z,
-                                   arma::vec & fval,
-                                   arma::mat & gval,
-                                   arma::vec & lval,
-                                   bool do_grad, bool do_lapl) const {
-  shells[ish].eval_func_grad_lapl(x, y, z, fval, gval, lval, do_grad, do_lapl);
+void BasisSet::eval_bf_derivs(size_t ish, double x, double y, double z,
+                              arma::vec & fval,
+                              arma::mat & gval,
+                              arma::vec & lval,
+                              arma::mat & hval,
+                              arma::mat & lgval,
+                              bool do_grad, bool do_lapl,
+                              bool do_hess, bool do_lgrad) const {
+  shells[ish].eval_bf_derivs(x, y, z, fval, gval, lval, hval, lgval,
+                             do_grad, do_lapl, do_hess, do_lgrad);
 }
 
 void BasisSet::convert_contractions() {

--- a/src/basis.h
+++ b/src/basis.h
@@ -426,6 +426,15 @@ class BasisSet {
   arma::mat eval_hess(size_t ish, double x, double y, double z) const;
   /// Evaluate gradient of laplacian of shell ish at (x,y,z)
   arma::mat eval_laplgrad(size_t ish, double x, double y, double z) const;
+  /// Evaluate functions / gradients / laplacian of shell ish at
+  /// (x,y,z) in one pass, sharing the contracted-exponential
+  /// evaluation. fval is filled always, gval iff do_grad, lval iff
+  /// do_lapl.
+  void eval_func_grad_lapl(size_t ish, double x, double y, double z,
+                           arma::vec & fval,
+                           arma::mat & gval,
+                           arma::vec & lval,
+                           bool do_grad, bool do_lapl) const;
 
   /// Print out basis set
   void print(bool verbose=false) const;
@@ -641,6 +650,15 @@ class GaussianShell {
   arma::mat eval_hess(double x, double y, double z) const;
   /// Evaluate gradient of laplacian at (x,y,z)
   arma::mat eval_laplgrad(double x, double y, double z) const;
+  /// Evaluate functions, gradients and laplacian at (x,y,z) in one
+  /// pass, sharing the contracted-exponential evaluation and the
+  /// power tables. fval is always filled; gval is filled iff do_grad,
+  /// lval iff do_lapl.
+  void eval_func_grad_lapl(double x, double y, double z,
+                           arma::vec & fval,
+                           arma::mat & gval,
+                           arma::vec & lval,
+                           bool do_grad, bool do_lapl) const;
 
   /// Calculate block overlap matrix between shells
   arma::mat overlap(const GaussianShell & rhs) const;

--- a/src/basis.h
+++ b/src/basis.h
@@ -426,15 +426,16 @@ class BasisSet {
   arma::mat eval_hess(size_t ish, double x, double y, double z) const;
   /// Evaluate gradient of laplacian of shell ish at (x,y,z)
   arma::mat eval_laplgrad(size_t ish, double x, double y, double z) const;
-  /// Evaluate functions / gradients / laplacian of shell ish at
-  /// (x,y,z) in one pass, sharing the contracted-exponential
-  /// evaluation. fval is filled always, gval iff do_grad, lval iff
-  /// do_lapl.
-  void eval_func_grad_lapl(size_t ish, double x, double y, double z,
-                           arma::vec & fval,
-                           arma::mat & gval,
-                           arma::vec & lval,
-                           bool do_grad, bool do_lapl) const;
+  /// Evaluate functions / gradient / laplacian / Hessian / gradient
+  /// of laplacian for shell ish at (x,y,z) in one pass.
+  void eval_bf_derivs(size_t ish, double x, double y, double z,
+                      arma::vec & fval,
+                      arma::mat & gval,
+                      arma::vec & lval,
+                      arma::mat & hval,
+                      arma::mat & lgval,
+                      bool do_grad, bool do_lapl,
+                      bool do_hess, bool do_lgrad) const;
 
   /// Print out basis set
   void print(bool verbose=false) const;
@@ -650,15 +651,21 @@ class GaussianShell {
   arma::mat eval_hess(double x, double y, double z) const;
   /// Evaluate gradient of laplacian at (x,y,z)
   arma::mat eval_laplgrad(double x, double y, double z) const;
-  /// Evaluate functions, gradients and laplacian at (x,y,z) in one
-  /// pass, sharing the contracted-exponential evaluation and the
-  /// power tables. fval is always filled; gval is filled iff do_grad,
-  /// lval iff do_lapl.
-  void eval_func_grad_lapl(double x, double y, double z,
-                           arma::vec & fval,
-                           arma::mat & gval,
-                           arma::vec & lval,
-                           bool do_grad, bool do_lapl) const;
+  /// Evaluate functions / gradient / laplacian / Hessian / gradient
+  /// of laplacian at (x,y,z) in one pass, sharing the
+  /// contracted-exponential evaluation and the power tables across
+  /// whichever outputs the caller has asked for. fval is always
+  /// filled; the others iff their corresponding do_* flag is set.
+  /// hval is laid out (Ncart, 9) with row-major (3x3) entries; lgval
+  /// is (Ncart, 3).
+  void eval_bf_derivs(double x, double y, double z,
+                      arma::vec & fval,
+                      arma::mat & gval,
+                      arma::vec & lval,
+                      arma::mat & hval,
+                      arma::mat & lgval,
+                      bool do_grad, bool do_lapl,
+                      bool do_hess, bool do_lgrad) const;
 
   /// Calculate block overlap matrix between shells
   arma::mat overlap(const GaussianShell & rhs) const;

--- a/src/dftgrid.cpp
+++ b/src/dftgrid.cpp
@@ -3095,20 +3095,28 @@ void AngularGrid::compute_bf() {
   }
   if(do_lapl)
     bf_lapl.zeros(bf_ind.n_elem,grid.size());
+  if(do_hess)
+    bf_hess.zeros(9*bf_ind.n_elem,grid.size());
+  if(do_lgrad) {
+    bf_lx.zeros(bf_ind.n_elem,grid.size());
+    bf_ly.zeros(bf_ind.n_elem,grid.size());
+    bf_lz.zeros(bf_ind.n_elem,grid.size());
+  }
 
-  // One pass over (ip, ish) that fuses the func / grad / lapl
-  // evaluations: the fused shell-level routine reuses the contracted
-  // exponentials and the power tables across all three outputs, so
-  // we save (do_grad ? 1 : 0) + (do_lapl ? 1 : 0) extra exp / power
-  // builds per shell-point.
+  // One pass over (ip, ish) that fuses the func / grad / lapl / hess /
+  // lgrad evaluations: the fused shell-level routine reuses the
+  // contracted exponentials and the power tables across all requested
+  // outputs, saving the redundant exp / power builds per shell-point
+  // that the separate eval_* siblings would have performed.
   arma::vec fval, lval;
-  arma::mat gval;
+  arma::mat gval, hval, lgval;
   for(size_t ip=0;ip<grid.size();ip++) {
     ioff=0;
     for(size_t ish=0;ish<shells.size();ish++) {
-      basp->eval_func_grad_lapl(shells[ish],
-                                grid[ip].r.x, grid[ip].r.y, grid[ip].r.z,
-                                fval, gval, lval, do_grad, do_lapl);
+      basp->eval_bf_derivs(shells[ish],
+                           grid[ip].r.x, grid[ip].r.y, grid[ip].r.z,
+                           fval, gval, lval, hval, lgval,
+                           do_grad, do_lapl, do_hess, do_lgrad);
       const size_t Nf = fval.n_elem;
       bf.submat(ioff, ip, ioff+Nf-1, ip) = fval;
       if(do_grad) {
@@ -3118,44 +3126,19 @@ void AngularGrid::compute_bf() {
       }
       if(do_lapl)
         bf_lapl.submat(ioff, ip, ioff+Nf-1, ip) = lval;
+      if(do_hess) {
+        // hval is (Nf, 9) row-major (3x3); bf_hess is (9*Nbf, npts)
+        // packed as (cart, c) -> 9*ioff + 9*f + c.
+        for(size_t f=0;f<Nf;f++)
+          for(int c=0;c<9;c++)
+            bf_hess(9*ioff + 9*f + c, ip) = hval(f, c);
+      }
+      if(do_lgrad) {
+        bf_lx.submat(ioff, ip, ioff+Nf-1, ip) = lgval.col(0);
+        bf_ly.submat(ioff, ip, ioff+Nf-1, ip) = lgval.col(1);
+        bf_lz.submat(ioff, ip, ioff+Nf-1, ip) = lgval.col(2);
+      }
       ioff += Nf;
-    }
-  }
-
-  if(do_hess) {
-    bf_hess.zeros(9*bf_ind.n_elem,grid.size());
-    // Loop over points
-    for(size_t ip=0;ip<grid.size();ip++) {
-      // Loop over shells. Offset
-      ioff=0;
-      for(size_t ish=0;ish<shells.size();ish++) {
-	// eval_hess returns Nbf x 9 matrix, transpose to 9 x Nbf
-	arma::mat hval=arma::trans(basp->eval_hess(shells[ish],grid[ip].r.x,grid[ip].r.y,grid[ip].r.z));
-	// Store values
-	for(int c=0;c<9;c++)
-	  for(size_t f=0;f<hval.n_cols;f++) {
-	    bf_hess(ioff + 9*f + c,ip)=hval(c,f);
-	  }
-	ioff+=hval.n_elem;
-      }
-    }
-  }
-
-  if(do_lgrad) {
-    bf_lx.zeros(bf_ind.n_elem,grid.size());
-    bf_ly.zeros(bf_ind.n_elem,grid.size());
-    bf_lz.zeros(bf_ind.n_elem,grid.size());
-    // Loop over points
-    for(size_t ip=0;ip<grid.size();ip++) {
-      // Loop over shells. Offset
-      ioff=0;
-      for(size_t ish=0;ish<shells.size();ish++) {
-	arma::mat lgval=basp->eval_laplgrad(shells[ish],grid[ip].r.x,grid[ip].r.y,grid[ip].r.z);
-	bf_lx.submat(ioff,ip,ioff+lgval.n_rows-1,ip)=lgval.col(0);
-	bf_ly.submat(ioff,ip,ioff+lgval.n_rows-1,ip)=lgval.col(1);
-	bf_lz.submat(ioff,ip,ioff+lgval.n_rows-1,ip)=lgval.col(2);
-	ioff+=lgval.n_rows;
-      }
     }
   }
 }

--- a/src/dftgrid.cpp
+++ b/src/dftgrid.cpp
@@ -3088,46 +3088,37 @@ void AngularGrid::compute_bf() {
   info.nfunc=Nbf*grid.size();
 
   bf.zeros(bf_ind.n_elem,grid.size());
-  // Loop over points
-  for(size_t ip=0;ip<grid.size();ip++) {
-    // Loop over shells. Offset
-    ioff=0;
-    for(size_t ish=0;ish<shells.size();ish++) {
-      arma::vec fval=basp->eval_func(shells[ish],grid[ip].r.x,grid[ip].r.y,grid[ip].r.z);
-      bf.submat(ioff,ip,ioff+fval.n_elem-1,ip)=fval;
-      ioff+=fval.n_elem;
-    }
-  }
-
   if(do_grad) {
     bf_x.zeros(bf_ind.n_elem,grid.size());
     bf_y.zeros(bf_ind.n_elem,grid.size());
     bf_z.zeros(bf_ind.n_elem,grid.size());
-    // Loop over points
-    for(size_t ip=0;ip<grid.size();ip++) {
-      // Loop over shells. Offset
-      ioff=0;
-      for(size_t ish=0;ish<shells.size();ish++) {
-	arma::mat gval=basp->eval_grad(shells[ish],grid[ip].r.x,grid[ip].r.y,grid[ip].r.z);
-	bf_x.submat(ioff,ip,ioff+gval.n_rows-1,ip)=gval.col(0);
-	bf_y.submat(ioff,ip,ioff+gval.n_rows-1,ip)=gval.col(1);
-	bf_z.submat(ioff,ip,ioff+gval.n_rows-1,ip)=gval.col(2);
-	ioff+=gval.n_rows;
-      }
-    }
   }
-
-  if(do_lapl) {
+  if(do_lapl)
     bf_lapl.zeros(bf_ind.n_elem,grid.size());
-    // Loop over points
-    for(size_t ip=0;ip<grid.size();ip++) {
-      // Loop over shells. Offset
-      ioff=0;
-      for(size_t ish=0;ish<shells.size();ish++) {
-	arma::vec lval=basp->eval_lapl(shells[ish],grid[ip].r.x,grid[ip].r.y,grid[ip].r.z);
-	bf_lapl.submat(ioff,ip,ioff+lval.n_elem-1,ip)=lval;
-	ioff+=lval.n_elem;
+
+  // One pass over (ip, ish) that fuses the func / grad / lapl
+  // evaluations: the fused shell-level routine reuses the contracted
+  // exponentials and the power tables across all three outputs, so
+  // we save (do_grad ? 1 : 0) + (do_lapl ? 1 : 0) extra exp / power
+  // builds per shell-point.
+  arma::vec fval, lval;
+  arma::mat gval;
+  for(size_t ip=0;ip<grid.size();ip++) {
+    ioff=0;
+    for(size_t ish=0;ish<shells.size();ish++) {
+      basp->eval_func_grad_lapl(shells[ish],
+                                grid[ip].r.x, grid[ip].r.y, grid[ip].r.z,
+                                fval, gval, lval, do_grad, do_lapl);
+      const size_t Nf = fval.n_elem;
+      bf.submat(ioff, ip, ioff+Nf-1, ip) = fval;
+      if(do_grad) {
+        bf_x.submat(ioff, ip, ioff+Nf-1, ip) = gval.col(0);
+        bf_y.submat(ioff, ip, ioff+Nf-1, ip) = gval.col(1);
+        bf_z.submat(ioff, ip, ioff+Nf-1, ip) = gval.col(2);
       }
+      if(do_lapl)
+        bf_lapl.submat(ioff, ip, ioff+Nf-1, ip) = lval;
+      ioff += Nf;
     }
   }
 


### PR DESCRIPTION
## Summary
- Extends the fused shell-level evaluator from #109 (func/grad/lapl) to also fold in the Hessian and laplacian-of-gradient paths under one routine, `eval_bf_derivs`. The same xrel/yrel/zrel, power tables, and contracted `exp(-z·r²)` terms are now reused across all five outputs.
- Inner-loop `_der1` / `_der2` / `_der3` along each axis are computed at most once per `(iexp, icart)` when any active output needs them, eliminating the redundant recomputation that the standalone `eval_hess` / `eval_laplgrad` performed.
- `eval_grad` / `eval_lapl` / `eval_hess` / `eval_laplgrad` are reduced to thin wrappers around `eval_bf_derivs` with the appropriate flag set. `eval_func` is intentionally kept specialised because its sum-then-multiply pattern (N_exp + N_cart muls) is faster than fused (N_exp × N_cart) for func-only callers.
- `compute_bf` in `dftgrid.cpp` now drives the func / grad / lapl / hess / lgrad tables in a single `(ip, ish)` pass instead of four separate per-output passes.

## Test plan
- [x] Full `ctest -j8` 176/176 passing