### PR TITLE
basis: Basis Set Exchange (BSE) JSON reader and writer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,26 @@ else()
 endif()
 message("")
 
+# nlohmann/json for Basis Set Exchange (BSE) JSON parsing. If a system
+# install isn't present, fetch v3.11.3 from GitHub. Either path exposes
+# the nlohmann_json::nlohmann_json imported target.
+find_package(nlohmann_json 3.11 QUIET CONFIG)
+if(nlohmann_json_FOUND)
+ message("Found nlohmann_json ${nlohmann_json_VERSION}: ${nlohmann_json_DIR}")
+else()
+ message("nlohmann_json not found; fetching v3.11.3 from GitHub.")
+ include(FetchContent)
+ set(JSON_BuildTests OFF CACHE INTERNAL "")
+ set(JSON_Install OFF CACHE INTERNAL "")
+ FetchContent_Declare(
+   nlohmann_json
+   GIT_REPOSITORY https://github.com/nlohmann/json.git
+   GIT_TAG        v3.11.3
+ )
+ FetchContent_MakeAvailable(nlohmann_json)
+endif()
+message("")
+
 
 # Find out how to preprocess C++ source code files
 if(CMAKE_COMPILER_IS_GNUCXX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ endif()
 # It is an imported target, so include directories and the link
 # requirement propagate transitively to consumers of liberkale.
 target_link_libraries(liberkale wignernj::wignernj)
+# Basis Set Exchange JSON parsing (BasisSetLibrary::load_bse_json).
+target_link_libraries(liberkale nlohmann_json::nlohmann_json)
 
 # Create the ERKALE main executable
 add_executable (erkale main.cpp)

--- a/src/basislibrary.cpp
+++ b/src/basislibrary.cpp
@@ -21,6 +21,8 @@
 #include "stringutil.h"
 #include "linalg.h"
 #include "timer.h"
+
+#include <nlohmann/json.hpp>
 // erifit declarations have been folded into erichol.h
 #include "erichol.h"
 
@@ -1649,6 +1651,126 @@ void BasisSetLibrary::load_basis(const std::string & basis0, bool verbose) {
 
   } else
     load_gaussian94(basis,verbose);
+}
+
+namespace {
+  /// Parse a BSE JSON number that may be encoded either as a string
+  /// (BSE's canonical high-precision form) or as a native JSON
+  /// number. std::stod rounds the decimal to the nearest representable
+  /// double, so the converted value is the best IEEE double available
+  /// regardless of how many digits the JSON carried.
+  double parse_bse_number(const nlohmann::json & j) {
+    if(j.is_string())
+      return std::stod(j.get<std::string>());
+    if(j.is_number())
+      return j.get<double>();
+    throw std::runtime_error("BSE JSON: expected a number, got " + std::string(j.type_name()));
+  }
+}
+
+void BasisSetLibrary::load_bse_json(const std::string & filename, bool verbose) {
+  // Read & parse the JSON.
+  std::ifstream is(filename);
+  if(!is.good()) {
+    std::ostringstream oss;
+    oss << "Failed to open BSE JSON file '" << filename << "'\n";
+    throw std::runtime_error(oss.str());
+  }
+  nlohmann::json j;
+  try {
+    is >> j;
+  } catch(const std::exception & e) {
+    std::ostringstream oss;
+    oss << "Failed to parse BSE JSON '" << filename << "': " << e.what() << "\n";
+    throw std::runtime_error(oss.str());
+  }
+
+  // Top-level "name" field; fall back to the filename.
+  if(j.contains("name") && j["name"].is_string())
+    name = j["name"].get<std::string>();
+  else
+    name = filename;
+
+  if(!j.contains("elements"))
+    throw std::runtime_error("BSE JSON '" + filename + "' is missing the 'elements' section.\n");
+  const auto & elements_json = j["elements"];
+
+  for(auto it = elements_json.begin(); it != elements_json.end(); ++it) {
+    // BSE keys elements by their atomic-number string.
+    const int Z = std::stoi(it.key());
+    if(Z < 1 || Z >= maxZ) {
+      std::ostringstream oss;
+      oss << "BSE JSON '" << filename << "': element Z=" << Z << " out of range.\n";
+      throw std::runtime_error(oss.str());
+    }
+    ElementBasisSet el(element_symbols[Z]);
+
+    const auto & el_json = it.value();
+    if(!el_json.contains("electron_shells")) {
+      // Pure ECP entry (or empty); skip for orbital-basis loading.
+      add_element(el);
+      continue;
+    }
+
+    for(const auto & shell_json : el_json["electron_shells"]) {
+      // We accept "gto" / "gto_spherical" / "gto_cartesian" alike. The
+      // spherical-vs-Cartesian choice is a downstream BasisSet setting
+      // (UseLM), not a basis-library property.
+      const auto & am_arr   = shell_json.at("angular_momentum");
+      const auto & exp_arr  = shell_json.at("exponents");
+      const auto & coef_arr = shell_json.at("coefficients");
+
+      const size_t Nexp = exp_arr.size();
+      std::vector<double> exps(Nexp);
+      for(size_t k=0; k<Nexp; k++)
+        exps[k] = parse_bse_number(exp_arr[k]);
+
+      // BSE layout: coefficients is a 2D array.
+      //   len(angular_momentum)==1  -> each row is a separately
+      //     contracted shell at that single L (general contractions).
+      //   len(angular_momentum)==len(coefficients) -> row i is the
+      //     contraction for angular_momentum[i] (joint SP-style shells).
+      const size_t Nam  = am_arr.size();
+      const size_t Nrow = coef_arr.size();
+
+      auto build_shell = [&](int am, const nlohmann::json & coef_row) {
+        if(coef_row.size() != Nexp) {
+          std::ostringstream oss;
+          oss << "BSE JSON '" << filename << "': coefficient row length " << coef_row.size()
+              << " does not match the " << Nexp << " exponents.\n";
+          throw std::runtime_error(oss.str());
+        }
+        std::vector<contr_t> C(Nexp);
+        for(size_t k=0; k<Nexp; k++) {
+          C[k].z = exps[k];
+          C[k].c = parse_bse_number(coef_row[k]);
+        }
+        return FunctionShell(am, C);
+      };
+
+      if(Nam == 1) {
+        const int am = am_arr[0].get<int>();
+        for(size_t r=0; r<Nrow; r++)
+          el.add_function(build_shell(am, coef_arr[r]));
+      } else if(Nam == Nrow) {
+        for(size_t r=0; r<Nrow; r++)
+          el.add_function(build_shell(am_arr[r].get<int>(), coef_arr[r]));
+      } else {
+        std::ostringstream oss;
+        oss << "BSE JSON '" << filename << "': cannot interpret " << Nrow
+            << " coefficient rows with " << Nam << " angular momenta.\n";
+        throw std::runtime_error(oss.str());
+      }
+    }
+
+    add_element(el);
+  }
+
+  if(verbose) {
+    printf("Loaded BSE JSON basis '%s' from %s (%i elements).\n",
+           name.c_str(), filename.c_str(), (int) get_Nel());
+    fflush(stdout);
+  }
 }
 
 void BasisSetLibrary::load_gaussian94(const std::string & basis, bool verbose) {

--- a/src/basislibrary.cpp
+++ b/src/basislibrary.cpp
@@ -1805,6 +1805,66 @@ void BasisSetLibrary::load_bse_json(const std::string & filename, bool verbose) 
   }
 }
 
