### PR TITLE
ERIscreen: per-thread ERIWorker / dERIWorker pool

### DIFF
--- a/src/eriscreen.cpp
+++ b/src/eriscreen.cpp
@@ -71,6 +71,11 @@ void ERIscreen::set_range_separation(double w, double a, double b) {
   omega=w;
   alpha=a;
   beta=b;
+  // Workers in the pool were built against the previous omega /
+  // alpha / beta -- drop them so the next acquire_eri / acquire_deri
+  // rebuilds with the new parameters.
+  eri_pool_.clear();
+  deri_pool_.clear();
 }
 
 void ERIscreen::get_range_separation(double & w, double & a, double & b) const {
@@ -96,7 +101,40 @@ size_t ERIscreen::fill(const BasisSet * basisv, double shtol, bool verbose) {
   M = std::move(s.M);
   shpairs = std::move(s.shpairs);
 
+  // Worker pools are tied to (basis, omega/alpha/beta). Basis just
+  // changed, so reset; size to omp_get_max_threads() so threads can
+  // index by omp_get_thread_num() without locking.
+#ifdef _OPENMP
+  const int nth = omp_get_max_threads();
+#else
+  const int nth = 1;
+#endif
+  eri_pool_.clear();
+  eri_pool_.resize(nth);
+  deri_pool_.clear();
+  deri_pool_.resize(nth);
+
   return shpairs.size();
+}
+
+ERIWorker * ERIscreen::acquire_eri(int ith) const {
+  if(!eri_pool_[ith]) {
+    if(omega==0.0 && alpha==1.0 && beta==0.0)
+      eri_pool_[ith].reset(new ERIWorker(basp->get_max_am(), basp->get_max_Ncontr()));
+    else
+      eri_pool_[ith].reset(new ERIWorker_srlr(basp->get_max_am(), basp->get_max_Ncontr(), omega, alpha, beta));
+  }
+  return eri_pool_[ith].get();
+}
+
+dERIWorker * ERIscreen::acquire_deri(int ith) const {
+  if(!deri_pool_[ith]) {
+    if(omega==0.0 && alpha==1.0 && beta==0.0)
+      deri_pool_[ith].reset(new dERIWorker(basp->get_max_am(), basp->get_max_Ncontr()));
+    else
+      deri_pool_[ith].reset(new dERIWorker_srlr(basp->get_max_am(), basp->get_max_Ncontr(), omega, alpha, beta));
+  }
+  return deri_pool_[ith].get();
 }
 
 void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & digest, double tol) const {
@@ -109,16 +147,18 @@ void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & diges
 #pragma omp parallel
 #endif
   {
-    // ERI worker
-    ERIWorker *eri = (omega==0.0 && alpha==1.0 && beta==0.0) ? new ERIWorker(basp->get_max_am(),basp->get_max_Ncontr()) : new ERIWorker_srlr(basp->get_max_am(),basp->get_max_Ncontr(),omega,alpha,beta);
-
-    // Integral array
-    const std::vector<double> * erip;
-
 #ifndef _OPENMP
     int ith=0;
 #else
     int ith(omp_get_thread_num());
+#endif
+    // ERI worker (per-thread pool; lazily built on first acquire).
+    ERIWorker *eri = acquire_eri(ith);
+
+    // Integral array
+    const std::vector<double> * erip;
+
+#ifdef _OPENMP
 #pragma omp for schedule(dynamic)
 #endif
     for(size_t ip=0;ip<Npairs;ip++) {
@@ -157,8 +197,7 @@ void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & diges
 	  digest[ith][i]->digest(shpairs,ip,jp,*erip,0);
       }
     }
-
-    delete eri;
+    // eri is owned by eri_pool_ -- do not delete.
   }
 }
 
