### PR TITLE
ERIWorker: per-position cache for shellpair precursors

### DIFF
--- a/src/eriworker.cpp
+++ b/src/eriworker.cpp
@@ -28,6 +28,10 @@ IntegralWorker::IntegralWorker() {
   input=&arrone;
   output=&arrtwo;
 
+  // Empty precursor cache.
+  cached_is_[0]=cached_is_[1]=nullptr;
+  cached_js_[0]=cached_js_[1]=nullptr;
+
 #ifndef BOYSNOINTERP
   // Maximum value of m for Boys function is
 #ifdef _OPENMP
@@ -102,8 +106,10 @@ dERIWorker::~dERIWorker() {
 }
 
 void ERIWorker::compute_cartesian(const GaussianShell *is, const GaussianShell *js, const GaussianShell *ks, const GaussianShell *ls) {
-  eri_precursor_t ip=compute_precursor(is,js);
-  eri_precursor_t jp=compute_precursor(ks,ls);
+  // Per-worker precursor cache: slot 0 for the bra pair, slot 1 for
+  // the ket pair, so the two refs don't alias.
+  const eri_precursor_t & ip=compute_precursor(is,js,0);
+  const eri_precursor_t & jp=compute_precursor(ks,ls,1);
 
   // Compute shell of cartesian ERIs using libint
 
@@ -196,8 +202,8 @@ void ERIWorker::compute_cartesian(const GaussianShell *is, const GaussianShell *
 }
 
 void dERIWorker::compute_cartesian() {
-  eri_precursor_t ip=compute_precursor(is,js);
-  eri_precursor_t jp=compute_precursor(ks,ls);
+  const eri_precursor_t & ip=compute_precursor(is,js,0);
+  const eri_precursor_t & jp=compute_precursor(ks,ls,1);
 
   // Compute shell of cartesian ERI derivatives using libderiv
 
@@ -888,10 +894,18 @@ std::vector<double> dERIWorker::get_debug(int idx) {
   return *input;
 }
 
-eri_precursor_t IntegralWorker::compute_precursor(const GaussianShell *is, const GaussianShell *js) {
-  // Returned precursor
-  eri_precursor_t r;
+const eri_precursor_t & IntegralWorker::compute_precursor(const GaussianShell *is, const GaussianShell *js, int slot) {
+  if(cached_is_[slot]==is && cached_js_[slot]==js)
+    return cached_precursor_[slot];
+  // Miss: refill the slot in place. set_size in fill_precursor's
+  // zeros() calls reuses the existing allocation when sizes match.
+  cached_is_[slot]=is;
+  cached_js_[slot]=js;
+  fill_precursor(is, js, cached_precursor_[slot]);
+  return cached_precursor_[slot];
+}
 
+void IntegralWorker::fill_precursor(const GaussianShell *is, const GaussianShell *js, eri_precursor_t & r) {
   // Initialize arrays
   r.AB.zeros(3);
 
@@ -944,8 +958,6 @@ eri_precursor_t IntegralWorker::compute_precursor(const GaussianShell *is, const
   for(size_t i=0;i<r.ic.size();i++)
     for(size_t j=0;j<r.jc.size();j++)
       r.S(i,j)=r.ic[i].c*r.jc[j].c*(M_PI/r.zeta(i,j))*sqrt(M_PI/r.zeta(i,j))*exp(-r.ic[i].z*r.jc[j].z/r.zeta(i,j)*rabsq);
-
-  return r;
 }
 
 void IntegralWorker::compute_G(double rho, double T, int nmax) {

--- a/src/eriworker.h
+++ b/src/eriworker.h
@@ -64,6 +64,20 @@ class IntegralWorker {
   /// Integral kernel (i.e. Boys' function for Coulomb integrals)
   arma::vec Gn;
 
+  /// Per-position shellpair-precursor cache, keyed by shell pointer
+  /// pair. Each compute_precursor call site identifies itself with a
+  /// slot index (0 for the bra "ij" pair, 1 for the ket "kl" pair);
+  /// the slots are independent so a hit in one never invalidates the
+  /// other. Within a 4-index J/K build the outer (is,js) pair
+  /// repeats for many (ks,ls) inner iterations -- slot 0 stays
+  /// perfectly warm and slot 1 churns harmlessly. One worker per
+  /// thread under OpenMP, so no locking. Geometry steps rebuild the
+  /// basis and the workers, so stale shell pointers don't survive
+  /// across iterations.
+  const GaussianShell* cached_is_[2];
+  const GaussianShell* cached_js_[2];
+  eri_precursor_t cached_precursor_[2];
+
   /// Compute the integral kernel
   virtual void compute_G(double rho, double T, int nmax);
 
@@ -81,8 +95,15 @@ class IntegralWorker {
   /// Do spherical transform with respect to fourth index
   void transform_l(int am, size_t Ni, size_t Nj, size_t Nk);
 
-  /// Compute precursor
-  eri_precursor_t compute_precursor(const GaussianShell *is, const GaussianShell *js);
+  /// Get precursor for a shell pair, consulting the per-worker cache.
+  /// `slot` (0 or 1) identifies the cache bucket: callers must use a
+  /// distinct slot for each precursor that needs to coexist in one
+  /// computation (slot 0 for the bra ij pair, slot 1 for the ket kl
+  /// pair). The returned reference is valid until the next
+  /// compute_precursor() call on the *same* slot.
+  const eri_precursor_t & compute_precursor(const GaussianShell *is, const GaussianShell *js, int slot);
+  /// Fill an eri_precursor_t for a shell pair (uncached helper).
+  void fill_precursor(const GaussianShell *is, const GaussianShell *js, eri_precursor_t & r);
 
  public:
   IntegralWorker();


### PR DESCRIPTION
## Summary

In a 4-index J/K build the outer (is,js) shellpair loop sweeps each shellpair once but `compute_precursor(is,js)` is rebuilt ip+1 times -- once per inner (ks,ls) iteration. The function fills 5 arma::mat/cube arrays plus exponential / sqrt work; doing it Nshellpair² times is wasted.

Add a small per-worker cache keyed by shell pointer pair, with one slot per call position (slot 0 for the bra ij pair, slot 1 for the ket kl pair) so the two precursor references returned in a single `compute_cartesian()` don't alias the same slot. Within an outer iteration slot 0 is a perfect hit; slot 1 churns harmlessly. One ERIWorker per thread under OpenMP -- no locking. Geometry steps rebuild the basis and the workers, so stale shell pointers don't survive.

API change: `IntegralWorker::compute_precursor` now returns `const eri_precursor_t &` and takes a slot index. The two call sites in `compute_cartesian` (ERIWorker and dERIWorker) pass slots 0/1.

## Benchmark

Benzene (12 atoms) HF / cc-pVDZ direct mode, 4 OpenMP threads, 3 runs each:

| | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| master | 166.1 s | 161.9 s | 158.6 s | 162.2 s |
| this PR | 154.8 s | 149.5 s | 147.8 s | 150.7 s |

≈ 7% wall-clock speedup.

## Test plan

- [x] Full ctest 178/178 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)