+void BasisSetLibrary::save_bse_json(const std::string & filename) const {
+  nlohmann::json j;
+
+  // Schema header.
+  j["molssi_bse_schema"] = {
+    {"schema_type", "complete"},
+    {"schema_version", "0.1"}
+  };
+  j["name"] = name;
+  j["function_types"] = nlohmann::json::array({"gto"});
+
+  // Format a double with 17 significant digits -- round-trip safe for
+  // IEEE doubles. Numbers are written as strings to match BSE's
+  // canonical high-precision encoding.
+  auto fmt = [](double x) {
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "%.17g", x);
+    return std::string(buf);
+  };
+
+  j["elements"] = nlohmann::json::object();
+  for(const auto & el : elements) {
+    const int Z = get_Z(el.get_symbol());
+
+    nlohmann::json el_json;
+    el_json["electron_shells"] = nlohmann::json::array();
+
+    // Each ERKALE FunctionShell is a segmented contraction and is
+    // written as one BSE electron_shell with a single coefficient row.
+    // (BSE supports collapsing multiple ERKALE shells with shared
+    // exponents into a single electron_shell with multiple rows; the
+    // segmented form is semantically equivalent and round-trips
+    // exactly through load_bse_json.)
+    for(const auto & sh : el.get_shells()) {
+      const std::vector<contr_t> C = sh.get_contr();
+      nlohmann::json shell_json;
+      shell_json["function_type"] = "gto";
+      shell_json["region"] = "";
+      shell_json["angular_momentum"] = nlohmann::json::array({sh.get_am()});
+
+      nlohmann::json exps = nlohmann::json::array();
+      nlohmann::json coef_row = nlohmann::json::array();
+      for(const auto & c : C) {
+        exps.push_back(fmt(c.z));
+        coef_row.push_back(fmt(c.c));
+      }
+      shell_json["exponents"] = exps;
+      shell_json["coefficients"] = nlohmann::json::array({coef_row});
+      el_json["electron_shells"].push_back(shell_json);
+    }
+
+    j["elements"][std::to_string(Z)] = el_json;
+  }
+
+  std::ofstream of(filename);
+  if(!of.good())
+    throw std::runtime_error("Failed to open '" + filename + "' for writing BSE JSON.\n");
+  of << j.dump(2) << std::endl;
+}
+
 void BasisSetLibrary::load_gaussian94(const std::string & basis, bool verbose) {
   // First, find out file where basis set is
   std::string filename=find_basis(basis,verbose);

--- a/src/basislibrary.cpp
+++ b/src/basislibrary.cpp
@@ -1594,7 +1594,39 @@ static BasisSetLibrary combine_pople_basis(const BasisSetLibrary & hbas, const B
   return ret;
 }
 
+namespace {
+  /// Search the same directories as find_basis for a BSE JSON file
+  /// by the given basis name. Returns the full path if found, or an
+  /// empty string otherwise (non-throwing complement to find_basis).
+  std::string find_bse_json(const std::string & basisname) {
+    std::vector<std::string> dirs;
+    dirs.push_back("");
+    if(const char * libloc = getenv("ERKALE_LIBRARY"))
+      dirs.push_back(libloc + std::string("/"));
+    dirs.push_back(ERKALE_SYSTEM_LIBRARY + std::string("/"));
+    for(const auto & d : dirs) {
+      const std::string fname = d + basisname + ".json";
+      std::ifstream in(fname.c_str());
+      if(in.is_open())
+        return fname;
+    }
+    return "";
+  }
+}
+
 void BasisSetLibrary::load_basis(const std::string & basis0, bool verbose) {
+  // Prefer a BSE JSON file by this name if present. JSON wins over the
+  // legacy Gaussian'94 (.gbs) entries, so the migration can proceed
+  // file by file: drop in cc-pVTZ.json next to cc-pVTZ.gbs and the
+  // JSON path takes over.
+  {
+    const std::string json_path = find_bse_json(basis0);
+    if(!json_path.empty()) {
+      load_bse_json(json_path, verbose);
+      return;
+    }
+  }
+
   std::string basis(basis0);
 
   if(basis.size()>4 && basis.substr(0,4).compare("6-31")==0) {

--- a/src/basislibrary.h
+++ b/src/basislibrary.h
@@ -268,6 +268,14 @@ class BasisSetLibrary {
 
   /// Load basis set from file in Gaussian'94 format
   void load_gaussian94(const std::string & filename, bool verbose=true);
+
+  /// Load basis set from a Basis Set Exchange (BSE) JSON file. The
+  /// canonical BSE schema is documented at
+  /// https://molssi-bse.github.io/basis_set_exchange/ ; users generate
+  /// the JSON via the `basis_set_exchange` Python package or the BSE
+  /// web app and feed the file in. Numbers are parsed from BSE's
+  /// string form to give the best-rounded IEEE double.
+  void load_bse_json(const std::string & filename, bool verbose=true);
   /// Save basis set to file in Gaussian'94 format
   void save_gaussian94(const std::string & filename, bool append=false) const;
 

--- a/src/basislibrary.h
+++ b/src/basislibrary.h
@@ -276,6 +276,10 @@ class BasisSetLibrary {
   /// web app and feed the file in. Numbers are parsed from BSE's
   /// string form to give the best-rounded IEEE double.
   void load_bse_json(const std::string & filename, bool verbose=true);
+  /// Save basis set to a file in BSE JSON form. Exponents and
+  /// coefficients are written with 17 significant digits (round-trip
+  /// safe for IEEE doubles).
+  void save_bse_json(const std::string & filename) const;
   /// Save basis set to file in Gaussian'94 format
   void save_gaussian94(const std::string & filename, bool append=false) const;
 

--- a/src/test/basictests.cpp
+++ b/src/test/basictests.cpp
@@ -283,6 +283,25 @@ void test_bse_json() {
       throw std::runtime_error("BSE JSON: load_basis dispatch yielded a different contraction.\n");
     }
   }
+
+  // Round-trip: save the just-loaded library back to JSON, re-load,
+  // and verify the contraction matches the original bit-for-bit. The
+  // writer uses %.17g (round-trip safe for IEEE doubles), so values
+  // are preserved exactly.
+  const std::string roundtrip_file = "bse_test_roundtrip.json";
+  lib.save_bse_json(roundtrip_file);
+  BasisSetLibrary lib_rt;
+  lib_rt.load_bse_json(roundtrip_file, false);
+  remove(roundtrip_file.c_str());
+  std::vector<contr_t> C_rt = lib_rt.get_element("H").get_shells().at(0).get_contr();
+  for(size_t k=0; k<3; k++) {
+    if(C_rt[k].z != C[k].z || C_rt[k].c != C[k].c) {
+      ERROR_INFO();
+      printf("Round-trip mismatch at primitive %i: got (z=%.17e, c=%.17e), expected (z=%.17e, c=%.17e).\n",
+             (int) k, C_rt[k].z, C_rt[k].c, C[k].z, C[k].c);
+      throw std::runtime_error("BSE JSON: round-trip is not bit-exact.\n");
+    }
+  }
   printf("BSE JSON reader OK.\n");
 }
 

--- a/src/test/basictests.cpp
+++ b/src/test/basictests.cpp
@@ -19,6 +19,10 @@
 #include "../linalg.h"
 #include "../mathf.h"
 #include "../settings.h"
+#include "../basislibrary.h"
+
+#include <cstdio>
+#include <fstream>
 
 /// Check orthogonality of spherical harmonics up to
 const int Lmax=10;
@@ -194,6 +198,72 @@ void test_checkpoint() {
   remove(tmpfile.c_str());
 }
 
+// Load a minimal BSE-format JSON file and verify the parsed
+// BasisSetLibrary matches the well-known STO-3G hydrogen contraction.
+// Tolerance is set to DBL_EPSILON because BSE stores numbers as
+// strings and std::stod rounds to the nearest double.
+void test_bse_json() {
+  // STO-3G hydrogen: one s shell, three primitives. Exponents and
+  // coefficients are the canonical Pople-Hehre-Stewart values.
+  const std::string json_str = R"JSON({
+  "molssi_bse_schema": {"schema_type":"complete","schema_version":"0.1"},
+  "name": "STO-3G",
+  "elements": {
+    "1": {
+      "electron_shells": [
+        {
+          "function_type": "gto",
+          "region": "valence",
+          "angular_momentum": [0],
+          "exponents": ["3.42525091", "0.62391373", "0.16885540"],
+          "coefficients": [["0.15432897", "0.53532814", "0.44463454"]]
+        }
+      ]
+    }
+  }
+})JSON";
+
+  // Write to a tempfile and load through the public file-based API.
+  const std::string tmpfile = "bse_test_sto3g_h.json";
+  {
+    std::ofstream of(tmpfile);
+    of << json_str;
+  }
+
+  BasisSetLibrary lib;
+  lib.load_bse_json(tmpfile, false);
+  remove(tmpfile.c_str());
+
+  if(lib.get_Nel() != 1) {
+    ERROR_INFO();
+    printf("BSE JSON: expected 1 element, got %i.\n", (int) lib.get_Nel());
+    throw std::runtime_error("BSE JSON element-count check failed.\n");
+  }
+  ElementBasisSet H = lib.get_element("H");
+  std::vector<FunctionShell> shells = H.get_shells();
+  if(shells.size() != 1 || shells[0].get_am() != 0) {
+    ERROR_INFO();
+    throw std::runtime_error("BSE JSON: expected exactly one s shell on H.\n");
+  }
+  std::vector<contr_t> C = shells[0].get_contr();
+  if(C.size() != 3) {
+    ERROR_INFO();
+    throw std::runtime_error("BSE JSON: expected 3 primitives in H s shell.\n");
+  }
+  const double z_ref[] = {3.42525091, 0.62391373, 0.16885540};
+  const double c_ref[] = {0.15432897, 0.53532814, 0.44463454};
+  for(size_t k=0; k<3; k++) {
+    if(std::abs(C[k].z - z_ref[k]) > DBL_EPSILON*std::abs(z_ref[k]) ||
+       std::abs(C[k].c - c_ref[k]) > DBL_EPSILON*std::abs(c_ref[k])) {
+      ERROR_INFO();
+      printf("Primitive %i mismatch: got (z=%.17e, c=%.17e), expected (z=%.17e, c=%.17e).\n",
+             (int) k, C[k].z, C[k].c, z_ref[k], c_ref[k]);
+      throw std::runtime_error("BSE JSON: primitive mismatch.\n");
+    }
+  }
+  printf("BSE JSON reader OK.\n");
+}
+
 Settings settings;
 
 int main(void) {
@@ -212,4 +282,6 @@ int main(void) {
   } catch(std::runtime_error &) {
     throw std::runtime_error("LAPACK library is not thread safe!\nThis might cause problems in some parts of ERKALE.\n");
   }
+  // BSE JSON basis-set reader
+  test_bse_json();
 }

--- a/src/test/basictests.cpp
+++ b/src/test/basictests.cpp
@@ -224,14 +224,23 @@ void test_bse_json() {
 })JSON";
 
   // Write to a tempfile and load through the public file-based API.
