### PR TITLE
complex_orbs: electric field (LinearE) + optional harmonic confinement

### DIFF
--- a/src/contrib/complex_orbs.cpp
+++ b/src/contrib/complex_orbs.cpp
@@ -108,6 +108,8 @@ int main_guarded(int argc, char **argv) {
   int readlinocc = settings.get_int("LinearOccupations");
   std::string linoccfname = settings.get_string("LinearOccupationFile");
   double linB = settings.get_double("LinearB");
+  double linE = settings.get_double("LinearE");
+  double confinement = settings.get_double("Confinement");
   bool unrestricted = !(settings.get_bool("Restricted"));
   bool density_fitting = settings.get_bool("DensityFitting");
   std::string guess = settings.get_string("Guess");
@@ -271,17 +273,33 @@ int main_guarded(int argc, char **argv) {
     return std::make_pair(C, occs);
   };
 
+  // One-electron field operator added to the Fock matrix. Collects the
+  // magnetic terms (orbital Zeeman -1/2 B L_z, diamagnetic 1/8 B^2 (x^2+y^2)),
+  // the electric dipole (E z along the bond axis), and an optional harmonic
+  // confinement (1/2 k r^2). z preserves L_z, so the m-block structure is kept;
+  // it mixes l within a block, which is what polarizes the density. The
+  // confinement is an artificial regulariser (a static field has no bound
+  // ground state) -- leave it off (k=0) for weak fields with a non-diffuse
+  // basis; turn it on to prevent variational collapse toward the continuum.
   arma::mat Bterms(Nbf, Nbf, arma::fill::zeros);
-  if (linB) {
+  if (linB || linE || confinement) {
     double cenx = 0.0, ceny = 0.0, cenz = 0.0;
+    std::vector<arma::mat> dip = basis.moment(1, cenx, ceny, cenz);
     std::vector<arma::mat> momstack = basis.moment(2, cenx, ceny, cenz);
     arma::mat xymat = momstack[getind(2, 0, 0)] + momstack[getind(0, 2, 0)];
+    arma::mat zmat = dip[getind(0, 0, 1)];
+    arma::mat r2mat = xymat + momstack[getind(0, 0, 2)];
     const auto & Smat = complexbas ? S_c : S;
     if(complexbas) {
       xymat = arma::real(D.t()*xymat*D);
+      zmat = arma::real(D.t()*zmat*D);
+      r2mat = arma::real(D.t()*r2mat*D);
     }
     for (size_t j = 0; j < Nbf; j++)
-      Bterms.col(j) = -0.5 * linB * mvals(j) * Smat.col(j) + 0.125 * linB * linB * xymat.col(j);
+      Bterms.col(j) = -0.5 * linB * mvals(j) * Smat.col(j)   // orbital Zeeman
+        + 0.125 * linB * linB * xymat.col(j)                 // diamagnetic
+        + linE * zmat.col(j)                                 // electric dipole
+        + 0.5 * confinement * r2mat.col(j);                  // harmonic confinement
   }
 
   std::function<std::tuple<arma::mat, arma::mat, arma::cx_mat>(const std::vector<arma::mat> orbitals, const std::vector<arma::vec> & occupations)> electronic_terms = [&](const auto & orbitals, const auto & occupations) {
@@ -356,7 +374,7 @@ int main_guarded(int argc, char **argv) {
       printf("e-e Coulomb energy          % .10f\n", Ecoul);
       printf("e-e exchange energy         % .10f\n", Eexch);
       printf("nuclear repulsion energy    % .10f\n", Enucr);
-      printf("magnetic interaction energy % .10f\n", Emag);
+      printf("field interaction energy    % .10f\n", Emag);
       printf("Total energy                % .10f\n", Etot);
       fflush(stdout);
     }
@@ -437,7 +455,7 @@ int main_guarded(int argc, char **argv) {
       printf("e-e Coulomb energy          % .10f\n", Ecoul);
       printf("e-e exchange energy         % .10f\n", Eexch);
       printf("nuclear repulsion energy    % .10f\n", Enucr);
-      printf("magnetic interaction energy % .10f\n", Emag);
+      printf("field interaction energy    % .10f\n", Emag);
       printf("Total energy                % .10f\n", Etot);
       fflush(stdout);
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -68,6 +68,8 @@ void Settings::add_scf_settings() {
   add_int("LinearOccupations", "Read in occupations for linear molecule calculations?", 0, true);
   add_string("LinearOccupationFile", "File to read linear occupations from", "linoccs.dat");
   add_double("LinearB", "Magnetic field along bond axis", 0.0, true);
+  add_double("LinearE", "Electric field along bond (z) axis", 0.0, true);
+  add_double("Confinement", "Harmonic confinement strength k (potential 1/2 k r^2), 0 = off", 0.0, true);
 
   // Decontract basis set?
   add_string("Decontract","Indices of atoms to decontract basis set for","");


### PR DESCRIPTION
Adds an electric field along the bond (z) axis to `erkale_complex_orbs`, for breaking symmetry to generate polarization functions, plus an optional harmonic confinement to regularise the field problem.

> Stacked on #132 (base `neo-cc-export`): `complex_orbs` only builds against the current Eigen-based OpenOrbitalOptimizer with the shim work from that PR. Retarget to `master` once #132 merges.

## Changes
- New SCF keywords (`settings.cpp`): `LinearE` (field strength) and `Confinement` (`½k·r²` strength, `0` = off), alongside `LinearB`.
- `complex_orbs.cpp`: the `E·z` dipole and `½k·r²` confinement are folded into the existing one-electron field operator next to the magnetic terms. `E·z` preserves `L_z`, so the m-block / linear-symmetry machinery is unchanged; it mixes `l` within each m-block, which polarizes the density. The field energy is reported through the same trace (label updated to "field interaction energy").

## Why the confinement
A static uniform field has no bound ground state (Stark resonance), so a diffuse basis can collapse toward the continuum. The `½k·r²` confinement is an opt-in regulariser.

## Validation (He / AHGBSP2-9)
- no confinement, `E=0.05`: oscillates, does not tightly converge, `ΔE ≈ -0.019 Ha` (density leaking downfield — the pathology)
- `k=0.01`, `E=0.05`: converges in 8 iterations, `ΔE = -0.0016 Ha ≈ -½αE²` (physical He Stark shift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)