### PR TITLE
Replace get_eripairs(out Q, out M) with ScreeningData factory

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -1411,48 +1411,43 @@ std::vector<shellpair_t> BasisSet::get_unique_shellpairs() const {
   return shellpairs;
 }
 
-std::vector<eripair_t> BasisSet::get_eripairs(arma::mat & Q, arma::mat & M, double tol, double omega, double alpha, double beta, bool verbose) const {
+ScreeningData BasisSet::compute_screening(double tol, double omega, double alpha, double beta, bool verbose) const {
+  ScreeningData s;
+
   // Get the screening matrices
-  eri_screening(Q,M,omega,alpha,beta);
+  eri_screening(s.Q,s.M,omega,alpha,beta);
 
   // Fill out list
-  std::vector<eripair_t> list(shellpairs.size());
+  s.shpairs.resize(shellpairs.size());
   for(size_t i=0;i<shellpairs.size();i++) {
-    list[i].is=shellpairs[i].is;
-    list[i].i0=shells[shellpairs[i].is].get_first_ind();
-    list[i].Ni=shells[shellpairs[i].is].get_Nbf();
+    s.shpairs[i].is=shellpairs[i].is;
+    s.shpairs[i].i0=shells[shellpairs[i].is].get_first_ind();
+    s.shpairs[i].Ni=shells[shellpairs[i].is].get_Nbf();
 
-    list[i].js=shellpairs[i].js;
-    list[i].j0=shells[shellpairs[i].js].get_first_ind();
-    list[i].Nj=shells[shellpairs[i].js].get_Nbf();
+    s.shpairs[i].js=shellpairs[i].js;
+    s.shpairs[i].j0=shells[shellpairs[i].js].get_first_ind();
+    s.shpairs[i].Nj=shells[shellpairs[i].js].get_Nbf();
 
-    list[i].eri=Q(list[i].is,list[i].js);
+    s.shpairs[i].eri=s.Q(s.shpairs[i].is,s.shpairs[i].js);
   }
   // and sort it
-  std::stable_sort(list.begin(),list.end());
+  std::stable_sort(s.shpairs.begin(),s.shpairs.end());
 
   // Find out which pairs are negligible.
-  size_t ulimit=list.size()-1;
+  size_t ulimit=s.shpairs.size()-1;
   // An integral (ij|kl) <= sqrt( (ij|ij) (kl|kl) ). Since the
   // integrals are in decreasing order, the integral threshold is
-  double thr=tol/list[0].eri;
-  while(list[ulimit].eri < thr)
+  double thr=tol/s.shpairs[0].eri;
+  while(s.shpairs[ulimit].eri < thr)
     ulimit--;
-  if(ulimit<list.size())
-    list.resize(ulimit+1);
+  if(ulimit<s.shpairs.size())
+    s.shpairs.resize(ulimit+1);
 
   (void) verbose;
   //if(verbose)
-  // printf("%u shell pairs out of %u are significant.\n",(unsigned int) list.size(),(unsigned int) shellpairs.size());
+  // printf("%u shell pairs out of %u are significant.\n",(unsigned int) s.shpairs.size(),(unsigned int) shellpairs.size());
 
-  /*
-    FILE *out=fopen("screen.dat","w");
-    for(size_t i=0;i<list.size();i++)
-    fprintf(out,"%4i %4i %e\n",(int) list[i].is, (int) list[i].js, list[i].eri);
-    fclose(out);
-  */
-
-  return list;
+  return s;
 }
 
 bool operator<(const eripair_t & lhs, const eripair_t & rhs) {
@@ -2397,8 +2392,9 @@ arma::mat BasisSet::sap_potential(const BasisSetLibrary & sapfit) const {
   double omega=0.0;
   double alpha=1.0;
   double beta=0.0;
-  arma::mat Q, M;
-  std::vector<eripair_t> shpairs=get_eripairs(Q,M,intthr,omega,alpha,beta,false);
+  ScreeningData scr=compute_screening(intthr,omega,alpha,beta,false);
+  const arma::mat & Q = scr.Q;
+  const std::vector<eripair_t> & shpairs = scr.shpairs;
   // and nuclei
   std::vector<nucleus_t> nuclei=get_nuclei();
   if(verbose)

--- a/src/basis.h
+++ b/src/basis.h
@@ -128,6 +128,22 @@ typedef struct {
 /// Comparison operator
 bool operator<(const eripair_t & lhs, const eripair_t & rhs);
 
+/// Bundle of Schwarz screening data for a basis: the shell-shell
+/// (uv|uv)^1/2 matrix Q, the distance estimate M (a |R_uv - R_ls|
+/// upper bound on (uv|ls) once a few prefactors are folded in), and
+/// the value-sorted list of significant shell pairs. Constructed
+/// once per (basis, range-separation, threshold) tuple via
+/// BasisSet::compute_screening; replaces the get_eripairs(out Q,
+/// out M) factory whose three outputs were always stored together.
+struct ScreeningData {
+  /// Shell-pair Schwarz matrix, Q(is,js) = sqrt((is js | is js)).
+  arma::mat Q;
+  /// Distance estimate matrix, M(is,js) -- upper bound prefactor.
+  arma::mat M;
+  /// Shell pairs sorted by value, truncated to those above threshold.
+  std::vector<eripair_t> shpairs;
+};
+
 // Forward declaration
 class BasisSetLibrary;
 class ElementBasisSet;
@@ -293,8 +309,11 @@ class BasisSet {
   /// Get list of unique shell pairs
   std::vector<shellpair_t> get_unique_shellpairs() const;
 
-  /// Get list of ERI pairs
-  std::vector<eripair_t> get_eripairs(arma::mat & Q, arma::mat & M, double thr, double omega=0.0, double alpha=1.0, double beta=0.0, bool verbose=false) const;
+  /// Build ScreeningData: Schwarz Q, distance estimate M, and a
+  /// value-sorted, threshold-truncated shell-pair list. Single
+  /// factory replacing the (Q, M, shpairs) triple that every J/K
+  /// path used to own as three separate fields.
+  ScreeningData compute_screening(double thr, double omega=0.0, double alpha=1.0, double beta=0.0, bool verbose=false) const;
 
   /// Convert contractions from normalized primitives to unnormalized primitives
   void convert_contractions();

--- a/src/contrib/hneoci.cpp
+++ b/src/contrib/hneoci.cpp
@@ -252,12 +252,15 @@ int main_guarded(int argc, char **argv) {
   std::vector<GaussianShell> pshells=pbasis.get_shells();
 
   // Compute shell pairs
-  arma::mat Qe, Qp, M;
   double omega=0.0;
   double alpha=1.0;
   double beta=0.0;
-  auto epairs=basis.get_eripairs(Qe,M,intthr,omega,alpha,beta,verbose);
-  auto ppairs=pbasis.get_eripairs(Qp,M,intthr,omega,alpha,beta,verbose);
+  ScreeningData e_scr=basis.compute_screening(intthr,omega,alpha,beta,verbose);
+  ScreeningData p_scr=pbasis.compute_screening(intthr,omega,alpha,beta,verbose);
+  const arma::mat & Qe = e_scr.Q;
+  const arma::mat & Qp = p_scr.Q;
+  const std::vector<eripair_t> & epairs = e_scr.shpairs;
+  const std::vector<eripair_t> & ppairs = p_scr.shpairs;
 
   int max_am = std::max(basis.get_max_am(), pbasis.get_max_am());
   int max_Ncontr = std::max(basis.get_max_Ncontr(), pbasis.get_max_Ncontr());

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -353,11 +353,14 @@ int main_guarded(int argc, char **argv) {
     std::vector<GaussianShell> tshells=target_basis.get_shells();
 
     // Get shellpairs
-    arma::mat Qs, Qt, Ms, Mt;
     double shtol=settings.get_double("IntegralThresh");
     bool verbose=false;
-    auto spairs=source_basis.get_eripairs(Qs,Ms,shtol,omega,alpha,beta,verbose);
-    auto tpairs=target_basis.get_eripairs(Qt,Mt,shtol,omega,alpha,beta,verbose);
+    ScreeningData s_scr = source_basis.compute_screening(shtol,omega,alpha,beta,verbose);
+    ScreeningData t_scr = target_basis.compute_screening(shtol,omega,alpha,beta,verbose);
+    const arma::mat & Qs = s_scr.Q;
+    const arma::mat & Qt = t_scr.Q;
+    const std::vector<eripair_t> & spairs = s_scr.shpairs;
+    const std::vector<eripair_t> & tpairs = t_scr.shpairs;
 
     // Sanity check
     if(source_density.n_rows != source_basis.get_Nbf() or source_density.n_cols != source_basis.get_Nbf())

--- a/src/contrib/neosp.cpp
+++ b/src/contrib/neosp.cpp
@@ -202,11 +202,14 @@ int main_guarded(int argc, char **argv) {
     std::vector<GaussianShell> tshells=target_basis.get_shells();
 
     // Get shellpairs
-    arma::mat Qs, Qt, Ms, Mt;
     double shtol=settings.get_double("IntegralThresh");
     bool verbose=false;
-    auto spairs=source_basis.get_eripairs(Qs,Ms,shtol,omega,alpha,beta,verbose);
-    auto tpairs=target_basis.get_eripairs(Qt,Mt,shtol,omega,alpha,beta,verbose);
+    ScreeningData s_scr = source_basis.compute_screening(shtol,omega,alpha,beta,verbose);
+    ScreeningData t_scr = target_basis.compute_screening(shtol,omega,alpha,beta,verbose);
+    const arma::mat & Qs = s_scr.Q;
+    const arma::mat & Qt = t_scr.Q;
+    const std::vector<eripair_t> & spairs = s_scr.shpairs;
+    const std::vector<eripair_t> & tpairs = t_scr.shpairs;
 
     // Sanity check
     if(source_density.n_rows != source_basis.get_Nbf() or source_density.n_cols != source_basis.get_Nbf())

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -58,8 +58,7 @@ size_t DensityFit::fill(const BasisSet & orbbas, const BasisSet & auxbas, bool d
   direct=dir;
 
   // Fill list of shell pairs
-  arma::mat Q, M;
-  orbpairs=orbbas.get_eripairs(Q,M,erithr);
+  orbpairs=orbbas.compute_screening(erithr).shpairs;
 
   // Get orbital shells, auxiliary shells and dummy shell
   orbshells=orbbas.get_shells();
@@ -608,8 +607,7 @@ size_t DensityFit::memory_estimate(const BasisSet & orbbas, const BasisSet & aux
   // Memory taken up by  ( \alpha | \mu \nu)
   if(!dir) {
     // Form screening matrix
-    arma::mat Q, M;
-    std::vector<eripair_t> opairs=orbbas.get_eripairs(Q,M,thr);
+    std::vector<eripair_t> opairs=orbbas.compute_screening(thr).shpairs;
 
     // Count number of function pairs
     size_t np=0;

--- a/src/erichol.cpp
+++ b/src/erichol.cpp
@@ -176,8 +176,10 @@ size_t ERIchol::fill(const BasisSet & basis, double cholesky_tol, double shell_r
   }
 
   // Screening matrix and pairs
-  arma::mat Q, M;
-  std::vector<eripair_t> shpairs=basis.get_eripairs(Q,M,shell_screen_tol,omega,alpha,beta,verbose);
+  ScreeningData scr=basis.compute_screening(shell_screen_tol,omega,alpha,beta,verbose);
+  const arma::mat & Q = scr.Q;
+  const arma::mat & M = scr.M;
+  const std::vector<eripair_t> & shpairs = scr.shpairs;
 
   // Amount of basis functions
   Nbf=basis.get_Nbf();
@@ -609,8 +611,10 @@ size_t ERIchol::fill_two_step(const BasisSet & basis,
   }
 
   // Screening matrix and pairs
-  arma::mat Q, M_screen;
-  std::vector<eripair_t> shpairs=basis.get_eripairs(Q,M_screen,shell_screen_tol,omega,alpha,beta,verbose);
+  ScreeningData scr=basis.compute_screening(shell_screen_tol,omega,alpha,beta,verbose);
+  const arma::mat & Q = scr.Q;
+  const arma::mat & M_screen = scr.M;
+  const std::vector<eripair_t> & shpairs = scr.shpairs;
 
   // Amount of basis functions
   Nbf=basis.get_Nbf();
@@ -1518,11 +1522,8 @@ arma::vec ERIchol::forceJ(const BasisSet & basis, const arma::mat & P) const {
   // Same shape as DensityFit::forceJ Part 2 (which uses 3-center
   // derivatives), but routed via dERIWorker.compute on 4 real shells.
   // dERIWorker yields 12 components mapped to the 4 centers.
-  std::vector<eripair_t> orb_shps_;
-  {
-    arma::mat Q, MS;
-    orb_shps_ = basis.get_eripairs(Q, MS, /*tol*/0.0, omega, alpha, beta, false);
-  }
+  std::vector<eripair_t> orb_shps_ =
+    basis.compute_screening(/*tol*/0.0, omega, alpha, beta, false).shpairs;
 
 #ifdef _OPENMP
 #pragma omp parallel

--- a/src/eriscreen.cpp
+++ b/src/eriscreen.cpp
@@ -91,7 +91,10 @@ size_t ERIscreen::fill(const BasisSet * basisv, double shtol, bool verbose) {
   iidx=i_idx(Nbf);
 
   // Shell-pair list
-  shpairs=basp->get_eripairs(Q,M,shtol,omega,alpha,beta,verbose);
+  ScreeningData s = basp->compute_screening(shtol,omega,alpha,beta,verbose);
+  Q = std::move(s.Q);
+  M = std::move(s.M);
+  shpairs = std::move(s.shpairs);
 
   return shpairs.size();
 }

--- a/src/eritable.cpp
+++ b/src/eritable.cpp
@@ -58,7 +58,10 @@ void ERItable::get_range_separation(double & w, double & a, double & b) const {
 
 size_t ERItable::N_ints(const BasisSet * basp, double thr) {
   // Get ERI pairs
-  shpairs=basp->get_eripairs(Q, M, thr, omega, alpha, beta);
+  ScreeningData s = basp->compute_screening(thr, omega, alpha, beta);
+  Q = std::move(s.Q);
+  M = std::move(s.M);
+  shpairs = std::move(s.shpairs);
 
   // Form offset table and calculate amount of integrals
   size_t N=0;


### PR DESCRIPTION
## Summary

Every J/K path called the same factory with the same out-parameter shape:

\`\`\`cpp
arma::mat Q, M;
std::vector<eripair_t> shpairs = basis.get_eripairs(Q,M,thr, omega, alpha, beta, verbose);
\`\`\`

and stored the resulting triple as three separate fields. The three outputs travel together, get computed together, get used together — they're a bundle.

Bundle them. New \`ScreeningData\` struct (Q, M, shpairs) in \`basis.h\`; single \`BasisSet::compute_screening(thr, omega=0, alpha=1, beta=0, verbose)\` factory returning the bundle by value. \`get_eripairs\` removed; all 9 callsites migrated (ERIscreen, ERItable, ERIchol × 3, DensityFit × 2, basis-internal SAP path, contrib NEO / NEOSP / hNEO-CI).

ERIscreen and ERItable still own their own Q / M / shpairs members and \`std::move\` from the factory return; collapsing them to a single \`ScreeningData\` member would be a much larger churn with no behaviour payoff, so left for follow-up.

This is the prep step for the unified K-build (#1 from the audit shortlist) — that path will take a \`const ScreeningData &\` instead of having to also untangle the (Q, M, shpairs) field set across direct / DF / Cholesky paths.

## Test plan

- [x] Full build clean (liberkale + all contrib executables)
- [x] Full ctest 178/178 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)