### PR TITLE
Introduce RangeSeparation struct; tighten 4 SCF range-sep sites

### DIFF
--- a/src/basis.h
+++ b/src/basis.h
@@ -144,6 +144,20 @@ struct ScreeningData {
   std::vector<eripair_t> shpairs;
 };
 
+/// Range-separation parameters for Coulomb / exchange operators.
+/// The two-electron kernel decomposes as
+///   1/r12 = alpha * erf(omega r12) / r12 + beta * erfc(omega r12) / r12
+/// so for plain Coulomb / full-range exchange we have
+/// omega=0, alpha=1, beta=0 (default); pure short-range exchange is
+/// omega=omega, alpha=0, beta=1; etc. ERIscreen, ERIchol, DensityFit,
+/// ERItable and the libint workers all store and forward this triple.
+/// Bundle it so signatures stop carrying three loose doubles.
+struct RangeSeparation {
+  double omega = 0.0;
+  double alpha = 1.0;
+  double beta = 0.0;
+};
+
 // Forward declaration
 class BasisSetLibrary;
 class ElementBasisSet;

--- a/src/density_fitting.h
+++ b/src/density_fitting.h
@@ -137,8 +137,10 @@ class DensityFit {
 
   /// Set range separation constants
   void set_range_separation(double w, double a, double b);
+  void set_range_separation(const RangeSeparation & rs) { set_range_separation(rs.omega, rs.alpha, rs.beta); }
   /// Get range separation constants
   void get_range_separation(double & w, double & a, double & b) const;
+  RangeSeparation get_range_separation() const { RangeSeparation rs; get_range_separation(rs.omega, rs.alpha, rs.beta); return rs; }
 
   /**
    * Compute integrals, use given linear dependency threshold. The HF

--- a/src/erichol.h
+++ b/src/erichol.h
@@ -75,7 +75,9 @@ class ERIchol {
 
   /// Set range separation
   void set_range_separation(double w, double a, double b);
+  void set_range_separation(const RangeSeparation & rs) { set_range_separation(rs.omega, rs.alpha, rs.beta); }
   void get_range_separation(double & w, double & a, double & b) const;
+  RangeSeparation get_range_separation() const { RangeSeparation rs; get_range_separation(rs.omega, rs.alpha, rs.beta); return rs; }
 
   /// Load B matrix
   void load();

--- a/src/eriscreen.h
+++ b/src/eriscreen.h
@@ -77,8 +77,10 @@ class ERIscreen {
 
   /// Set range separation
   void set_range_separation(double omega, double alpha, double beta);
+  void set_range_separation(const RangeSeparation & rs) { set_range_separation(rs.omega, rs.alpha, rs.beta); }
   /// Get range separation
   void get_range_separation(double & omega, double & alpha, double & beta) const;
+  RangeSeparation get_range_separation() const { RangeSeparation rs; get_range_separation(rs.omega, rs.alpha, rs.beta); return rs; }
 
   /// Form screening matrix, return amount of significant shell pairs
   size_t fill(const BasisSet * basis, double shtol, bool verbose=true);

--- a/src/eritable.h
+++ b/src/eritable.h
@@ -73,8 +73,10 @@ class ERItable {
 
   /// Set range separation
   void set_range_separation(double omega, double alpha, double beta);
+  void set_range_separation(const RangeSeparation & rs) { set_range_separation(rs.omega, rs.alpha, rs.beta); }
   /// Get range separation
   void get_range_separation(double & omega, double & alpha, double & beta) const;
+  RangeSeparation get_range_separation() const { RangeSeparation rs; get_range_separation(rs.omega, rs.alpha, rs.beta); return rs; }
 
   /// Fill table, return amount of significant shell pairs
   size_t fill(const BasisSet * basis, double thr);

--- a/src/scf-base.cpp
+++ b/src/scf-base.cpp
@@ -555,16 +555,9 @@ void SCF::set_verbose(bool verb) {
 void SCF::fill_rs(double omega) {
   if(densityfit) {
     // Compute range separated integrals if necessary
-    bool fill;
-    if(!dfit_rs.get_Naux()) {
-      fill=true;
-    } else {
-      double o, kl, ks;
-      dfit_rs.get_range_separation(o,kl,ks);
-      fill=(!(o==omega));
-    }
+    const bool fill = !dfit_rs.get_Naux() || dfit_rs.get_range_separation().omega != omega;
     if(fill) {
-      dfit_rs.set_range_separation(omega,0.0,1.0);
+      dfit_rs.set_range_separation({omega, 0.0, 1.0});
 
       // Compute memory estimate
       std::string memest=memory_size(dfit.memory_estimate(*basisp,dfitbas,intthr,direct));
@@ -590,14 +583,7 @@ void SCF::fill_rs(double omega) {
 
   } else if(cholesky) {
     // Compute range separated integrals if necessary
-    bool fill;
-    if(!chol_rs.get_Naux()) {
-      fill=true;
-    } else {
-      double o, kl, ks;
-      chol_rs.get_range_separation(o,kl,ks);
-      fill=(!(o==omega));
-    }
+    bool fill = !chol_rs.get_Naux() || chol_rs.get_range_separation().omega != omega;
     if(fill) {
       Timer t;
       if(verbose) {
@@ -605,7 +591,7 @@ void SCF::fill_rs(double omega) {
 	fflush(stdout);
       }
 
-      chol_rs.set_range_separation(omega,0.0,1.0);
+      chol_rs.set_range_separation({omega, 0.0, 1.0});
       if(cholmode==-1) {
 	chol_rs.load();
 	if(verbose) {
@@ -635,21 +621,14 @@ void SCF::fill_rs(double omega) {
   } else {
     if(!direct) {
       // Compute range separated integrals if necessary
-      bool fill;
-      if(!tab_rs.get_N()) {
-	fill=true;
-      } else {
-	double o, kl, ks;
-	tab_rs.get_range_separation(o,kl,ks);
-	fill=(!(o==omega));
-      }
+      const bool fill = !tab_rs.get_N() || tab_rs.get_range_separation().omega != omega;
       if(fill) {
 	Timer t;
 	if(verbose) {
 	  printf("Computing short-range repulsion integrals ... ");
 	  fflush(stdout);
 	}
-	tab_rs.set_range_separation(omega,0.0,1.0);
+	tab_rs.set_range_separation({omega, 0.0, 1.0});
 	size_t Np=tab_rs.fill(basisp,intthr);
 
 	if(verbose) {
@@ -659,14 +638,7 @@ void SCF::fill_rs(double omega) {
 	}
       }
     } else {
-      bool fill;
-      if(!scr_rs.get_N()) {
-	fill=true;
-      } else {
-	double o, kl, ks;
-	scr_rs.get_range_separation(o,kl,ks);
-	fill=(!(o==omega));
-      }
+      const bool fill = !scr_rs.get_N() || scr_rs.get_range_separation().omega != omega;
       if(fill) {
 	Timer t;
 	if(verbose) {
@@ -674,7 +646,7 @@ void SCF::fill_rs(double omega) {
 	  fflush(stdout);
 	}
 
-	scr_rs.set_range_separation(omega,0.0,1.0);
+	scr_rs.set_range_separation({omega, 0.0, 1.0});
 	size_t Np=scr_rs.fill(basisp,intthr);
 
 	if(verbose) {

--- a/src/scf-force.cpp.in
+++ b/src/scf-force.cpp.in
@@ -121,7 +121,7 @@ arma::vec SCF::force_ROHF(uscf_t & sol, int Nel_alpha, int Nel_beta, double tol)
 
   if(omega != 0.0) {
     // Set range separation and fill (low-cost compared to forces anyway)
-    scr_rs.set_range_separation(omega,0.0,1.0);
+    scr_rs.set_range_separation({omega, 0.0, 1.0});
     scr_rs.fill(basisp,intthr,verbose);
 
     // Exchange forces


### PR DESCRIPTION
## Summary

\`omega/alpha/beta\` has been a loose triple in every range-separated hybrid path -- \`ERIscreen\`, \`ERIchol\`, \`ERItable\`, \`DensityFit\` each carry the trio as three separate members, set/got as three loose doubles, with no abstraction tying them together. As the audit noted, a mismatch in one object goes undetected.

Introduce a \`RangeSeparation\` struct in \`basis.h\` (omega, alpha, beta, defaulted to plain Coulomb 0/1/0) and add additive overloads on each consumer:

\`\`\`cpp
void set_range_separation(const RangeSeparation &);
RangeSeparation get_range_separation() const;
\`\`\`

Existing 3-arg setter / 3-out-param getter are kept; the new ones forward to them. No behaviour change.

Migrate the 4 sites in \`scf-base.cpp\` + 1 in \`scf-force.cpp.in\` that followed the same "compare omega-only and update if different" pattern -- each block goes from ~10 lines to ~3:

\`\`\`cpp
// Before
bool fill;
if(!obj.get_N()) fill=true;
else {
  double o,kl,ks; obj.get_range_separation(o,kl,ks);
  fill = !(o==omega);
}
if(fill) { obj.set_range_separation(omega, 0.0, 1.0); ... }

// After
const bool fill = !obj.get_N() || obj.get_range_separation().omega != omega;
if(fill) { obj.set_range_separation({omega, 0.0, 1.0}); ... }
\`\`\`

Same semantics, half the lines, no scratch variables, no order-dependent 3-out-param idiom.

## Test plan

- [x] Full build clean (liberkale + every contrib executable)
- [x] Full ctest 178/178 pass

## Not in scope

Worker ctors (\`ERIWorker_srlr\`, \`dERIWorker_srlr\`) and basis-internal \`eri_screening\` still take loose triples. Those touch many more callers and have less clear payoff -- left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)