### PR TITLE
Fix stale comments after the two-step CD pivot rework

### DIFF
--- a/src/b_tensor.cpp
+++ b/src/b_tensor.cpp
@@ -329,11 +329,12 @@ arma::mat DirectCDBlocks::get_block(size_t ip) const {
       }
   }
 
-  // Second stage: bake the pivot metric into the block, matching what
-  // CachedBlocks stores. L_block = X^T B_raw_block, shape
-  // (Naux_indep x Nmu*Nnu). Without this multiply the J/K kernels
-  // (which assume identity metric in CD mode) would see raw integrals
-  // and produce wrong J/K; cf. fill_cholesky's L-bake.
+  // Second stage: bake the pivot metric into the block.
+  // L_block = X^T (piv|mu nu), shape (Naux_indep x Nmu*Nnu). Without
+  // this multiply the J/K kernels (which assume identity metric in CD
+  // mode) would see raw integrals and produce wrong J/K; cf.
+  // fill_cholesky's L-bake. (The cached path stores exactly these
+  // blocks -- it materialises get_block.)
   arma::mat raw_view(buf_ptr, Nselected_, Nmu * Nnu, /*copy*/false, /*strict*/true);
   arma::mat & buf_L = scratch_L_[tid];
   arma::mat L_view(buf_L.memptr(), Naux_, Nmu * Nnu, /*copy*/false, /*strict*/true);

--- a/src/b_tensor.h
+++ b/src/b_tensor.h
@@ -184,9 +184,9 @@ class DirectCDBlocks : public BTensorBlocksBase {
   /// Sentinel value used in pivot_index_ (Nselected = pivot_index_xt.n_rows).
   arma::uword pivot_sentinel_;
   /// X = M^{-1/2} on the pivot metric, shape (Nselected x Naux_indep).
-  /// Applied inside get_block as the final L = X^T B_raw multiply so
-  /// the J/K kernels see the same L-baked block shape the cached path
-  /// produces. naux() == Naux_indep == pivot_X_.n_cols.
+  /// Applied inside get_block as the final L = X^T (piv|mu nu) multiply,
+  /// giving the L-baked block the J/K kernels consume; the cached path
+  /// materialises these same blocks. naux() == Naux_indep == pivot_X_.n_cols.
   arma::mat pivot_X_;
 
   double omega_, alpha_, beta_;

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -302,8 +302,8 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
     }
     // Trim invmap to the significant products. (Shed the whole unused
     // tail, including the n_cols-1 column the old < n_cols-1 guard
-    // skipped, which would otherwise leak into the cached B_raw
-    // scatter that iterates over invmap.n_cols.)
+    // skipped; Nprod below is invmap.n_cols, so a stray column would
+    // inflate the product count and corrupt the pivoting.)
     if(iprod < invmap.n_cols)
       invmap.shed_cols(iprod, invmap.n_cols-1);
   }
