### PR TITLE
Forces: fill scr screening matrix on Cholesky / DF SCF paths

### DIFF
--- a/src/eriscreen.cpp
+++ b/src/eriscreen.cpp
@@ -57,6 +57,7 @@ ERIscreen::ERIscreen() {
   alpha=1.0;
   beta=0.0;
   basp=NULL;
+  Nbf=0;
 }
 
 ERIscreen::~ERIscreen() {

--- a/src/scf-force.cpp.in
+++ b/src/scf-force.cpp.in
@@ -86,7 +86,10 @@ arma::vec SCF::force_ROHF(uscf_t & sol, int Nel_alpha, int Nel_beta, double tol)
       // available).
       fx_full=chol.forceJ(*basisp, sol.P);
     } else {
-      if(!direct)
+      // scr is filled in scf-base.cpp only on the four-index path
+      // (direct or table). On the Cholesky / DF paths it stays
+      // unfilled; ensure it's ready before any forceJ/forceJK call.
+      if(scr.get_N() != basisp->get_Nbf())
 	scr.fill(basisp,intthr,verbose);
 
       fx_full=scr.forceJ(sol.P,tol);
@@ -94,7 +97,7 @@ arma::vec SCF::force_ROHF(uscf_t & sol, int Nel_alpha, int Nel_beta, double tol)
   } else {
 #endif
 
-    if(!direct)
+    if(scr.get_N() != basisp->get_Nbf())
       scr.fill(basisp,intthr,verbose);
 
 #ifdef RESTRICTED


### PR DESCRIPTION
## Summary

- ERIscreen ctor now initialises Nbf=0 (was indeterminate).
- scf-force.cpp.in: when starting the gradient build, fill scr on demand whenever its Nbf doesn't match the orbital basis -- covers the Cholesky and DF SCF paths where scr is never filled at the scf-base.cpp setup site. Previously this fell through and threw `Error in ERIscreen: Nbf = <garbage>, P.n_rows = N, P.n_cols = N` after the first SCF in any HF / Cholesky geom-opt.

## Test plan

- [x] Full ctest 178/178 pass
- [x] erkale_geom on H2O / cc-pVDZ:
  - HF + Cholesky=true (default) + Direct=true: fmax 1.594e-2, frms 1.392e-2
  - HF + Cholesky=true + Direct=false: same
  - HF + Cholesky=false + Direct=true: same (regression-free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)