-  const std::string tmpfile = "bse_test_sto3g_h.json";
+  // We also test the load_basis dispatch -- if a "<name>.json" exists,
+  // load_basis must pick it up in preference to a legacy .gbs entry.
+  // find_basis searches cwd first so a bare filename without a path
+  // suffices for the dispatch leg.
+  const std::string tmpname = "bse_test_sto3g_h";
+  const std::string tmpfile = tmpname + ".json";
   {
     std::ofstream of(tmpfile);
     of << json_str;
   }
 
+  // Direct API
   BasisSetLibrary lib;
   lib.load_bse_json(tmpfile, false);
+  // Dispatch via load_basis (the Basis-keyword entry point)
+  BasisSetLibrary lib_dispatch;
+  lib_dispatch.load_basis(tmpname, false);
   remove(tmpfile.c_str());
 
   if(lib.get_Nel() != 1) {
@@ -259,6 +268,19 @@ void test_bse_json() {
       printf("Primitive %i mismatch: got (z=%.17e, c=%.17e), expected (z=%.17e, c=%.17e).\n",
              (int) k, C[k].z, C[k].c, z_ref[k], c_ref[k]);
       throw std::runtime_error("BSE JSON: primitive mismatch.\n");
+    }
+  }
+  // The same checks for the dispatch path.
+  if(lib_dispatch.get_Nel() != 1) {
+    ERROR_INFO();
+    throw std::runtime_error("BSE JSON: load_basis dispatch returned the wrong number of elements.\n");
+  }
+  std::vector<contr_t> C_disp = lib_dispatch.get_element("H").get_shells().at(0).get_contr();
+  for(size_t k=0; k<3; k++) {
+    if(std::abs(C_disp[k].z - C[k].z) > DBL_EPSILON*std::abs(C[k].z) ||
+       std::abs(C_disp[k].c - C[k].c) > DBL_EPSILON*std::abs(C[k].c)) {
+      ERROR_INFO();
+      throw std::runtime_error("BSE JSON: load_basis dispatch yielded a different contraction.\n");
     }
   }
   printf("BSE JSON reader OK.\n");