@@ -688,7 +688,7 @@ size_t DensityFit::fill_cholesky(const BasisSet & basis,
   build_shellpair_descriptor(sp_pairs, sp_firsts, sp_sizes);
 
   // Bake the metric into the block storage so the J/K kernels see
-  // L = B_raw * X with identity metric. The on-the-fly form
+  // L = X^T (piv|mu nu) with identity metric. The on-the-fly form
   // (raw integrals + X X^T applied per call) loses precision because
   // X X^T = M^-1 has eigenvalues 1/lambda up to ~1e8-1e11, so forming
   // it explicitly rounds badly; baking X into L sidesteps that.
@@ -996,8 +996,8 @@ arma::vec DensityFit::forceJ_cholesky(const BasisSet & basis, const arma::mat & 
   if(P.n_rows != Nbf || P.n_cols != Nbf)
     throw std::runtime_error("DensityFit::forceJ_cholesky: density matrix dimension mismatch.\n");
 
-  // The blocks store L = B_raw * X (indep-space orthonormal vectors),
-  // so compute_expansion returns d = L^T Pv (with doubling),
+  // The blocks store L = X^T (piv|mu nu) (indep-space orthonormal
+  // vectors), so compute_expansion returns d = L^T Pv (with doubling),
   // which is the indep-space expansion. The force algebra is in
   // pivot space: c_raw = X * d gives the pivot-space coefficient
   // that goes against M, dM/dR and the 3-center derivatives, the
@@ -1434,7 +1434,7 @@ void DensityFit::accumulate_K_from_blocks(const arma::Mat<T> & C, const arma::ve
       // K_uv = (a|ui) (a|b)^-1 (b|vi); ab_invh is the canonical-orth
       // half-inverse X with X^T (a|b) X = I, so (a|b)^{-1} ≈ X X^T
       // and the half-transform is X^T aui. In CD mode the blocks are
-      // already L = X^T B_raw, so aui = sum_munu L C is the
+      // already L = X^T (piv|mu nu), so aui = sum_munu L C is the
       // half-transform directly -- no X^T multiply (ab_invh is empty).
       if(!cholesky_mode)
         aui = ab_invh.t() * aui;
@@ -1503,7 +1503,7 @@ arma::vec DensityFit::compute_expansion(const arma::mat & P) const {
     project_density_to_aux(P,ip,blocks->get_block(ip),gamma);
 #endif
 
-  // CD mode: the L blocks already carry the metric (L = X^T B_raw),
+  // CD mode: the L blocks already carry the metric (L = X^T (piv|mu nu)),
   // so the projection gamma_j = sum_munu L_{j,munu} P_munu is the
   // indep-space expansion directly -- no (a|b)^-1 multiply.
   if(cholesky_mode)
@@ -1751,7 +1751,7 @@ void DensityFit::B_matrix(arma::mat & B) const {
   // cached or direct mode; the latter recomputes the shellpair
   // blocks on demand via libint inside the iteration. In DF mode
   // ab_invh is the metric half-inverse; in CD mode the blocks are
-  // already L = X^T B_raw (metric baked in, ab_invh empty), so the
+  // already L = X^T (piv|mu nu) (metric baked in, ab_invh empty), so the
   // three-center integrals are the final B with no extra multiply.
   three_center_integrals(B);
   if(!cholesky_mode)

--- a/src/density_fitting.h
+++ b/src/density_fitting.h
@@ -116,8 +116,7 @@ class DensityFit {
   /// True when this object was filled via fill_cholesky. CD and DF
   /// share the same J/K machinery; the only thing this flag affects
   /// is which gradient path is available (forceJ for DF aux shells,
-  /// forceJ_cholesky for pivot-orbital-pair "aux") and the pivot
-  /// machinery exposed via get_pivot_shellpairs().
+  /// forceJ_cholesky for pivot-orbital-pair "aux").
   bool cholesky_mode;
 
   /// CD-only half-inverse X = D^-1 X~ of the pivot metric M=(piv|piv).
@@ -141,9 +140,9 @@ class DensityFit {
   /// the dM/dR sweep in forceJ_cholesky without re-sorting per call.
   std::vector<std::pair<size_t, size_t>> cd_pivot_shellpairs_vec;
 
-  /// Pivot shellpairs (set form) populated by fill_cholesky. Exposed
-  /// via get_pivot_shellpairs() for basistool / basislibrary atom-CD
-  /// aux basis construction.
+  /// Pivot shellpairs (set form) populated by fill_cholesky via
+  /// select_two_step_pivots; copied into cd_pivot_shellpairs_vec to
+  /// drive the metric build and the force sweeps.
   std::set<std::pair<size_t, size_t>> pivot_shellpairs;
 
   /// Form screening matrix


### PR DESCRIPTION
Comment-only cleanup (no code change; builds clean).

The two-step CD pivot path was reworked across several commits — the ERIchol→DensityFit merge, active-set screening, compact-scratch storage, and the B_raw-free cached fill ([#126](https://github.com/susilehtola/erkale/pull/126), [#128](https://github.com/susilehtola/erkale/pull/128)) — which left a handful of comments pointing at code that no longer exists:

- **`density_fitting.h`** — two doc comments still described the pivot set as "exposed via `get_pivot_shellpairs()`"; that accessor was removed (the set is internal now, copied into `cd_pivot_shellpairs_vec`).
- **`select_two_step_pivots`** — the `invmap`-trim comment referenced "the cached `B_raw` scatter", which was removed in the B_raw-free fill; it now points at the real consumer (`Nprod = invmap.n_cols`).
- **J/K/force kernels + `DirectCDBlocks`** — the L-baked blocks were written as `L = X^T B_raw` / `L = B_raw * X`, but there is no longer any `B_raw` variable (both cached and direct build blocks via `DirectCDBlocks`). Restated in terms of the integrals: `L = X^T (piv|mu nu)`. The single remaining `B_raw` mention is deliberate — it explains what the B_raw-free fill *no longer* forms.

Verified `Edmiston` still holds `DensityFit` by value, so the `shared_ptr` rationale comment is accurate and left as-is; and confirmed no `ERIchol`/one-step/`cholincore` references survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)