### PR TITLE
NEO-SCF HDF5 integral dump for post-SCF correlation; OpenOrbitalOptimizer Eigen shim

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Resolve dependencies
-        run: sudo apt-get update && sudo apt-get install -y libarmadillo-dev cmake gfortran libgsl-dev libxc-dev libint1 libint-dev libhdf5-serial-dev
+        run: sudo apt-get update && sudo apt-get install -y libarmadillo-dev libeigen3-dev cmake gfortran libgsl-dev libxc-dev libint1 libint-dev libhdf5-serial-dev
 
       - name: Compile
         run: mkdir build && cd build && cmake -E env CXXFLAGS="-DARMA_DONT_USE_WRAPPER" cmake .. && make -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,11 +128,11 @@ message("")
 # Find libwignernj for Wigner 3j symbols. If a system install is not
 # present, fetch and build from source. Either path exposes the
 # wignernj::wignernj imported target.
-find_package(wignernj 0.5.0 QUIET CONFIG)
+find_package(wignernj 0.7.0 QUIET CONFIG)
 if(wignernj_FOUND)
  message("Found libwignernj ${wignernj_VERSION}: ${wignernj_DIR}")
 else()
- message("libwignernj not found; fetching v0.5.0 from GitHub.")
+ message("libwignernj not found; fetching v0.7.0 from GitHub.")
  include(FetchContent)
  # Disable libwignernj's own tests / examples / extra interfaces so the
  # subbuild only produces the C library we link against.
@@ -143,7 +143,7 @@ else()
  FetchContent_Declare(
    wignernj
    GIT_REPOSITORY https://github.com/susilehtola/libwignernj.git
-   GIT_TAG        v0.5.0
+   GIT_TAG        v0.7.0
  )
  FetchContent_MakeAvailable(wignernj)
  # FetchContent's add_subdirectory only exposes the bare "wignernj"

--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -1,0 +1,211 @@
+# `neo_dump.h5` — NEO-SCF export format
+
+A self-describing HDF5 dump of a **converged ERKALE NEO-SCF** (nuclear-electronic
+orbital SCF), produced by `erkale_neo` when the `NEODump` keyword is set. It
+contains everything a post-SCF correlation code (e.g. a spin-orbital NEO-CCSD
+driver) needs: AO basis dimensions, MO coefficients, orbital energies, core and
+Fock matrices, and the **bare AO two-particle integrals** (electron-electron,
+proton-proton, electron-proton).
+
+All quantities are in **Hartree atomic units**. Everything is in the **AO basis**
+except `C` / `eps` (MO quantities). The downstream code performs the AO→MO
+transformation and the spin-orbital construction itself; ERKALE's side is a pure
+export.
+
+Supported: **restricted (RHF) and unrestricted (UHF) electrons**, one or more
+**quantum protons** (point nuclei). See *Limitations* for what is out of scope.
+
+---
+
+## 1. Conventions (read this first — the whole contract lives here)
+
+### 1.1 Integral convention
+
+All two-particle integrals use the **chemist (charge-cloud) convention** `(pq|rs)`,
+the **bare (positive) Coulomb** integral over the real AO basis functions:
+
+```
+(pq | rs)  =  ∫∫  φ_p(r1) φ_q(r1)  (1 / |r1 - r2|)  φ_r(r2) φ_s(r2)  dr1 dr2
+```
+
+- Operator is the bare `1/r12`. **No charge factors and no sign are applied** — every
+  stored integral is a positive Coulomb integral. Charge signs (electron `-1`,
+  proton `+1`, or any other quantum species such as `µ⁻`) are the consumer's job.
+- `p,q` share coordinate `r1`; `r,s` share `r2`.
+- Basis functions are ERKALE's real solid-harmonic Gaussians, in the same AO order
+  used by every matrix/tensor in this file. Treat the AO index as an opaque,
+  self-consistent label.
+
+Recorded in `/meta` as `integral_convention = "chemist (pq|rs)"`.
+
+### 1.2 Storage / index order (CRITICAL)
+
+Every array is written **C / row-major**, so an `h5py`/NumPy reader gets the natural
+shape with **no transpose**: a dataset declared `(d0,d1,…)` reads back as `A` with
+`A[i,j,…] = M(i,j,…)`. (ERKALE's internal `.chk` writer is column-major; this dump
+deliberately is not — do not assume the `.chk` convention here.)
+
+### 1.3 Two-particle integral representation
+
+Selected by `/meta:integral_representation`:
+
+**`"btensor"` (default).** The per-species integrals are stored *factorized*, exactly
+as the SCF's density-fitting / Cholesky engine used them:
+
+| Dataset       | Shape (C-order)        | Reconstruction |
+|---------------|------------------------|----------------|
+| `electron/B`  | `(naux_e, nbf_e, nbf_e)` | `(μν\|λσ) = Σ_P B[P,μ,ν]·B[P,λ,σ]` |
+| `proton/B`    | `(naux_p, nbf_p, nbf_p)` | `(ab\|cd)  = Σ_P B[P,a,b]·B[P,c,d]` |
+
+For density fitting `B = (μν|P)·V^{-1/2}` (metric `V=(P|Q)` of the shared aux basis);
+for Cholesky `B = L` are the Cholesky vectors. The fit dimension `naux` (=
+`/meta:naux_e`, `naux_p`) is the number of aux/Cholesky vectors and may differ
+between species.
+
+**`"dense"`.** The per-species integrals are stored as full rank-4 tensors:
+
+| Dataset    | Shape (C-order)                 | Element |
+|------------|---------------------------------|---------|
+| `eri_ee`   | `(nbf_e,nbf_e,nbf_e,nbf_e)`     | `(μν\|λσ)` |
+| `eri_pp`   | `(nbf_p,nbf_p,nbf_p,nbf_p)`     | `(ab\|cd)` |
+
+These are reconstructed from the same engine factors (`= Σ_P B·B`), i.e. they carry
+the SCF's fitting/Cholesky approximation, not a separate exact recomputation.
+
+**Electron-proton — always dense, in both representations:**
+
+| Dataset  | Shape (C-order)              | Element |
+|----------|------------------------------|---------|
+| `eri_ep` | `(nbf_e,nbf_e,nbf_p,nbf_p)`  | `(μν\|ab)`, electrons on `r1`, protons on `r2`, **bare positive** |
+
+(In DF mode the SCF shares one aux basis, so `(μν|ab)=Σ_P B_e[P,μν]B_p[P,ab]`; in CD
+mode the species have independent Cholesky spaces and the SCF computes e-p
+*exactly* — so `eri_ep` is dumped dense to stay engine-consistent either way.)
+
+### 1.4 MO ordering and occupations
+
+- MOs in `C`/`eps` are **energy-ordered** (aufbau): occupied first, then virtual.
+- `nmo ≤ nbf`: linearly dependent AO directions are removed by canonical
+  orthogonalization, so `C` is `(nbf, nmo)` with no padding.
+- Occupation vectors are **not stored** — they follow from `nocc` and the species rule:
+
+| Species block        | occ per occupied MO | `nocc` | density `D` |
+|----------------------|---------------------|--------|-------------|
+| electrons, RHF       | `2.0`               | `n_electrons/2` | `2·C[:,:nocc]C[:,:nocc]ᵀ` |
+| electrons α / β, UHF | `1.0`               | `n_α` / `n_β`    | `C[:,:nocc]C[:,:nocc]ᵀ` |
+| protons (high-spin)  | `1.0`               | `n_quantum_protons` | `C[:,:nocc]C[:,:nocc]ᵀ` |
+
+`proton_spin_treatment = "high-spin"`: protons occupy a single spin block (one per
+spatial orbital, full p-p exchange) — a fully spin-polarized determinant of identical
+fermions. For one proton the p-p Coulomb+exchange self-interaction cancels exactly.
+
+### 1.5 Sign of the electron-proton interaction
+
+`eri_ep` is the **bare, positive** `(μν|ab)`. The physical interaction is attractive
+(opposite charges); the dump does **not** apply that sign. The CC Hamiltonian
+multiplies by `q_e·q_p = -1`:
+
+```
+E_ep  =  - Σ_{μν∈e}  Σ_{ab∈p}   eri_ep[μ,ν,a,b] · D^e[μ,ν] · D^p[a,b]
+```
+
+The `fock` matrices in this file *do* already include the mean-field e-p attraction
+with its `-` sign (they are the converged SCF Fock matrices — §2.3); only the raw
+`eri_ep` tensor is sign-free.
+
+---
+
+## 2. File layout
+
+### 2.1 `/meta` (root-group attributes)
+
+| Attribute                  | Type   | Meaning |
+|----------------------------|--------|---------|
+| `units`                    | string | `"Hartree atomic units"` |
+| `integral_convention`      | string | `"chemist (pq|rs)"` (§1.1) |
+| `integral_representation`  | string | `"btensor"` or `"dense"` (§1.3) |
+| `ao_or_mo`                 | string | `"AO"` |
+| `storage_order`            | string | `"C (row-major)"` |
+| `n_electrons`              | int    | total electrons |
+| `restricted_electrons`     | bool   | `true` = RHF (one electron set); `false` = UHF (α/β sets) |
+| `n_quantum_protons`        | int    | number of quantum protons |
+| `proton_spin_treatment`    | string | `"high-spin"` |
+| `proton_mass`              | double | proton mass (atomic units) scaling the nuclear kinetic operator |
+| `naux_e`                   | int    | electron fit dimension (only in `btensor` mode) |
+| `naux_p`                   | int    | proton fit dimension (only in `btensor` mode) |
+| `e_scf`                    | double | converged NEO-SCF total energy printed by ERKALE |
+| `e_classical`              | double | Coulomb repulsion among the *classical* (non-quantum) nuclei only |
+| `erkale_version`           | string | ERKALE version / git description |
+
+`e_classical` excludes quantum protons; their coupling to classical nuclei is a
+one-particle term in `proton/hcore`, and to electrons it is `eri_ep`. No other
+constants.
+
+### 2.2 `/electron` and `/proton` (groups)
+
+Common datasets:
+
+| Dataset | Shape         | Notes |
+|---------|---------------|-------|
+| `nbf`   | scalar int    | AO basis functions |
+| `B`     | `(naux,nbf,nbf)` | engine factor — `btensor` mode only (§1.3) |
+
+Electron group, **RHF** (`restricted_electrons = true`):
+
+| Dataset | Shape        | Notes |
+|---------|--------------|-------|
+| `nmo`,`nocc` | scalar int | `nocc = n_electrons/2` |
+| `C`     | `(nbf,nmo)`  | AO→MO, energy-ordered |
+| `eps`   | `(nmo,)`     | MO energies |
+| `hcore` | `(nbf,nbf)`  | one-particle core (§2.3) |
+| `fock`  | `(nbf,nbf)`  | converged Fock (§2.3) |
+
+Electron group, **UHF** (`restricted_electrons = false`): the same, suffixed `_a`/`_b`
+— `nmo_a/nmo_b`, `nocc_a/nocc_b`, `C_a/C_b`, `eps_a/eps_b`, `hcore` (spin-independent,
+single copy), `fock_a/fock_b`.
+
+Proton group: `nmo`, `nocc` (`= n_quantum_protons`), `C`, `eps`, `hcore`, `fock`.
+
+### 2.3 What `hcore` and `fock` contain
+
+- **Electron `hcore`** `= T_e + V_e(classical)` — kinetic + attraction to the
+  *classical* nuclei only. The e-p attraction is **not** here (two-particle, via
+  `eri_ep`).
+- **Proton `hcore`** `= T_p/m_p + V_p(classical)` — mass-scaled kinetic + repulsion
+  from classical nuclei (`+` sign for the positive test charge), `m_p = proton_mass`.
+- **`fock`** is the converged self-consistent AO Fock with all mean-field two-particle
+  terms at their physical signs (including the `-` e-p attraction). Its generalized
+  eigenvalues with the AO overlap equal `eps`. Per species:
+  `fock_e = hcore_e + J_ee[D^e] − ½K_ee[D^e] − J_ep[D^p]` (RHF; UHF uses
+  `J_ee[D^e] − K_ee[D^{σ}]` per spin), `fock_p = hcore_p + J_pp[D^p] − K_pp[D^p]
+  − J_pe[D^e]`, where `J_ep`/`J_pe` denote the (positive) Coulomb fields and the `−`
+  is the attraction.
+
+---
+
+## 3. Energy reconstruction (self-consistency check)
+
+```
+E = Σ_species [ Tr(D h) + ½ Tr(D J[D]) − c_x Tr(D K[D]) ]
+    − Σ_{μν∈e, ab∈p} eri_ep[μ,ν,a,b] · D^e[μν] · D^p[ab]
+    + e_classical
+```
+
+with `J[D]_pq = Σ_rs (pq|rs) D_rs`, `K[D]_pq = Σ_rs (pr|qs) D_rs`, densities from
+§1.4, and `c_x = ¼` for RHF electrons (total density, occ 2), `c_x = ½` for each UHF
+spin and for the high-spin protons. The `(pq|rs)` come from `eri_xx` (`dense`) or are
+reconstructed from `B` (`btensor`).
+
+`erkale_neo` with `NEODumpVerify true` reconstructs `E` from the on-disk tensors and
+asserts agreement with `e_scf`. Because the dumped integrals match the SCF's own
+engine (B-tensors / engine-reconstructed dense, and an engine-consistent `eri_ep`),
+the residual is at the SCF convergence level (≈ `1e-9`) for both RI and Cholesky.
+
+---
+
+## 4. Limitations
+
+- **Point protons only.** `FiniteProton` (range-separated / Gaussian nucleus) is not
+  exported — the e-p operator would be screened, not bare `1/r12`. The writer throws.
+- **Dense `eri_ep` / dense mode.** No permutational-symmetry packing — intended for
+  small systems (one/two quantum protons, modest electronic basis).