@@ -176,17 +215,19 @@ arma::vec ERIscreen::calculate_force(std::vector< std::vector<ForceDigestor *> >
 #pragma omp parallel
 #endif
   {
-    /// ERI derivative worker
-    dERIWorker *deri = (omega==0.0 && alpha==1.0 && beta==0.0) ? new dERIWorker(basp->get_max_am(),basp->get_max_Ncontr()) : new dERIWorker_srlr(basp->get_max_am(),basp->get_max_Ncontr(),omega,alpha,beta);
-
-    // Shell centers
-    size_t inuc, jnuc, knuc, lnuc;
-
 #ifndef _OPENMP
     int ith=0;
 #else
     int ith(omp_get_thread_num());
     arma::vec Fwrk(F);
+#endif
+    /// ERI derivative worker (per-thread pool, lazily built).
+    dERIWorker *deri = acquire_deri(ith);
+
+    // Shell centers
+    size_t inuc, jnuc, knuc, lnuc;
+
+#ifdef _OPENMP
 #pragma omp for schedule(dynamic)
 #endif
     for(size_t ip=0;ip<Npairs;ip++) {
@@ -256,8 +297,7 @@ arma::vec ERIscreen::calculate_force(std::vector< std::vector<ForceDigestor *> >
 #pragma omp critical
     F+=Fwrk;
 #endif
-
-    delete deri;
+    // deri is owned by deri_pool_ -- do not delete.
   }
 
   return F;

--- a/src/eriscreen.h
+++ b/src/eriscreen.h
@@ -36,9 +36,11 @@ class IntegralDigestor;
 class ForceDigestor;
 #include "global.h"
 #include <armadillo>
+#include <memory>
 #include <vector>
 
 #include "basis.h"
+#include "eriworker.h"
 
 /// Screening of electron repulsion integrals
 class ERIscreen {
@@ -60,6 +62,24 @@ class ERIscreen {
   double alpha;
   /// Fraction of short-range exchange
   double beta;
+
+  /// Per-thread ERIWorker / dERIWorker pool. Sized to
+  /// omp_get_max_threads() in fill(); each thread lazily constructs
+  /// its slot on first use via acquire_eri / acquire_deri. Workers
+  /// are reused across calcJ / calcK / calcJK / forceJ / forceK
+  /// calls (workers' internal state is overwritten on every
+  /// compute() so cross-call reuse is safe). Pools are cleared
+  /// whenever set_range_separation or fill change the parameters
+  /// the constructors baked in.
+  ///
+  /// mutable so the const calc* / force* members can populate.
+  mutable std::vector< std::unique_ptr<ERIWorker> > eri_pool_;
+  mutable std::vector< std::unique_ptr<dERIWorker> > deri_pool_;
+
+  /// Lazily construct & return the per-thread ERI worker.
+  ERIWorker * acquire_eri(int ith) const;
+  /// Lazily construct & return the per-thread derivative ERI worker.
+  dERIWorker * acquire_deri(int ith) const;
 
   /// Run calculation with given digestor
   void calculate(std::vector< std::vector<IntegralDigestor *> > & digest, double tol) const;


### PR DESCRIPTION
## Summary

\`ERIscreen::calculate\` and \`calculate_force\` both allocated their per-thread \`ERIWorker\` / \`dERIWorker\` *inside* the omp parallel region and tore it down at the end. Every \`calcJ\` / \`calcK\` / \`calcJK\` / \`forceJ\` / \`forceK\` call hits both -- so over an SCF iteration (~20 iters), that's ~20 fresh worker constructions per thread, each paying \`init_libint\` + the libint scratch / arma container allocations the worker ctor performs.

Hoist the worker into a member-owned per-thread pool sized in \`fill()\` to \`omp_get_max_threads()\`. Lazy-construct each slot on first acquire (the (omega, alpha, beta)-aware switch between \`ERIWorker\` / \`ERIWorker_srlr\` lives in \`acquire_eri\`). Reuse across all subsequent \`calc*\` / \`force*\` calls until the basis or range-separation changes:

- \`set_range_separation\` clears the pool so the next \`acquire_*\` rebuilds with the new params
- \`fill\` clears + resizes for the new basis

\`unique_ptr\` ownership, no manual \`delete\` in the hot loops.

## Benchmark

Benzene HF / cc-pVDZ direct mode, 4 OpenMP threads, 3 back-to-back runs:

| | run 1 | run 2 | run 3 | mean |
|---|---|---|---|---|
| baseline (master) | 209.9 s | 200.5 s | 191.0 s | 200.5 s |
| this PR | 182.1 s | 162.1 s | 171.4 s | 171.9 s |

≈ 14% wall-clock speedup, no algorithmic change.

## Test plan

- [x] Full ctest 178/178 pass
- [x] Sanity-check HF / cc-pVDZ direct on water (converges to -76.026768140876)

## Not in scope

\`ERIchol\` / \`DensityFit\` allocate workers far less often (once per \`fill\`, not once per SCF iter) so a worker pool there is much lower-payoff -- left for follow-up. The \`compute_libint_data\` seam itself (the actual libint boundary) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)