### PR DESCRIPTION
First slice of the migration to BSE-format basis sets ([memory: project-basis-set-exchange-migration]).

## What's in

| Commit | What |
|---|---|
| `307b1cca` | `BasisSetLibrary::load_bse_json` — reads BSE JSON files into the existing `ElementBasisSet`/`FunctionShell` structure. Numbers accepted in either BSE's canonical string form or as native JSON; `std::stod` rounds to the nearest IEEE double. Handles single-`am` general contractions and SP-style joint shells. |
| `8bc3d349` | `load_basis` dispatch: probes for `<name>.json` in the same directories as `find_basis` (cwd / `ERKALE_LIBRARY` / `ERKALE_SYSTEM_LIBRARY`); JSON wins over the legacy `.gbs`. No behaviour change for inputs that resolve to `.gbs`. |
| `de2aed92` | `BasisSetLibrary::save_bse_json` — writes a BSE-format JSON file. Numbers serialised with `%.17g`, round-trip bit-identical for IEEE doubles. |

## Build / test

- nlohmann/json wired via `find_package` + `FetchContent` fallback (v3.11.3), mirroring the libwignernj pattern.
- `basictests` builds a minimal STO-3G H JSON in memory, exercises:
  - direct `load_bse_json` parses to the canonical Pople-Hehre-Stewart values to `DBL_EPSILON`;
  - `load_basis(name)` dispatch picks up `<name>.json` and produces the same contraction;
  - `save_bse_json` → `load_bse_json` round-trip is bit-exact (`==`, not `DBL_EPSILON`).
- No regression-suite changes — the dispatch falls through to `.gbs` when no JSON is present, so the 178 ctest inputs are untouched.

## What's not in (separate follow-ups)

- One-time conversion of the in-tree `basis/` library to JSON (`load_gaussian94 → save_bse_json` per file, no precision loss).
- `BasisAtom <idx> <file.json>` keyword for per-atom overrides (BSE schema is per-element; per-atom assignment lives in the input layer).
- Retirement of `basislibrary.cpp`'s `.gbs` reader and the in-tree `basis/` directory.
- `slaterfit` / `tempered` / `basistool` Python ports.

## Workflow this unlocks

Users prepare basis-set JSON via the `basis_set_exchange` Python package or the BSE webapp and feed it to ERKALE — no embedded Python at runtime, no GSL involvement, no in-tree library to maintain. BSE's high-precision decimal values round to the best IEEE double at parse time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)