--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -145,20 +145,27 @@ constants.
 
 Common datasets:
 
-| Dataset | Shape         | Notes |
-|---------|---------------|-------|
-| `nbf`   | scalar int    | AO basis functions |
-| `B`     | `(naux,nbf,nbf)` | engine factor — `btensor` mode only (§1.3) |
+| Dataset   | Shape         | Notes |
+|-----------|---------------|-------|
+| `nbf`     | scalar int    | AO basis functions |
+| `overlap` | `(nbf,nbf)`   | AO overlap `S` — the metric this species' AO basis lives in |
+| `B`       | `(naux,nbf,nbf)` | engine factor — `btensor` mode only (§1.3) |
 
 Electron group, **RHF** (`restricted_electrons = true`):
 
 | Dataset | Shape        | Notes |
 |---------|--------------|-------|
 | `nmo`,`nocc` | scalar int | `nocc = n_electrons/2` |
-| `C`     | `(nbf,nmo)`  | AO→MO, energy-ordered |
-| `eps`   | `(nmo,)`     | MO energies |
+| `C`     | `(nbf,nmo)`  | canonical AO→MO, energy-ordered (§2.3) |
+| `eps`   | `(nmo,)`     | canonical MO energies |
 | `hcore` | `(nbf,nbf)`  | one-particle core (§2.3) |
 | `fock`  | `(nbf,nbf)`  | converged Fock (§2.3) |
+
+`C`/`eps` are the **canonical** orbitals: the writer diagonalizes the stored
+`fock` in the `overlap` metric, so they satisfy `F C = S C diag(eps)`,
+`Cᵀ S C = I`, `Cᵀ F C = diag(eps)` (validated at write time, residuals printed).
+`nocc` is the integer particle count of the block (occupied = lowest `nocc`
+canonical orbitals).
 
 Electron group, **UHF** (`restricted_electrons = false`): the same, suffixed `_a`/`_b`
 — `nmo_a/nmo_b`, `nocc_a/nocc_b`, `C_a/C_b`, `eps_a/eps_b`, `hcore` (spin-independent,
@@ -173,13 +180,20 @@ Proton group: `nmo`, `nocc` (`= n_quantum_protons`), `C`, `eps`, `hcore`, `fock`
   `eri_ep`).
 - **Proton `hcore`** `= T_p/m_p + V_p(classical)` — mass-scaled kinetic + repulsion
   from classical nuclei (`+` sign for the positive test charge), `m_p = proton_mass`.
-- **`fock`** is the converged self-consistent AO Fock with all mean-field two-particle
-  terms at their physical signs (including the `-` e-p attraction). Its generalized
-  eigenvalues with the AO overlap equal `eps`. Per species:
+- **Electron `fock`** is the converged self-consistent AO Fock with all mean-field
+  two-particle terms at their physical signs (including the `−` e-p attraction):
   `fock_e = hcore_e + J_ee[D^e] − ½K_ee[D^e] − J_ep[D^p]` (RHF; UHF uses
-  `J_ee[D^e] − K_ee[D^{σ}]` per spin), `fock_p = hcore_p + J_pp[D^p] − K_pp[D^p]
-  − J_pe[D^e]`, where `J_ep`/`J_pe` denote the (positive) Coulomb fields and the `−`
-  is the attraction.
+  `J_ee[D^e] − K_ee[D^{σ}]` per spin). Its generalized eigenvalues in `overlap`
+  equal `eps`, and `C` are the eigenvectors (§2.2).
+- **Proton `fock`** is the **self-interaction-free** one-particle-per-orbital
+  operator `fock_p = hcore_p − J_pe[D^e]` (kinetic + classical-nucleus repulsion +
+  the electron mean-field attraction `−J_pe`), with **no** proton–proton `J_p/K_p`.
+  A single quantum proton has no proton–proton interaction; including its own
+  Coulomb/exchange leaves the occupied orbital and the total SCF energy unchanged
+  but spuriously unbinds the proton virtuals. Excluding it gives a physically bound
+  proton spectrum (occupied + virtual `eps` below the free-proton dissociation
+  threshold), which is what the CC consumer needs. The proton–proton interaction,
+  if needed, is available exactly from `proton/B` (`eri_pp`).
 
 ---
 

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -171,7 +171,19 @@ if(OPENORBITAL_HEADER)
       PATH_SUFFIXES eigen3 include/eigen3)
   endif()
   if(NOT EIGEN3_INCLUDE_DIR)
-    message(FATAL_ERROR "Eigen3 headers not found, but needed by OpenOrbitalOptimizer for the NEO and complex-orbital targets. Set -DEIGEN3_INCLUDE_DIR=/path/to/eigen3")
+    # Header-only; fetch when no system copy is found, like openorbitaloptimizer
+    # and libwignernj. Populate-only -- we just need the include directory.
+    message(STATUS "Eigen3 not found locally; fetching v3.4.0 from GitLab (header-only).")
+    include(FetchContent)
+    FetchContent_Declare(eigen3
+      GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
+      GIT_TAG        3.4.0
+      GIT_SHALLOW    TRUE)
+    FetchContent_GetProperties(eigen3)
+    if(NOT eigen3_POPULATED)
+      FetchContent_Populate(eigen3)
+    endif()
+    set(EIGEN3_INCLUDE_DIR "${eigen3_SOURCE_DIR}")
   endif()
   message(STATUS "Eigen3 headers for OpenOrbitalOptimizer targets: ${EIGEN3_INCLUDE_DIR}")
 

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -156,7 +156,27 @@ endif()
 if(OPENORBITAL_HEADER)
   message(STATUS "openorbitaloptimizer headers: ${OPENORBITAL_HEADER}; building NEO targets")
 
+  # OpenOrbitalOptimizer is Eigen-based, so the targets need Eigen3
+  # headers even though ERKALE uses Armadillo: the drivers use OOO's
+  # Armadillo compatibility shim (openorbitaloptimizer/armadillo_compat.hpp,
+  # OpenOrbitalOptimizer::Armadillo::), which converts at the solver
+  # boundary and pulls in Eigen.
+  find_package(Eigen3 QUIET NO_MODULE)
+  if(TARGET Eigen3::Eigen)
+    get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+  if(NOT EIGEN3_INCLUDE_DIR)
+    find_path(EIGEN3_INCLUDE_DIR Eigen/Core
+      HINTS ${EIGEN3_ROOT_DIR} ${EIGEN3_ROOT} /usr/include /usr/local/include
+      PATH_SUFFIXES eigen3 include/eigen3)
+  endif()
+  if(NOT EIGEN3_INCLUDE_DIR)
+    message(FATAL_ERROR "Eigen3 headers not found, but needed by OpenOrbitalOptimizer for the NEO and complex-orbital targets. Set -DEIGEN3_INCLUDE_DIR=/path/to/eigen3")
+  endif()
+  message(STATUS "Eigen3 headers for OpenOrbitalOptimizer targets: ${EIGEN3_INCLUDE_DIR}")
+
   add_executable (erkale_neo neo.cpp neo_dump.cpp)
+  target_include_directories(erkale_neo PUBLIC "${EIGEN3_INCLUDE_DIR}")
   set_target_properties(erkale_neo PROPERTIES OUTPUT_NAME "erkale_neo${SUFFIX}")
   target_include_directories(erkale_neo PUBLIC "${OPENORBITAL_HEADER}")
   target_link_libraries(erkale_neo liberkale_cmp)
@@ -174,6 +194,7 @@ if(OPENORBITAL_HEADER)
   add_executable (erkale_neosp neosp.cpp)
   set_target_properties(erkale_neosp PROPERTIES OUTPUT_NAME "erkale_neosp${SUFFIX}")
   target_include_directories(erkale_neosp PUBLIC "${OPENORBITAL_HEADER}")
+  target_include_directories(erkale_neosp PUBLIC "${EIGEN3_INCLUDE_DIR}")
   target_link_libraries(erkale_neosp liberkale_cmp)
   target_link_libraries(erkale_neosp liberkale_emd)
   target_link_libraries(erkale_neosp liberkale)
@@ -204,6 +225,7 @@ if(OPENORBITAL_HEADER)
   add_executable (erkale_complex_orbs complex_orbs.cpp)
   set_target_properties(erkale_complex_orbs PROPERTIES OUTPUT_NAME "erkale_complex_orbs${SUFFIX}")
   target_include_directories(erkale_complex_orbs PUBLIC "${OPENORBITAL_HEADER}")
+  target_include_directories(erkale_complex_orbs PUBLIC "${EIGEN3_INCLUDE_DIR}")
   target_link_libraries(erkale_complex_orbs liberkale_cmp)
   target_link_libraries(erkale_complex_orbs liberkale_emd)
   target_link_libraries(erkale_complex_orbs liberkale)

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -156,7 +156,7 @@ endif()
 if(OPENORBITAL_HEADER)
   message(STATUS "openorbitaloptimizer headers: ${OPENORBITAL_HEADER}; building NEO targets")
 
-  add_executable (erkale_neo neo.cpp)
+  add_executable (erkale_neo neo.cpp neo_dump.cpp)
   set_target_properties(erkale_neo PROPERTIES OUTPUT_NAME "erkale_neo${SUFFIX}")
   target_include_directories(erkale_neo PUBLIC "${OPENORBITAL_HEADER}")
   target_link_libraries(erkale_neo liberkale_cmp)

--- a/src/contrib/complex_orbs.cpp
+++ b/src/contrib/complex_orbs.cpp
@@ -319,7 +319,7 @@ int main_guarded(int argc, char **argv) {
     return P;
   };
 
-  OpenOrbitalOptimizer::FockBuilder<double, double> restricted_fock_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> restricted_fock_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
 
@@ -365,7 +365,7 @@ int main_guarded(int argc, char **argv) {
   }; //restricted Fock builder
 
 
-  OpenOrbitalOptimizer::FockBuilder<double, double> unrestricted_fock_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> unrestricted_fock_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
 
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
@@ -446,7 +446,7 @@ int main_guarded(int argc, char **argv) {
   }; //unrestricted Fock builder
 
   // Save matrices to disk
-  std::function<void(const OpenOrbitalOptimizer::FockMatrix<double> &)> save_matrices = [&](const OpenOrbitalOptimizer::FockMatrix<double> fock) {
+  std::function<void(const OpenOrbitalOptimizer::Armadillo::FockMatrix<double> &)> save_matrices = [&](const OpenOrbitalOptimizer::Armadillo::FockMatrix<double> fock) {
 
     if(!unrestricted) {
       for (size_t m=0; m<X.size(); m++) {
@@ -496,7 +496,7 @@ int main_guarded(int argc, char **argv) {
   arma::vec number_of_particles;
   arma::vec number_of_particles_per_block;
   std::vector<std::string> block_descriptions;
-  OpenOrbitalOptimizer::FockBuilder<double, double> fock_builder;
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> fock_builder;
 
   // Run SCF
   if (!unrestricted) {
@@ -528,7 +528,7 @@ int main_guarded(int argc, char **argv) {
 
   printf("\n\n\nSolving SCF\n");
   fflush(stdout);
-  OpenOrbitalOptimizer::SCFSolver scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
+  OpenOrbitalOptimizer::Armadillo::SCFSolver<double,double> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
   if (readlinocc < 0)
     scfsolver.fixed_number_of_particles_per_block(number_of_particles_per_block);
   scfsolver.initialize_with_fock(Fguess);

--- a/src/contrib/complex_orbs.cpp
+++ b/src/contrib/complex_orbs.cpp
@@ -108,6 +108,8 @@ int main_guarded(int argc, char **argv) {
   int readlinocc = settings.get_int("LinearOccupations");
   std::string linoccfname = settings.get_string("LinearOccupationFile");
   double linB = settings.get_double("LinearB");
+  double linE = settings.get_double("LinearE");
+  double confinement = settings.get_double("Confinement");
   bool unrestricted = !(settings.get_bool("Restricted"));
   bool density_fitting = settings.get_bool("DensityFitting");
   std::string guess = settings.get_string("Guess");
@@ -271,17 +273,33 @@ int main_guarded(int argc, char **argv) {
     return std::make_pair(C, occs);
   };
 
+  // One-electron field operator added to the Fock matrix. Collects the
+  // magnetic terms (orbital Zeeman -1/2 B L_z, diamagnetic 1/8 B^2 (x^2+y^2)),
+  // the electric dipole (E z along the bond axis), and an optional harmonic
+  // confinement (1/2 k r^2). z preserves L_z, so the m-block structure is kept;
+  // it mixes l within a block, which is what polarizes the density. The
+  // confinement is an artificial regulariser (a static field has no bound
+  // ground state) -- leave it off (k=0) for weak fields with a non-diffuse
+  // basis; turn it on to prevent variational collapse toward the continuum.
   arma::mat Bterms(Nbf, Nbf, arma::fill::zeros);
-  if (linB) {
+  if (linB || linE || confinement) {
     double cenx = 0.0, ceny = 0.0, cenz = 0.0;
+    std::vector<arma::mat> dip = basis.moment(1, cenx, ceny, cenz);
     std::vector<arma::mat> momstack = basis.moment(2, cenx, ceny, cenz);
     arma::mat xymat = momstack[getind(2, 0, 0)] + momstack[getind(0, 2, 0)];
+    arma::mat zmat = dip[getind(0, 0, 1)];
+    arma::mat r2mat = xymat + momstack[getind(0, 0, 2)];
     const auto & Smat = complexbas ? S_c : S;
     if(complexbas) {
       xymat = arma::real(D.t()*xymat*D);
+      zmat = arma::real(D.t()*zmat*D);
+      r2mat = arma::real(D.t()*r2mat*D);
     }
     for (size_t j = 0; j < Nbf; j++)
-      Bterms.col(j) = -0.5 * linB * mvals(j) * Smat.col(j) + 0.125 * linB * linB * xymat.col(j);
+      Bterms.col(j) = -0.5 * linB * mvals(j) * Smat.col(j)   // orbital Zeeman
+        + 0.125 * linB * linB * xymat.col(j)                 // diamagnetic
+        + linE * zmat.col(j)                                 // electric dipole
+        + 0.5 * confinement * r2mat.col(j);                  // harmonic confinement
   }
 
   std::function<std::tuple<arma::mat, arma::mat, arma::cx_mat>(const std::vector<arma::mat> orbitals, const std::vector<arma::vec> & occupations)> electronic_terms = [&](const auto & orbitals, const auto & occupations) {
@@ -356,7 +374,7 @@ int main_guarded(int argc, char **argv) {
       printf("e-e Coulomb energy          % .10f\n", Ecoul);
       printf("e-e exchange energy         % .10f\n", Eexch);
       printf("nuclear repulsion energy    % .10f\n", Enucr);
-      printf("magnetic interaction energy % .10f\n", Emag);
+      printf("field interaction energy    % .10f\n", Emag);
       printf("Total energy                % .10f\n", Etot);
       fflush(stdout);
     }
@@ -437,7 +455,7 @@ int main_guarded(int argc, char **argv) {
       printf("e-e Coulomb energy          % .10f\n", Ecoul);
       printf("e-e exchange energy         % .10f\n", Eexch);
       printf("nuclear repulsion energy    % .10f\n", Enucr);
-      printf("magnetic interaction energy % .10f\n", Emag);
+      printf("field interaction energy    % .10f\n", Emag);
       printf("Total energy                % .10f\n", Etot);
       fflush(stdout);
     }

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -1188,10 +1188,16 @@ int main_guarded(int argc, char **argv) {
         Focke.push_back(hcore_e + Ja + Jb + Kb + Jpe);
       }
       arma::mat hcore_p = Tp + Vpc;
-      arma::mat Jp, Kp;
-      std::tie(Jp, Kp) = protonic_terms(Cp_ao, occp);
       arma::mat Jep = electron_proton_coulomb(De);
-      arma::mat Fock_p = hcore_p + Jp + Kp + Jep;
+      // Self-interaction-free proton Fock for the correlation consumer:
+      // kinetic + classical-nucleus attraction + the electron mean-field
+      // attraction only. The proton-proton J_p/K_p are deliberately excluded
+      // (a single quantum proton has no proton-proton interaction; including
+      // it leaves the occupied orbital unchanged but spuriously unbinds the
+      // proton virtuals). The total SCF energy and the dumped p-p B-tensor are
+      // unaffected -- this only sets the reference operator whose canonical
+      // orbitals/energies are written.
+      arma::mat Fock_p = hcore_p + Jep;
 
 #ifdef SVNRELEASE
       std::string version(SVNREVISION);

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -31,6 +31,7 @@
 #include "stringutil.h"
 #include "timer.h"
 #include "density_fitting.h"
+#include "neo_dump.h"
 
 // Needed for libint init
 #include "eriworker.h"
@@ -109,6 +110,9 @@ int main_guarded(int argc, char **argv) {
   settings.add_string("LoadChk", "Checkpoint file to load from", "");
   settings.add_bool("FiniteProton", "Use a finite proton model", false);
   settings.add_bool("vpp", "Include JK terms for protons?", true);
+  settings.add_string("NEODump", "Dump converged NEO-SCF to this HDF5 file for post-SCF correlation codes (empty = off)", "");
+  settings.add_string("NEODumpIntegrals", "Integral representation in NEODump: btensor (engine CD/RI factors) or dense", "btensor");
+  settings.add_bool("NEODumpVerify", "Reconstruct the energy from the NEODump tensors and check it against the SCF energy", true);
 
   // Parse settings
   settings.parse(std::string(argv[1]),true);
@@ -1137,6 +1141,69 @@ int main_guarded(int argc, char **argv) {
       save_electron_matrices(std::make_pair(std::vector<arma::mat>({dm.first[0]}),std::vector<arma::vec>({dm.second[0]})), std::vector<arma::mat>({fock[0]}));
     } else {
       save_electron_matrices(std::make_pair(std::vector<arma::mat>({dm.first[0],dm.first[1]}),std::vector<arma::vec>({dm.second[0],dm.second[1]})), std::vector<arma::mat>({fock[0],fock[1]}));
+    }
+
+    // Optional export of the converged NEO-SCF for an external correlation code
+    std::string neodump = settings.get_string("NEODump");
+    if(neodump.size()) {
+      if(!vpp)
+        throw std::runtime_error("NEODump requires vpp=true: the proton-proton integrals are part of the dump.\n");
+
+      bool restricted_e = (M==1);
+      size_t Nmat = fock.size();
+
+      // Proton block (last) in the AO basis
+      arma::mat Cp_ao = Xp * dm.first[Nmat-1];
+      arma::vec occp = dm.second[Nmat-1];
+      arma::vec Ep = arma::diagvec(dm.first[Nmat-1].t() * fock[Nmat-1] * dm.first[Nmat-1]);
+      arma::mat Dp = Cp_ao * arma::diagmat(occp) * Cp_ao.t();
+
+      // Electron block(s) in the AO basis + total electron density
+      std::vector<arma::mat> Ce, Focke;
+      std::vector<arma::vec> occe_v, Ee_v;
+      arma::mat De(X.n_rows, X.n_rows, arma::fill::zeros);
+      size_t nblk = restricted_e ? 1 : 2;
+      for(size_t s=0;s<nblk;s++) {
+        arma::mat Cs = X * dm.first[s];
+        arma::vec os = dm.second[s];
+        Ce.push_back(Cs);
+        occe_v.push_back(os);
+        Ee_v.push_back(arma::diagvec(dm.first[s].t() * fock[s] * dm.first[s]));
+        De += Cs * arma::diagmat(os) * Cs.t();
+      }
+
+      // AO Fock matrices, rebuilt from the converged densities with the same
+      // engine the SCF used (the lambdas carry the correct K and e-p signs).
+      arma::mat hcore_e = T + Vc;
+      arma::mat Jpe = proton_electron_coulomb(Dp);
+      if(restricted_e) {
+        arma::mat J, K;
+        std::tie(J, K) = electronic_terms(Ce[0], occe_v[0]);
+        Focke.push_back(hcore_e + J + 0.5*K + Jpe);
+      } else {
+        arma::mat Ja, Ka, Jb, Kb;
+        std::tie(Ja, Ka) = electronic_terms(Ce[0], occe_v[0]);
+        std::tie(Jb, Kb) = electronic_terms(Ce[1], occe_v[1]);
+        Focke.push_back(hcore_e + Ja + Jb + Ka + Jpe);
+        Focke.push_back(hcore_e + Ja + Jb + Kb + Jpe);
+      }
+      arma::mat hcore_p = Tp + Vpc;
+      arma::mat Jp, Kp;
+      std::tie(Jp, Kp) = protonic_terms(Cp_ao, occp);
+      arma::mat Jep = electron_proton_coulomb(De);
+      arma::mat Fock_p = hcore_p + Jp + Kp + Jep;
+
+#ifdef SVNRELEASE
+      std::string version(SVNREVISION);
+#else
+      std::string version("unknown");
+#endif
+      neo_dump(neodump, settings.get_string("NEODumpIntegrals"), settings.get_bool("NEODumpVerify"),
+               basis, dfit, restricted_e, Ce, occe_v, Ee_v, hcore_e, Focke,
+               pbasis, pfit, Cp_ao, occp, Ep, hcore_p, Fock_p,
+               Nel, (int) proton_indices.size(), proton_mass,
+               scfsolver.get_energy(), Ecnucr,
+               density_fitting, omega, alpha, beta, version);
     }
   }
 

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -497,7 +497,7 @@ int main_guarded(int argc, char **argv) {
     return density_fitting ? proton_electron_coulomb_ri(Pp) : proton_electron_coulomb_exact(Pp);
   };
 
-  OpenOrbitalOptimizer::FockBuilder<double, double> restricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> restricted_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
 
@@ -539,7 +539,7 @@ int main_guarded(int argc, char **argv) {
     return std::make_pair(Etot,fock);
   };
 
-  OpenOrbitalOptimizer::FockBuilder<double, double> unrestricted_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> unrestricted_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
 
@@ -599,7 +599,7 @@ int main_guarded(int argc, char **argv) {
       }
   };
 
-  OpenOrbitalOptimizer::FockBuilder<double, double> restricted_neo_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> restricted_neo_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
 
@@ -659,7 +659,7 @@ int main_guarded(int argc, char **argv) {
     return std::make_pair(Etot,fock);
   };
 
-  OpenOrbitalOptimizer::FockBuilder<double, double> unrestricted_neo_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> unrestricted_neo_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
     const auto & orbitals = dm.first;
     const auto & occupations = dm.second;
 
@@ -730,7 +730,7 @@ int main_guarded(int argc, char **argv) {
   arma::vec maximum_occupation;
   arma::vec number_of_particles;
   std::vector<std::string> block_descriptions;
-  OpenOrbitalOptimizer::FockBuilder<double, double> fock_builder;
+  OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> fock_builder;
 
   int Nel = basis.Ztot()-Q;
   int Nela = (Nel+M-1)/2;
@@ -743,8 +743,8 @@ int main_guarded(int argc, char **argv) {
     throw std::logic_error("Nelb > Nela, check your charge and multiplicity!\n");
 
   // We will need the density matrices in the calculation
-  OpenOrbitalOptimizer::DensityMatrix<double, double> electronic_dm;
-  OpenOrbitalOptimizer::DensityMatrix<double, double> protonic_dm;
+  OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> electronic_dm;
+  OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> protonic_dm;
 
   // Set up protonic guess
   if(quantum_protons.size()) {
@@ -789,18 +789,18 @@ int main_guarded(int argc, char **argv) {
   }
 
   // Save the matrices to disk
-  std::function<void(const OpenOrbitalOptimizer::DensityMatrix<double,double> &,const OpenOrbitalOptimizer::FockMatrix<double> &)> save_proton_matrices = [&](const OpenOrbitalOptimizer::DensityMatrix<double,double> & pdm, const OpenOrbitalOptimizer::FockMatrix<double> & pfock) {
-    const OpenOrbitalOptimizer::Orbitals<double> & porbitals = pdm.first;
-    const OpenOrbitalOptimizer::OrbitalOccupations<double> & poccupations = pdm.second;
+  std::function<void(const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double,double> &,const OpenOrbitalOptimizer::Armadillo::FockMatrix<double> &)> save_proton_matrices = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double,double> & pdm, const OpenOrbitalOptimizer::Armadillo::FockMatrix<double> & pfock) {
+    const OpenOrbitalOptimizer::Armadillo::Orbitals<double> & porbitals = pdm.first;
+    const OpenOrbitalOptimizer::Armadillo::OrbitalOccupations<double> & poccupations = pdm.second;
     arma::mat Cp = Xp*porbitals[0];
     arma::vec Ep = arma::diagvec(porbitals[0].t()*pfock[0]*porbitals[0]);
     chkpt.write("Cp",Cp);
     chkpt.write("Ep",Ep);
   };
 
-  std::function<void(const OpenOrbitalOptimizer::DensityMatrix<double,double> &,const OpenOrbitalOptimizer::FockMatrix<double> &)> save_electron_matrices = [&](const OpenOrbitalOptimizer::DensityMatrix<double,double> & eldm, const OpenOrbitalOptimizer::FockMatrix<double> & elfock) {
-    const OpenOrbitalOptimizer::Orbitals<double> & eorbitals = eldm.first;
-    const OpenOrbitalOptimizer::OrbitalOccupations<double> & eoccupations = eldm.second;
+  std::function<void(const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double,double> &,const OpenOrbitalOptimizer::Armadillo::FockMatrix<double> &)> save_electron_matrices = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double,double> & eldm, const OpenOrbitalOptimizer::Armadillo::FockMatrix<double> & elfock) {
+    const OpenOrbitalOptimizer::Armadillo::Orbitals<double> & eorbitals = eldm.first;
+    const OpenOrbitalOptimizer::Armadillo::OrbitalOccupations<double> & eoccupations = eldm.second;
     if(M==1) {
       arma::mat Ce = X*eorbitals[0];
       arma::vec Ee = arma::diagvec(eorbitals[0].t()*elfock[0]*eorbitals[0]);
@@ -907,8 +907,8 @@ int main_guarded(int argc, char **argv) {
     // Update protonic terms for electronic solution
     arma::mat Pp(Xp.n_rows,Xp.n_rows,arma::fill::zeros);
     {
-      const OpenOrbitalOptimizer::Orbitals<double> & orbitals = protonic_dm.first;
-      const OpenOrbitalOptimizer::OrbitalOccupations<double>  & occupations = protonic_dm.second;
+      const OpenOrbitalOptimizer::Armadillo::Orbitals<double> & orbitals = protonic_dm.first;
+      const OpenOrbitalOptimizer::Armadillo::OrbitalOccupations<double>  & occupations = protonic_dm.second;
       for(size_t i=0;i<orbitals.size();i++) {
         arma::mat Cp = Xp*orbitals[i];
         arma::vec occp = occupations[i];
@@ -921,8 +921,8 @@ int main_guarded(int argc, char **argv) {
 
     // Update the frozen proton energy
     if(quantum_protons.size()) {
-      const OpenOrbitalOptimizer::Orbitals<double> & orbitals = protonic_dm.first;
-      const OpenOrbitalOptimizer::OrbitalOccupations<double>  & occupations = protonic_dm.second;
+      const OpenOrbitalOptimizer::Armadillo::Orbitals<double> & orbitals = protonic_dm.first;
+      const OpenOrbitalOptimizer::Armadillo::OrbitalOccupations<double>  & occupations = protonic_dm.second;
 
       // Get the electronic and protonic orbital coefficients
       arma::mat Cp = Xp*orbitals[0];
@@ -944,7 +944,7 @@ int main_guarded(int argc, char **argv) {
     }
 
     printf("\n\n\nIteration %i: solving electronic SCF\n", istep);
-    OpenOrbitalOptimizer::SCFSolver scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
+    OpenOrbitalOptimizer::Armadillo::SCFSolver<double,double> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
     scfsolver.initialize_with_orbitals(electronic_dm.first, electronic_dm.second);
     scfsolver.error_norm(error_norm);
     scfsolver.convergence_threshold(convergence_threshold); // use full threshold here since the electronic part is easy
@@ -961,8 +961,8 @@ int main_guarded(int argc, char **argv) {
       // Run protonic calculation.
       arma::mat Pe(X.n_rows,X.n_rows,arma::fill::zeros);
       {
-        const OpenOrbitalOptimizer::Orbitals<double> & orbitals = electronic_dm.first;
-        const OpenOrbitalOptimizer::OrbitalOccupations<double>  & occupations = electronic_dm.second;
+        const OpenOrbitalOptimizer::Armadillo::Orbitals<double> & orbitals = electronic_dm.first;
+        const OpenOrbitalOptimizer::Armadillo::OrbitalOccupations<double>  & occupations = electronic_dm.second;
         for(size_t i=0;i<orbitals.size();i++) {
           arma::mat Ce = X*orbitals[i];
           arma::vec occe = occupations[i];
@@ -1026,7 +1026,7 @@ int main_guarded(int argc, char **argv) {
         }
       }
 
-      OpenOrbitalOptimizer::FockBuilder<double, double> nuclear_builder = [&](const OpenOrbitalOptimizer::DensityMatrix<double, double> & dm) {
+      OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> nuclear_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
         const auto & orbitals = dm.first;
         const auto & occupations = dm.second;
 
@@ -1077,7 +1077,7 @@ int main_guarded(int argc, char **argv) {
 
       // Run protonic SCF
       printf("\n\nContinuing with protonic SCF\n");
-      OpenOrbitalOptimizer::SCFSolver scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
+      OpenOrbitalOptimizer::Armadillo::SCFSolver<double,double> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
       scfsolver.initialize_with_orbitals(protonic_dm.first, protonic_dm.second);
       scfsolver.error_norm(error_norm);
       scfsolver.convergence_threshold(init_convergence_threshold);
@@ -1105,8 +1105,8 @@ int main_guarded(int argc, char **argv) {
       printf("\n\nProceeding with simultaneous electron-proton SCF\n");
 
     // Proceed with nuclear-electronic calculation
-    OpenOrbitalOptimizer::Orbitals<double> guess_orbitals;
-    OpenOrbitalOptimizer::OrbitalOccupations<double> guess_occupations;
+    OpenOrbitalOptimizer::Armadillo::Orbitals<double> guess_orbitals;
+    OpenOrbitalOptimizer::Armadillo::OrbitalOccupations<double> guess_occupations;
     if(M==1) {
       guess_orbitals={electronic_dm.first[0], protonic_dm.first[0]};
       guess_occupations={electronic_dm.second[0], protonic_dm.second[0]};
@@ -1124,7 +1124,7 @@ int main_guarded(int argc, char **argv) {
       block_descriptions = {"electronic alpha", "electronic beta", "protonic"};
       fock_builder = unrestricted_neo_builder;
     }
-    OpenOrbitalOptimizer::SCFSolver scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
+    OpenOrbitalOptimizer::Armadillo::SCFSolver<double,double> scfsolver(number_of_blocks_per_particle_type, maximum_occupation, number_of_particles, fock_builder, block_descriptions);
     scfsolver.initialize_with_orbitals(guess_orbitals, guess_occupations);
     scfsolver.error_norm(error_norm);
     scfsolver.convergence_threshold(convergence_threshold);

--- a/src/contrib/neo_dump.cpp
+++ b/src/contrib/neo_dump.cpp
@@ -1,0 +1,391 @@
+/*
+ *                This source code is part of
+ *
+ *                     E  R  K  A  L  E
+ *                             -
+ *                       HF/DFT from Hel
+ *
+ * NEO-SCF export for external post-SCF correlation codes. See
+ * neo_dump_format.md for the on-disk format and the index/sign conventions.
+ */
+
+#include "neo_dump.h"
+#include "basis.h"
+#include "density_fitting.h"
+#include "eriworker.h"
+
+#include <hdf5.h>
+#include <cstdio>
+#include <stdexcept>
+#include <sstream>
+
+namespace {
+
+  // ---- raw HDF5 writers (C API, mirroring checkpoint.cpp's idiom) ----
+
+  void write_str_attr(hid_t loc, const std::string & name, const std::string & val) {
+    hid_t atype = H5Tcopy(H5T_C_S1);
+    H5Tset_size(atype, val.size()+1);
+    H5Tset_strpad(atype, H5T_STR_NULLTERM);
+    hid_t aspace = H5Screate(H5S_SCALAR);
+    hid_t attr = H5Acreate2(loc, name.c_str(), atype, aspace, H5P_DEFAULT, H5P_DEFAULT);
+    H5Awrite(attr, atype, val.c_str());
+    H5Aclose(attr);
+    H5Sclose(aspace);
+    H5Tclose(atype);
+  }
+
+  void write_int_attr(hid_t loc, const std::string & name, int val) {
+    hid_t aspace = H5Screate(H5S_SCALAR);
+    hid_t attr = H5Acreate2(loc, name.c_str(), H5T_NATIVE_INT, aspace, H5P_DEFAULT, H5P_DEFAULT);
+    H5Awrite(attr, H5T_NATIVE_INT, &val);
+    H5Aclose(attr);
+    H5Sclose(aspace);
+  }
+
+  void write_dbl_attr(hid_t loc, const std::string & name, double val) {
+    hid_t aspace = H5Screate(H5S_SCALAR);
+    hid_t attr = H5Acreate2(loc, name.c_str(), H5T_NATIVE_DOUBLE, aspace, H5P_DEFAULT, H5P_DEFAULT);
+    H5Awrite(attr, H5T_NATIVE_DOUBLE, &val);
+    H5Aclose(attr);
+    H5Sclose(aspace);
+  }
+
+  // Scalar integer dataset.
+  void write_int(hid_t loc, const std::string & name, int val) {
+    hid_t sp = H5Screate(H5S_SCALAR);
+    hid_t ds = H5Dcreate(loc, name.c_str(), H5T_NATIVE_INT, sp, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5Dwrite(ds, H5T_NATIVE_INT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &val);
+    H5Dclose(ds);
+    H5Sclose(sp);
+  }
+
+  // Double dataset from a flat C-order buffer of the given dimensions.
+  void write_buffer(hid_t loc, const std::string & name, const double * data,
+                    const std::vector<hsize_t> & dims) {
+    hid_t sp = H5Screate_simple((int) dims.size(), dims.data(), NULL);
+    hid_t ds = H5Dcreate(loc, name.c_str(), H5T_NATIVE_DOUBLE, sp, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5Dwrite(ds, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+    H5Dclose(ds);
+    H5Sclose(sp);
+  }
+
+  // 1D vector.
+  void write_vec(hid_t loc, const std::string & name, const arma::vec & v) {
+    std::vector<hsize_t> dims = { (hsize_t) v.n_elem };
+    write_buffer(loc, name, v.memptr(), dims);
+  }
+
+  // 2D matrix, written in C/row-major order so an h5py reader gets A[i,j]=M(i,j).
+  // Armadillo is column-major, so the column-major buffer of M.t() is exactly the
+  // row-major buffer of M.
+  void write_mat(hid_t loc, const std::string & name, const arma::mat & M) {
+    arma::mat Mt = M.t();
+    std::vector<hsize_t> dims = { (hsize_t) M.n_rows, (hsize_t) M.n_cols };
+    write_buffer(loc, name, Mt.memptr(), dims);
+  }
+
+  // ---- engine integral helpers ----
+
+  // The engine B factor (Nbf*Nbf) x Naux, with rows indexed by the C-order pair
+  // index mu*Nbf+nu and columns by the aux/Cholesky vector. (pq|rs) is
+  // reconstructed as sum_P B(p*Nbf+q, P) B(r*Nbf+s, P).
+  arma::mat B_factor(const DensityFit & fit) {
+    arma::mat B;
+    fit.B_matrix(B);
+    return B;
+  }
+
+  // Write the B factor as a (Naux, Nbf, Nbf) C-order tensor. B.memptr()
+  // (column-major (Nbf*Nbf) x Naux) IS the C-order (Naux,Nbf,Nbf) buffer with
+  // element [P,mu,nu] = B(mu*Nbf+nu, P), so no transpose is needed.
+  void write_B(hid_t loc, const arma::mat & B, size_t Nbf) {
+    size_t Naux = B.n_cols;
+    std::vector<hsize_t> dims = { (hsize_t) Naux, (hsize_t) Nbf, (hsize_t) Nbf };
+    write_buffer(loc, "B", B.memptr(), dims);
+  }
+
+  // Exact electron-proton Coulomb integrals (mu nu | a b), bare (no sign),
+  // with the engine's (omega,alpha,beta) operator so the finite-proton
+  // (screened) model is honored. Returns G(mu*Ne+nu, a*Np+b) = (mu nu | a b).
+  // Mirrors the contraction loop in neo.cpp's multicomponent_coulomb_tei, but
+  // stores the full tensor instead of contracting with a density.
+  arma::mat exact_ep(const BasisSet & ebasis, const BasisSet & pbasis,
+                     double omega, double alpha, double beta) {
+    std::vector<GaussianShell> eshells = ebasis.get_shells();
+    std::vector<GaussianShell> pshells = pbasis.get_shells();
+    size_t Ne = ebasis.get_Nbf();
+    size_t Np = pbasis.get_Nbf();
+
+    arma::mat G(Ne*Ne, Np*Np, arma::fill::zeros);
+
+    int maxam = std::max(ebasis.get_max_am(), pbasis.get_max_am());
+    int maxncontr = std::max(ebasis.get_max_Ncontr(), pbasis.get_max_Ncontr());
+    auto eri_owner = make_eri_worker(maxam, maxncontr, omega, alpha, beta);
+    ERIWorker * eri = eri_owner.get();
+
+    for(size_t i=0;i<eshells.size();i++) {
+      size_t Ni = eshells[i].get_Nbf();
+      size_t i0 = eshells[i].get_first_ind();
+      for(size_t j=0;j<eshells.size();j++) {
+        size_t Nj = eshells[j].get_Nbf();
+        size_t j0 = eshells[j].get_first_ind();
+        for(size_t k=0;k<pshells.size();k++) {
+          size_t Nk = pshells[k].get_Nbf();
+          size_t k0 = pshells[k].get_first_ind();
+          for(size_t l=0;l<pshells.size();l++) {
+            size_t Nl = pshells[l].get_Nbf();
+            size_t l0 = pshells[l].get_first_ind();
+
+            eri->compute(&eshells[i], &eshells[j], &pshells[k], &pshells[l]);
+            const std::vector<double> & ints = *eri->getp();
+
+            for(size_t ii=0;ii<Ni;ii++)
+              for(size_t jj=0;jj<Nj;jj++)
+                for(size_t kk=0;kk<Nk;kk++)
+                  for(size_t ll=0;ll<Nl;ll++) {
+                    double val = ints[((ii*Nj+jj)*Nk+kk)*Nl+ll];
+                    size_t mu = i0+ii, nu = j0+jj, a = k0+kk, b = l0+ll;
+                    G(mu*Ne+nu, a*Np+b) = val;
+                  }
+          }
+        }
+      }
+    }
+
+    return G;
+  }
+
+  // K[D]_pq = sum_rs (pr|qs) D_rs, from a dense G(p*N+r, q*N+s) = (pr|qs).
+  arma::mat calcK_from_G(const arma::mat & G, const arma::mat & D) {
+    size_t N = D.n_rows;
+    arma::mat K(N, N, arma::fill::zeros);
+    for(size_t p=0;p<N;p++)
+      for(size_t q=0;q<N;q++) {
+        double k=0.0;
+        for(size_t r=0;r<N;r++)
+          for(size_t s=0;s<N;s++)
+            k += G(p*N+r, q*N+s) * D(r,s);
+        K(p,q)=k;
+      }
+    return K;
+  }
+
+  // AO density from energy-ordered MOs and occupations.
+  arma::mat density(const arma::mat & C, const arma::vec & occ) {
+    return C * arma::diagmat(occ) * C.t();
+  }
+
+} // anonymous namespace
+
+void neo_dump(const std::string & filename,
+              const std::string & representation,
+              bool do_verify,
+              const BasisSet & ebasis, const DensityFit & dfit,
+              bool restricted_e,
+              const std::vector<arma::mat> & Ce,
+              const std::vector<arma::vec> & occe,
+              const std::vector<arma::vec> & epse,
+              const arma::mat & hcore_e,
+              const std::vector<arma::mat> & focke,
+              const BasisSet & pbasis, const DensityFit & pfit,
+              const arma::mat & Cp, const arma::vec & occp,
+              const arma::vec & epsp, const arma::mat & hcore_p,
+              const arma::mat & fock_p,
+              int n_electrons, int n_protons, double proton_mass,
+              double e_scf, double e_classical,
+              bool density_fitting, double omega, double alpha, double beta,
+              const std::string & version) {
+
+  if(representation != "btensor" && representation != "dense") {
+    std::ostringstream oss;
+    oss << "neo_dump: unknown integral representation '" << representation << "' (use btensor or dense)\n";
+    throw std::runtime_error(oss.str());
+  }
+  bool dense = (representation == "dense");
+
+  size_t Ne = ebasis.get_Nbf();
+  size_t Np = pbasis.get_Nbf();
+
+  printf("\nWriting NEO-SCF dump to %s (%s integrals).\n", filename.c_str(), representation.c_str());
+  fflush(stdout);
+
+  // Engine B factors and the dense integrals (used for verify, and for the
+  // dense representation on disk). e-e/p-p come from the SCF's own engine
+  // factor. The e-p tensor matches the engine the SCF used: the shared-aux RI
+  // reconstruction B_e B_p^T in density-fitting mode, or the exact engine
+  // integral (same omega,alpha,beta) in Cholesky mode -- where the SCF itself
+  // evaluates e-p exactly.
+  arma::mat Be = B_factor(dfit);
+  arma::mat Bp = B_factor(pfit);
+  arma::mat Gee = Be * Be.t();
+  arma::mat Gpp = Bp * Bp.t();
+  arma::mat Gep;
+  if(density_fitting) {
+    if(Be.n_cols != Bp.n_cols)
+      throw std::runtime_error("neo_dump: electron and proton density-fitting bases differ -- cannot share the e-p auxiliary expansion.\n");
+    Gep = Be * Bp.t();
+  } else {
+    Gep = exact_ep(ebasis, pbasis, omega, alpha, beta);
+  }
+
+  // ---- write the file ----
+  hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+  if(file < 0)
+    throw std::runtime_error("neo_dump: could not create " + filename + "\n");
+
+  // /meta attributes on the root group
+  hid_t root = H5Gopen2(file, "/", H5P_DEFAULT);
+  write_str_attr(root, "units", "Hartree atomic units");
+  write_str_attr(root, "integral_convention", "chemist (pq|rs)");
+  write_str_attr(root, "integral_representation", representation);
+  write_str_attr(root, "ao_or_mo", "AO");
+  write_str_attr(root, "storage_order", "C (row-major)");
+  write_int_attr(root, "n_electrons", n_electrons);
+  write_int_attr(root, "restricted_electrons", restricted_e ? 1 : 0);
+  write_int_attr(root, "n_quantum_protons", n_protons);
+  write_str_attr(root, "proton_spin_treatment", "high-spin");
+  write_dbl_attr(root, "proton_mass", proton_mass);
+  if(!dense) {
+    write_int_attr(root, "naux_e", (int) Be.n_cols);
+    write_int_attr(root, "naux_p", (int) Bp.n_cols);
+  }
+  write_dbl_attr(root, "e_scf", e_scf);
+  write_dbl_attr(root, "e_classical", e_classical);
+  write_str_attr(root, "erkale_version", version);
+
+  // /electron
+  hid_t eg = H5Gcreate2(file, "/electron", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  write_int(eg, "nbf", (int) Ne);
+  write_mat(eg, "hcore", hcore_e);
+  if(restricted_e) {
+    write_int(eg, "nmo", (int) Ce[0].n_cols);
+    write_int(eg, "nocc", (int) arma::accu(occe[0] > 0.0));
+    write_mat(eg, "C", Ce[0]);
+    write_vec(eg, "eps", epse[0]);
+    write_mat(eg, "fock", focke[0]);
+  } else {
+    const char * suf[2] = {"_a", "_b"};
+    for(int s=0;s<2;s++) {
+      write_int(eg, std::string("nmo")+suf[s], (int) Ce[s].n_cols);
+      write_int(eg, std::string("nocc")+suf[s], (int) arma::accu(occe[s] > 0.0));
+      write_mat(eg, std::string("C")+suf[s], Ce[s]);
+      write_vec(eg, std::string("eps")+suf[s], epse[s]);
+      write_mat(eg, std::string("fock")+suf[s], focke[s]);
+    }
+  }
+  if(!dense)
+    write_B(eg, Be, Ne);
+
+  // /proton
+  hid_t pg = H5Gcreate2(file, "/proton", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  write_int(pg, "nbf", (int) Np);
+  write_int(pg, "nmo", (int) Cp.n_cols);
+  write_int(pg, "nocc", (int) arma::accu(occp > 0.0));
+  write_mat(pg, "C", Cp);
+  write_vec(pg, "eps", epsp);
+  write_mat(pg, "hcore", hcore_p);
+  write_mat(pg, "fock", fock_p);
+  if(!dense)
+    write_B(pg, Bp, Np);
+
+  // electron-proton tensor: always dense (mu nu | a b), bare positive.
+  // Write C-order (Ne,Ne,Np,Np): need row-major of Gep, i.e. column-major of Gep.t().
+  {
+    arma::mat Gept = Gep.t();
+    std::vector<hsize_t> dims = { (hsize_t) Ne, (hsize_t) Ne, (hsize_t) Np, (hsize_t) Np };
+    write_buffer(file, "eri_ep", Gept.memptr(), dims);
+  }
+
+  // dense per-species tensors. Gee/Gpp are symmetric in (pair<->pair), so their
+  // column-major buffer equals the C-order rank-4 buffer.
+  if(dense) {
+    std::vector<hsize_t> edims = { (hsize_t) Ne, (hsize_t) Ne, (hsize_t) Ne, (hsize_t) Ne };
+    write_buffer(file, "eri_ee", Gee.memptr(), edims);
+    std::vector<hsize_t> pdims = { (hsize_t) Np, (hsize_t) Np, (hsize_t) Np, (hsize_t) Np };
+    write_buffer(file, "eri_pp", Gpp.memptr(), pdims);
+  }
+
+  H5Gclose(pg);
+  H5Gclose(eg);
+  H5Gclose(root);
+  H5Fclose(file);
+
+  printf("NEO-SCF dump written.\n");
+  fflush(stdout);
+
+  // ---- verify: reconstruct the SCF energy from the dumped quantities ----
+  if(do_verify) {
+    // electron density (total) and per-spin densities
+    arma::mat De(Ne, Ne, arma::fill::zeros);
+    std::vector<arma::mat> Dspin;
+    for(size_t s=0;s<Ce.size();s++) {
+      arma::mat Ds = density(Ce[s], occe[s]);
+      Dspin.push_back(Ds);
+      De += Ds;
+    }
+    arma::mat Dp = density(Cp, occp);
+
+    arma::vec de_vec = arma::vectorise(De); // symmetric => pair index mu*Ne+nu
+    arma::vec dp_vec = arma::vectorise(Dp);
+
+    // one-particle
+    double E1e = arma::trace(De * hcore_e);
+    double E1p = arma::trace(Dp * hcore_p);
+
+    // e-e Coulomb and exchange (ERKALE conventions)
+    double Ecoul_ee = 0.5 * arma::dot(de_vec, Gee * de_vec);
+    double Eexch_ee = 0.0;
+    if(restricted_e) {
+      arma::mat Ke = calcK_from_G(Gee, De);
+      Eexch_ee = -0.25 * arma::trace(Ke * De);
+    } else {
+      for(size_t s=0;s<2;s++) {
+        arma::mat Ks = calcK_from_G(Gee, Dspin[s]);
+        Eexch_ee += -0.5 * arma::trace(Ks * Dspin[s]);
+      }
+    }
+
+    // p-p Coulomb and exchange (high-spin protons)
+    double Ecoul_pp = 0.5 * arma::dot(dp_vec, Gpp * dp_vec);
+    arma::mat Kp = calcK_from_G(Gpp, Dp);
+    double Eexch_pp = -0.5 * arma::trace(Kp * Dp);
+
+    // e-p coupling: attractive sign applied here (q_e*q_p = -1)
+    double E_ep = - arma::dot(de_vec, Gep * dp_vec);
+
+    double E_recon = E1e + E1p + Ecoul_ee + Eexch_ee + Ecoul_pp + Eexch_pp + E_ep + e_classical;
+    double diff = E_recon - e_scf;
+
+    printf("\nNEO dump self-consistency check:\n");
+    printf("  e one-particle    % .10f\n", E1e);
+    printf("  p one-particle    % .10f\n", E1p);
+    printf("  e-e Coulomb       % .10f\n", Ecoul_ee);
+    printf("  e-e exchange      % .10f\n", Eexch_ee);
+    printf("  p-p Coulomb       % .10f\n", Ecoul_pp);
+    printf("  p-p exchange      % .10f\n", Eexch_pp);
+    printf("  e-p coupling      % .10f\n", E_ep);
+    printf("  classical nuc.    % .10f\n", e_classical);
+    printf("  reconstructed E   % .10f\n", E_recon);
+    printf("  SCF E             % .10f\n", e_scf);
+    printf("  difference        % .3e\n", diff);
+    fflush(stdout);
+
+    if(std::abs(diff) > 1e-7) {
+      bool screened = !(omega == 0.0 && alpha == 1.0 && beta == 0.0);
+      if(density_fitting && screened)
+        // Finite-proton RI uses dfit's metric for the electron-side expansion and
+        // pfit's (screened) 3-center for the proton-side projection; that mixed
+        // metric is not exactly B_e B_p^T, so a small residual is expected here.
+        printf("  NOTE: finite-proton density-fitting run -- the e-p RI uses a mixed\n"
+               "  metric, so a small residual is expected. Use the Cholesky path for\n"
+               "  a machine-precision check.\n");
+      else {
+        std::ostringstream oss;
+        oss << "neo_dump verify: reconstructed energy differs from SCF by " << diff << " (> 1e-7)!\n";
+        throw std::runtime_error(oss.str());
+      }
+    }
+    fflush(stdout);
+  }
+}

--- a/src/contrib/neo_dump.cpp
+++ b/src/contrib/neo_dump.cpp
@@ -13,9 +13,11 @@
 #include "basis.h"
 #include "density_fitting.h"
 #include "eriworker.h"
+#include "linalg.h"
 
 #include <hdf5.h>
 #include <cstdio>
+#include <cmath>
 #include <stdexcept>
 #include <sstream>
 
@@ -176,6 +178,32 @@ namespace {
     return C * arma::diagmat(occ) * C.t();
   }
 
+  // Canonical MOs of a Fock matrix F in the AO overlap metric S: solve the
+  // generalized eigenproblem F C = S C diag(eps) with C^T S C = I and
+  // C^T F C = diag(eps), eps ascending. Canonical (symmetric) orthonormalization
+  // via BasOrth projects out near-linear-dependent directions, so C is
+  // (Nbf x Nmo) with Nmo <= Nbf. The SCF solver returns occupation-ordered
+  // orbitals that do not in general diagonalize the converged Fock (DIIS
+  // extrapolation), so the dump recanonicalizes here.
+  arma::mat canonical_orbitals(const arma::mat & F, const arma::mat & S, arma::vec & eps) {
+    arma::mat X = BasOrth(S);                 // Nbf x Nmo
+    arma::mat Fmo = X.t() * F * X;            // Nmo x Nmo
+    Fmo = 0.5*(Fmo + Fmo.t());                // symmetrize against round-off
+    arma::mat U;
+    arma::eig_sym(eps, U, Fmo);
+    return X * U;                             // Nbf x Nmo, ascending in eps
+  }
+
+  // Max-norm residuals of the canonical conditions, for validation/printing.
+  void canonical_residuals(const arma::mat & C, const arma::mat & S,
+                           const arma::mat & F, const arma::vec & eps,
+                           double & orthonormality, double & eigres, double & offdiag) {
+    arma::mat I(C.n_cols, C.n_cols, arma::fill::eye);
+    orthonormality = arma::abs(C.t()*S*C - I).max();
+    eigres = arma::abs(F*C - S*C*arma::diagmat(eps)).max();
+    offdiag = arma::abs(C.t()*F*C - arma::diagmat(eps)).max();
+  }
+
 } // anonymous namespace
 
 void neo_dump(const std::string & filename,
@@ -229,6 +257,67 @@ void neo_dump(const std::string & filename,
     Gep = exact_ep(ebasis, pbasis, omega, alpha, beta);
   }
 
+  // ---- canonical MOs consistent with the dumped Fock + AO overlaps ----
+  // AO overlap is the metric each species' basis lives in (also dumped).
+  arma::mat S_e = ebasis.overlap();
+  arma::mat S_p = pbasis.overlap();
+
+  // Diagonalize the final converged Fock for each species so the stored MOs
+  // satisfy F C = S C diag(eps), C^T S C = I, C^T F C = diag(eps). The SCF
+  // solver returns occupation-ordered orbitals that do not diagonalize the
+  // rebuilt Fock; recanonicalize. The proton Fock passed in is already
+  // self-interaction-free (h_p + V_ep[D_e]), so its canonical virtuals are
+  // physically bound.
+  // Aufbau occupations on the canonical (energy-ordered) orbitals. The number
+  // of occupied orbitals is the integer particle count of the block (the sum of
+  // the SCF occupations, which may be spread fractionally over near-degenerate
+  // solver orbitals), NOT the count of nonzero entries -- otherwise a
+  // fractionally split orbital would be double-counted.
+  std::vector<arma::mat> Cc(Ce.size());
+  std::vector<arma::vec> epsc(Ce.size()), occc(Ce.size());
+  double occ_e = restricted_e ? 2.0 : 1.0;
+  for(size_t s=0;s<Ce.size();s++) {
+    Cc[s] = canonical_orbitals(focke[s], S_e, epsc[s]);
+    size_t nocc = (size_t) std::lround(arma::accu(occe[s]) / occ_e);
+    occc[s].zeros(Cc[s].n_cols);
+    if(nocc) occc[s].subvec(0,nocc-1).fill(occ_e);
+  }
+  arma::vec epsp_c;
+  arma::mat Cp_c = canonical_orbitals(fock_p, S_p, epsp_c);
+  size_t nocc_p = (size_t) std::lround(arma::accu(occp));
+  arma::vec occp_c(Cp_c.n_cols, arma::fill::zeros);
+  if(nocc_p) occp_c.subvec(0,nocc_p-1).ones();
+
+  // Validation: canonical conditions (a,b,c) and a bound proton spectrum.
+  printf("\nNEO dump canonicalization check (max-norm residuals):\n");
+  for(size_t s=0;s<Cc.size();s++) {
+    double rI,rFC,rOD;
+    canonical_residuals(Cc[s], S_e, focke[s], epsc[s], rI,rFC,rOD);
+    const char * lbl = (Ce.size()==1) ? "electron" : (s==0 ? "electron alpha" : "electron beta");
+    printf("  %-14s ||C'SC-I||=%.2e  ||FC-SCe||=%.2e  ||C'FC-diag||=%.2e\n", lbl, rI,rFC,rOD);
+    if(rI>1e-8 || rFC>1e-6 || rOD>1e-6)
+      throw std::runtime_error("neo_dump: electron canonicalization residual too large!\n");
+  }
+  {
+    double rI,rFC,rOD;
+    canonical_residuals(Cp_c, S_p, fock_p, epsp_c, rI,rFC,rOD);
+    printf("  %-14s ||C'SC-I||=%.2e  ||FC-SCe||=%.2e  ||C'FC-diag||=%.2e\n", "proton", rI,rFC,rOD);
+    if(rI>1e-8 || rFC>1e-6 || rOD>1e-6)
+      throw std::runtime_error("neo_dump: proton canonicalization residual too large!\n");
+    // Dissociation threshold for a quantum proton is 0 (free proton at rest,
+    // vanishing potential at infinity); bound orbitals have eps < 0.
+    const double thr = 0.0;
+    if(nocc_p < (size_t) Cp_c.n_cols) {
+      double lowest_virtual = epsp_c(nocc_p);
+      size_t nbound = (size_t) arma::accu(epsp_c.subvec(nocc_p, Cp_c.n_cols-1) < thr);
+      printf("  proton spectrum: highest occ %.4f, lowest virtual %.4f, %i bound virtual(s) below threshold %.1f\n",
+             epsp_c(nocc_p-1), lowest_virtual, (int) nbound, thr);
+      if(lowest_virtual >= thr)
+        throw std::runtime_error("neo_dump: lowest proton virtual is unbound -- proton self-interaction not removed?\n");
+    }
+  }
+  fflush(stdout);
+
   // ---- write the file ----
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
   if(file < 0)
@@ -258,19 +347,20 @@ void neo_dump(const std::string & filename,
   hid_t eg = H5Gcreate2(file, "/electron", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   write_int(eg, "nbf", (int) Ne);
   write_mat(eg, "hcore", hcore_e);
+  write_mat(eg, "overlap", S_e);
   if(restricted_e) {
-    write_int(eg, "nmo", (int) Ce[0].n_cols);
-    write_int(eg, "nocc", (int) arma::accu(occe[0] > 0.0));
-    write_mat(eg, "C", Ce[0]);
-    write_vec(eg, "eps", epse[0]);
+    write_int(eg, "nmo", (int) Cc[0].n_cols);
+    write_int(eg, "nocc", (int) arma::accu(occc[0] > 0.0));
+    write_mat(eg, "C", Cc[0]);
+    write_vec(eg, "eps", epsc[0]);
     write_mat(eg, "fock", focke[0]);
   } else {
     const char * suf[2] = {"_a", "_b"};
     for(int s=0;s<2;s++) {
-      write_int(eg, std::string("nmo")+suf[s], (int) Ce[s].n_cols);
-      write_int(eg, std::string("nocc")+suf[s], (int) arma::accu(occe[s] > 0.0));
-      write_mat(eg, std::string("C")+suf[s], Ce[s]);
-      write_vec(eg, std::string("eps")+suf[s], epse[s]);
+      write_int(eg, std::string("nmo")+suf[s], (int) Cc[s].n_cols);
+      write_int(eg, std::string("nocc")+suf[s], (int) arma::accu(occc[s] > 0.0));
+      write_mat(eg, std::string("C")+suf[s], Cc[s]);
+      write_vec(eg, std::string("eps")+suf[s], epsc[s]);
       write_mat(eg, std::string("fock")+suf[s], focke[s]);
     }
   }
@@ -280,12 +370,13 @@ void neo_dump(const std::string & filename,
   // /proton
   hid_t pg = H5Gcreate2(file, "/proton", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   write_int(pg, "nbf", (int) Np);
-  write_int(pg, "nmo", (int) Cp.n_cols);
-  write_int(pg, "nocc", (int) arma::accu(occp > 0.0));
-  write_mat(pg, "C", Cp);
-  write_vec(pg, "eps", epsp);
+  write_int(pg, "nmo", (int) Cp_c.n_cols);
+  write_int(pg, "nocc", (int) arma::accu(occp_c > 0.0));
+  write_mat(pg, "C", Cp_c);
+  write_vec(pg, "eps", epsp_c);
   write_mat(pg, "hcore", hcore_p);
   write_mat(pg, "fock", fock_p);
+  write_mat(pg, "overlap", S_p);
   if(!dense)
     write_B(pg, Bp, Np);
 
@@ -316,15 +407,16 @@ void neo_dump(const std::string & filename,
 
   // ---- verify: reconstruct the SCF energy from the dumped quantities ----
   if(do_verify) {
-    // electron density (total) and per-spin densities
+    // electron density (total) and per-spin densities, from the canonical
+    // occupied orbitals (same occupied subspace as the SCF solution).
     arma::mat De(Ne, Ne, arma::fill::zeros);
     std::vector<arma::mat> Dspin;
-    for(size_t s=0;s<Ce.size();s++) {
-      arma::mat Ds = density(Ce[s], occe[s]);
+    for(size_t s=0;s<Cc.size();s++) {
+      arma::mat Ds = density(Cc[s], occc[s]);
       Dspin.push_back(Ds);
       De += Ds;
     }
-    arma::mat Dp = density(Cp, occp);
+    arma::mat Dp = density(Cp_c, occp_c);
 
     arma::vec de_vec = arma::vectorise(De); // symmetric => pair index mu*Ne+nu
     arma::vec dp_vec = arma::vectorise(Dp);

--- a/src/contrib/neo_dump.h
+++ b/src/contrib/neo_dump.h
@@ -1,0 +1,69 @@
+/*
+ *                This source code is part of
+ *
+ *                     E  R  K  A  L  E
+ *                             -
+ *                       HF/DFT from Hel
+ *
+ * NEO-SCF export for external post-SCF correlation codes.
+ *
+ * Writes a converged nuclear-electronic-orbital SCF to a self-describing
+ * HDF5 file (see neo_dump_format.md) containing AO/MO data and the bare
+ * (sign-free) two-particle integrals (electron-electron, proton-proton,
+ * electron-proton) needed by a spin-orbital NEO-CCSD driver.
+ */
+
+#ifndef ERKALE_NEO_DUMP
+#define ERKALE_NEO_DUMP
+
+#include <armadillo>
+#include <string>
+#include <vector>
+
+class BasisSet;
+class DensityFit;
+
+/**
+ * Write a converged NEO-SCF to an HDF5 dump.
+ *
+ * The electron blocks are passed as vectors: size 1 for restricted (RHF),
+ * size 2 (alpha,beta) for unrestricted (UHF). Coefficients are AO x MO in
+ * the full AO basis, energy-ordered (occupied first). Fock/hcore are AO.
+ *
+ * \param filename        output HDF5 file
+ * \param representation  "btensor" (engine CD/RI factors) or "dense" (full rank-4)
+ * \param do_verify       reconstruct the SCF energy from the dumped tensors and check
+ * \param ebasis,dfit     electron basis and its (converged) density-fit/Cholesky engine
+ * \param restricted_e    true=RHF (one electron block), false=UHF (two blocks)
+ * \param Ce,occe,epse,focke  per-block electron MOs, occupations, energies, AO Fock
+ * \param hcore_e         electron AO core Hamiltonian (spin-independent)
+ * \param pbasis,pfit     proton basis and engine
+ * \param Cp,occp,epsp,fock_p,hcore_p  proton MOs, occupations, energies, AO Fock, core
+ * \param n_electrons,n_protons,proton_mass  counts / mass
+ * \param e_scf,e_classical  SCF total energy and classical nuclear repulsion
+ * \param density_fitting omega/alpha/beta select the e-p (and p-p) operator
+ * \param version         ERKALE version string for provenance
+ */
+void neo_dump(const std::string & filename,
+              const std::string & representation,
+              bool do_verify,
+              // electrons
+              const BasisSet & ebasis, const DensityFit & dfit,
+              bool restricted_e,
+              const std::vector<arma::mat> & Ce,
+              const std::vector<arma::vec> & occe,
+              const std::vector<arma::vec> & epse,
+              const arma::mat & hcore_e,
+              const std::vector<arma::mat> & focke,
+              // protons
+              const BasisSet & pbasis, const DensityFit & pfit,
+              const arma::mat & Cp, const arma::vec & occp,
+              const arma::vec & epsp, const arma::mat & hcore_p,
+              const arma::mat & fock_p,
+              // scalars
+              int n_electrons, int n_protons, double proton_mass,
+              double e_scf, double e_classical,
+              bool density_fitting, double omega, double alpha, double beta,
+              const std::string & version);
+
+#endif

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -68,6 +68,8 @@ void Settings::add_scf_settings() {
   add_int("LinearOccupations", "Read in occupations for linear molecule calculations?", 0, true);
   add_string("LinearOccupationFile", "File to read linear occupations from", "linoccs.dat");
   add_double("LinearB", "Magnetic field along bond axis", 0.0, true);
+  add_double("LinearE", "Electric field along bond (z) axis", 0.0, true);
+  add_double("Confinement", "Harmonic confinement strength k (potential 1/2 k r^2), 0 = off", 0.0, true);
 
   // Decontract basis set?
   add_string("Decontract","Indices of atoms to decontract basis set for","");


### PR DESCRIPTION
## Summary

Adds an opt-in HDF5 export of a converged **NEO (nuclear-electronic orbital) SCF** for an external spin-orbital NEO-CCSD code, and updates the OpenOrbitalOptimizer (OOO) consumers to build against OOO's Eigen-based interface.

### 1. NEO integral dump (`5b7c2214`)
New `src/contrib/neo_dump.{h,cpp}`, wired into `erkale_neo` via keywords `NEODump` (output file), `NEODumpIntegrals` (`btensor` default, or `dense`), `NEODumpVerify` (default true). Writes, in Hartree atomic units and C/row-major order, a self-describing file:
- `/meta` attributes (chemist `(pq|rs)` convention, counts, `restricted_electrons`, `proton_spin_treatment`, `proton_mass`, `e_scf`, `e_classical`, …)
- `/electron` and `/proton` groups: `C`, `eps`, `hcore`, `fock`, `overlap`, `nbf`/`nmo`/`nocc`, and the engine `B` factor (DF/CD 3-index); `_a`/`_b` for UHF
- bare, sign-free electron-proton tensor `eri_ep` `(nbf_e,nbf_e,nbf_p,nbf_p)` (the attractive `q_e·q_p` sign is the consumer's job, so the same export serves negative species such as µ⁻)

Per-species integrals match the engine the SCF used (shared-aux RI in DF, exact in CD). `NEODumpVerify` reconstructs the SCF energy from the dumped tensors and checks it. Format/conventions documented in `neo_dump_format.md`. Supports RHF and UHF electrons + point quantum protons.

### 2. Build against the Eigen-based OpenOrbitalOptimizer (`a0c987cc`)
OOO switched its public interface from Armadillo to Eigen. The NEO drivers (`neo`, `neosp`, `hneoci`) and `complex_orbs` now use OOO's Armadillo compatibility shim (`OpenOrbitalOptimizer::Armadillo::…`), keeping all ERKALE-side SCF math in Armadillo; CMake locates Eigen3 for these targets.

### 3. Dump-correctness fixes from a consumer (`36975625`)
- **Canonical MOs:** diagonalize the stored Fock in the AO `overlap` metric so `C`/`eps` satisfy `F C = S C diag(eps)`, `CᵀSC = I`, `CᵀFC = diag(eps)` (the SCF solver returns occupation-ordered orbitals that don't diagonalize the rebuilt Fock).
- **AO overlap** added to each species group.
- **Self-interaction-free proton Fock** `F_p = h_p + V_ep[D_e]` (no proton `J_p/K_p`), so the proton virtuals are physically bound. Occupations use the integer particle count (not `count(occ>0)`), fixing a fractional-occupation double-count.
- Canonicalization residuals + bound-proton-spectrum checks are printed and asserted at write time.

## Validation
`erkale_neo`/`neosp`/`hneoci`/`complex_orbs` build. On FHF⁻ (aug-cc-pVTZ, decontracted H, PB4-F1, DF): canonical residuals ~1e-13, all proton virtuals bound, p-p Coulomb/exchange cancel, energy reconstruction matches the SCF. RHF/UHF/dense/CD/DF dump variants all reproduce the SCF energy (≤~1e-9, or the DF auxiliary residual). `complex_orbs` He magnetic-field tests reproduce prior energies bit-for-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)