### PR TITLE
hneoci: external harmonic + quartic trap on the quantum proton

### DIFF
--- a/README_TRAP.md
+++ b/README_TRAP.md
@@ -1,0 +1,101 @@
+# External proton trap for ERKALE `hneoci`
+
+A static, one-body external confining potential on the quantum proton, so that a
+single electron + single proton (NEO-HF guess and `hneoci` FCI) can be solved
+with the proton held in a tunable **cylindrical harmonic + quartic** trap. This
+anchors an otherwise free 1e + 1p system into a contamination-free laboratory
+for optimizing protonic and near-proton electronic Gaussian exponents.
+
+Only the designated quantum proton feels the trap; the electron stays
+Coulomb-bound to the trapped proton. The trap is added to the protonic core
+Hamiltonian `H0p`, so it is seen by **both** the proton BO spectrum
+("Quantum proton spectrum") and the CI.
+
+## The operator
+
+Coordinates are relative to the trap center `R0` (default: the quantum proton's
+basis center). Atomic units throughout; `m` is the proton mass (`ProtonMass`,
+default 1836.15267389).
+
+```
+V(r) = 1/2 m [ w_perp^2 (x^2 + y^2) + w_par^2 z^2 ]        (harmonic, axis = z)
+     + lam_par z^4 + lam_perp (x^2+y^2)^2 + lam_cross z^2 (x^2+y^2)   (quartic)
+```
+
+The physical anharmonicity knob is the **dimensionless** `g` (`TrapG`), from
+which the axis-resolved quartic couplings follow (each mode carries the same
+relative anharmonicity):
+
+```
+lam_par  = g m^2 w_par^3
+lam_perp = g m^2 w_perp^3
+lam_cross = TrapLambdaCross   (independent input, default 0)
+```
+
+Isotropic quartic `lam r^4` corresponds to `(lam_par, lam_perp, lam_cross) =
+(lam, lam, 2 lam)` because `r^4 = z^4 + (x^2+y^2)^2 + 2 z^2 (x^2+y^2)`.
+
+Frequency unit conversion (when `TrapOmegaUnit cm-1`):
+`w[Eh] = nu[cm^-1] * 4.5563352529e-6`.
+
+## Matrix elements
+
+`V` is a sum of Cartesian monomials `C_{abc} (x-X0)^a (y-Y0)^b (z-Z0)^c` of total
+degree 2 or 4; its matrix in the protonic AO basis is a linear combination of
+Cartesian moment integrals `M^{abc} = <mu| (x-X0)^a (y-Y0)^b (z-Z0)^c |nu>`,
+formed by ERKALE's existing `BasisSet::moment(order, X0, Y0, Z0)` (order 4 =
+15 moments), indexed by `getind(a,b,c)`:
+
+```
+V = 1/2 m w_perp^2 (M^{200} + M^{020})
+  + 1/2 m w_par^2   M^{002}
+  + lam_par         M^{004}
+  + lam_perp        (M^{400} + 2 M^{220} + M^{040})
+  + lam_cross       (M^{202} + M^{022})
+```
+
+`V` is real symmetric and enters `H0p = Tp + Vp + V` exactly like the protonic
+kinetic term `Tp`; nothing about the two-particle (e-p) integrals, the SCF, or
+the CI structure changes.
+
+## Keywords (in the `hneoci` runfile)
+
+| keyword           | meaning                                                        | default |
+|-------------------|----------------------------------------------------------------|---------|
+| `NEOTrap`         | master switch                                                  | `false` |
+| `TrapOmegaUnit`   | unit of `TrapOmega*`: `cm-1` or `Eh`                           | `cm-1`  |
+| `TrapOmegaPar`    | `w_par` (trap frequency along z)                               | `0.0`   |
+| `TrapOmegaPerp`   | `w_perp` (perpendicular frequency; set `== TrapOmegaPar` for isotropic) | `0.0` |
+| `TrapG`           | dimensionless anharmonicity `g` (sets `lam_par`, `lam_perp`)   | `0.0`   |
+| `TrapLambdaCross` | `z^2 (x^2+y^2)` coefficient (a.u.)                             | `0.0`   |
+| `TrapCenter`      | `x y z` in bohr; empty = quantum proton center                | (proton center) |
+
+`NEOTrap false` (or `NEOTrap true` with `TrapG 0` and `w = 0`) reproduces the
+trap-off `hneoci` result bit-for-bit (`build_proton_trap` returns a zero
+matrix when disabled).
+
+**v1 restriction:** a single quantum proton. With more than one protonic
+nucleus, set `TrapCenter` explicitly (otherwise the writer throws).
+
+## Validation (`tests/trap_tests.sh`)
+
+Analytic checks on the printed "Quantum proton spectrum" (the eigenvalues of the
+one-body `H0p`, i.e. the trapped proton without the electron), so no external
+reference code is needed for T0-T3:
+
+- **T0 — regression.** `NEOTrap false` reproduces the baseline energies exactly;
+  `V` is symmetric.
+- **T1 — isotropic harmonic.** A single protonic `s` primitive with exponent
+  `zeta = m w / 2` in an isotropic trap gives proton ground energy `(3/2) w`.
+- **T2 — cylindrical harmonic.** `w_par != w_perp` with a converged basis:
+  ground state `-> w_perp + 1/2 w_par`; ladder = doubly degenerate `pi` at
+  `w_perp`, `sigma` at `w_par`, integer overtones.
+- **T3 — quartic (1D).** Freeze the transverse motion; small `g` gives a
+  ground-state shift `Delta E = (3/4) g w_par`
+  (`<z^4>_0 = 3 / (4 m^2 w_par^2)`, `lam_par = g m^2 w_par^3`).
+
+## Files touched
+
+`src/contrib/hneoci.cpp` only: the keywords, the `build_proton_trap()` matrix
+assembly, and `H0p = Tp + Vp + Vtrap`. No changes to `neo.cpp`, the two-particle
+integrals, the optimizer, or the electronic basis handling.

--- a/src/contrib/hneoci.cpp
+++ b/src/contrib/hneoci.cpp
@@ -94,6 +94,74 @@ void analyze_density(const BasisSet & basis, const arma::mat & P, const std::str
   printf("Root-mean-square size of %s wave packet % .6f\n",label.c_str(),sqrt(rsq-dipsq));
 }
 
+// External one-body confining trap on the quantum proton: a cylindrical
+// harmonic + C-inf-v-invariant quartic potential,
+//   V(r) = 1/2 m [ w_perp^2 (x^2+y^2) + w_par^2 z^2 ]
+//        + lam_par z^4 + lam_perp (x^2+y^2)^2 + lam_cross z^2 (x^2+y^2),
+// with lam_par = g m^2 w_par^3, lam_perp = g m^2 w_perp^3 from the dimensionless
+// anharmonicity g. Assembled from Cartesian moment integrals in the protonic AO
+// basis about the trap center. Returns a zero matrix when NEOTrap is off (so
+// TrapG=0 / trap-off reproduce the baseline bit-for-bit). See README_TRAP.md.
+static arma::mat build_proton_trap(const BasisSet & pbasis, double proton_mass) {
+  const size_t Nbf = pbasis.get_Nbf();
+  arma::mat V(Nbf, Nbf, arma::fill::zeros);
+  if(!settings.get_bool("NEOTrap"))
+    return V;
+
+  // Trap frequencies (convert cm^-1 -> Hartree if requested).
+  double wpar  = settings.get_double("TrapOmegaPar");
+  double wperp = settings.get_double("TrapOmegaPerp");
+  const std::string unit = settings.get_string("TrapOmegaUnit");
+  if(stricmp(unit, "cm-1") == 0) {
+    const double cm2Eh = 4.5563352529e-6;
+    wpar  *= cm2Eh;
+    wperp *= cm2Eh;
+  } else if(stricmp(unit, "Eh") != 0) {
+    throw std::runtime_error("TrapOmegaUnit must be 'cm-1' or 'Eh'.\n");
+  }
+
+  // Quartic couplings from the dimensionless anharmonicity g.
+  const double g  = settings.get_double("TrapG");
+  const double m2 = proton_mass*proton_mass;
+  const double lam_par   = g * m2 * wpar*wpar*wpar;
+  const double lam_perp  = g * m2 * wperp*wperp*wperp;
+  const double lam_cross = settings.get_double("TrapLambdaCross");
+
+  // Trap center: explicit TrapCenter, else the protonic nucleus center.
+  double x0=0.0, y0=0.0, z0=0.0;
+  const std::string tc = settings.get_string("TrapCenter");
+  if(tc.size()) {
+    std::vector<std::string> tok = splitline(tc);
+    if(tok.size() != 3)
+      throw std::runtime_error("TrapCenter needs three numbers: x y z (bohr).\n");
+    x0=readdouble(tok[0]); y0=readdouble(tok[1]); z0=readdouble(tok[2]);
+  } else {
+    std::vector<nucleus_t> nuc = pbasis.get_nuclei();
+    if(nuc.size() != 1)
+      throw std::runtime_error("NEOTrap v1 supports a single quantum proton; set TrapCenter for a multi-proton trap.\n");
+    x0=nuc[0].r.x; y0=nuc[0].r.y; z0=nuc[0].r.z;
+  }
+
+  // Cartesian moment integrals about the trap center. moment(n)[getind(a,b,c)]
+  // is < mu | (x-x0)^a (y-y0)^b (z-z0)^c | nu >.
+  std::vector<arma::mat> M2 = pbasis.moment(2, x0, y0, z0);
+  std::vector<arma::mat> M4 = pbasis.moment(4, x0, y0, z0);
+
+  V += 0.5*proton_mass*wperp*wperp * (M2[getind(2,0,0)] + M2[getind(0,2,0)]);
+  V += 0.5*proton_mass*wpar *wpar  *  M2[getind(0,0,2)];
+  V += lam_par   *  M4[getind(0,0,4)];
+  V += lam_perp  * (M4[getind(4,0,0)] + 2.0*M4[getind(2,2,0)] + M4[getind(0,4,0)]);
+  V += lam_cross * (M4[getind(2,0,2)] + M4[getind(0,2,2)]);
+
+  // The moment integrals are symmetric; enforce it exactly against round-off.
+  V = 0.5*(V + V.t());
+
+  printf("NEO proton trap: w_par = %.6e Eh, w_perp = %.6e Eh, g = %.5f, lam_cross = %.4e a.u.; center (% .4f % .4f % .4f).\n",
+         wpar, wperp, g, lam_cross, x0, y0, z0);
+  fflush(stdout);
+  return V;
+}
+
 int main_guarded(int argc, char **argv) {
   print_header();
 
@@ -115,6 +183,14 @@ int main_guarded(int argc, char **argv) {
   settings.add_bool("H2", "Run H2+ instead of H atom?", false);
   settings.add_double("H2BondLength", "Bond length for H2+ in a.u.", 2.0);
   settings.add_bool("RemoveCOM", "Remove COM terms", false);
+  // External one-body confining trap on the quantum proton (see README_TRAP.md)
+  settings.add_bool("NEOTrap", "Apply an external harmonic + quartic trap to the quantum proton", false);
+  settings.add_string("TrapOmegaUnit", "Unit of the trap frequencies: cm-1 or Eh", "cm-1");
+  settings.add_double("TrapOmegaPar", "Trap frequency along the z axis (w_par)", 0.0);
+  settings.add_double("TrapOmegaPerp", "Trap frequency perpendicular to z (w_perp)", 0.0);
+  settings.add_double("TrapG", "Dimensionless quartic anharmonicity g (sets lam_par, lam_perp)", 0.0);
+  settings.add_double("TrapLambdaCross", "Coefficient of the z^2 (x^2+y^2) quartic, a.u.", 0.0);
+  settings.add_string("TrapCenter", "Trap center 'x y z' in bohr (empty = quantum proton center)", "");
 
   // Parse settings
   settings.parse(std::string(argv[1]),true);
@@ -216,9 +292,14 @@ int main_guarded(int argc, char **argv) {
     Vp = -pbasis.nuclear(classical_nuclei);
   }
 
+  // External confining trap on the quantum proton (one-body). Added to the
+  // proton core Hamiltonian, so both the BO proton spectrum and the CI (which
+  // read H0p below) see it. Zero unless NEOTrap is enabled.
+  arma::mat Vtrap = build_proton_trap(pbasis, proton_mass);
+
   // Core Hamiltonian
   arma::mat H0 = T + V;
-  arma::mat H0p = Tp + Vp;
+  arma::mat H0p = Tp + Vp + Vtrap;
 
   // Orthogonalizing matrices
   arma::mat Xe(BasOrth(Se,verbose));
@@ -240,6 +321,11 @@ int main_guarded(int argc, char **argv) {
   arma::eig_sym(Ep_bo, Cp_bo, Hp_bo);
   arma::mat Xp_bo = Xp * Cp_bo;
   Ep_bo.print("Quantum proton spectrum");
+  // Low protonic roots at full precision (parseable by the trap sweep / tests).
+  for(size_t i=0;i<std::min((size_t) 8, (size_t) Ep_bo.n_elem);i++) {
+    printf("Proton root %2i % .10e\n", (int) i, Ep_bo(i));
+    fflush(stdout);
+  }
 
   // Compute the two-electron integrals
   size_t e_nbf = basis.get_Nbf();

--- a/tests/trap_tests.sh
+++ b/tests/trap_tests.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+#
+# Analytic validation of the external proton trap in erkale_hneoci.
+# See README_TRAP.md for the operator, keywords and the theory behind T0-T3.
+#
+# The trap is added to the one-body protonic core Hamiltonian H0p, so the
+# printed "Proton root" values are the eigenvalues of the *trapped free proton*
+# (the electron does not enter H0p). In a single, matched Gaussian the proton
+# energy equals the exact expectation value, which makes T1/T3 analytic.
+#
+# Usage:  tests/trap_tests.sh [path-to-erkale_hneoci]
+# Env:    ERKALE_LIBRARY (basis directory) — defaults to <repo>/basis
+#
+set -u
+
+here=$(cd "$(dirname "$0")" && pwd)
+root=$(cd "$here/.." && pwd)
+export ERKALE_LIBRARY=${ERKALE_LIBRARY:-$root/basis}
+
+# Locate the hneoci executable (arg overrides autodetection).
+HN=${1:-}
+if [ -z "$HN" ]; then
+  for c in "$root"/openmp/src/contrib/erkale_hneoci_omp \
+           "$root"/serial/src/contrib/erkale_hneoci \
+           "$(command -v erkale_hneoci_omp 2>/dev/null)" \
+           "$(command -v erkale_hneoci 2>/dev/null)"; do
+    [ -n "$c" ] && [ -x "$c" ] && HN="$c" && break
+  done
+fi
+if [ -z "$HN" ] || [ ! -x "$HN" ]; then
+  echo "ERROR: erkale_hneoci not found. Build it, or pass its path as argument."
+  exit 2
+fi
+echo "Using binary : $HN"
+echo "ERKALE_LIBRARY: $ERKALE_LIBRARY"
+
+mp=1836.15267389            # must match ProtonMass default in hneoci.cpp
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+pass=0; fail=0
+
+# root <outfile> <index>  -> the printed proton eigenvalue
+root() { awk -v i="$2" '$1=="Proton"&&$2=="root"&&$3==i{print $4}' "$1"; }
+cienergy() { awk '/CI energy/{print $3}' "$1"; }
+
+# assert_close <name> <got> <expect> <tol>
+assert_close() {
+  python3 - "$@" <<'PY'
+import sys
+name,got,exp,tol=sys.argv[1],sys.argv[2],float(sys.argv[3]),float(sys.argv[4])
+try: g=float(got)
+except: print("FAIL %-26s (no value parsed)"%name); sys.exit(1)
+ok=abs(g-exp)<=tol
+print("%s %-26s got %.10e  expect %.10e  |d|=%.2e (tol %.0e)"%(("PASS" if ok else "FAIL"),name,g,exp,abs(g-exp),tol))
+sys.exit(0 if ok else 1)
+PY
+}
+tally() { if [ "$1" -eq 0 ]; then pass=$((pass+1)); else fail=$((fail+1)); fi; }
+
+# Single s primitive matched to an isotropic trap of frequency w: zeta = mp*w/2.
+matched_basis() { # <w> <file>
+  python3 -c "print('H     0');print('S   1   1.00');print('   %.10f   1.00'%($mp*$1/2))" > "$2"
+  echo "****" >> "$2"
+}
+# Even-tempered s..f protonic basis for the anisotropic-oscillator convergence test.
+et_basis() { # <file>
+  python3 - "$1" <<'PY'
+import sys
+a0,beta,N=0.5,2.2,12
+tag=["S","P","D","F"]; out=["H     0"]
+for am in range(4):
+    for i in range(N):
+        out+= ["%s   1   1.00"%tag[am], "   %18.10f   1.00"%(a0*beta**i)]
+out.append("****")
+open(sys.argv[1],"w").write("\n".join(out)+"\n")
+PY
+}
+
+echo; echo "=============================== T0 : regression ==============================="
+# Trap off vs. trap enabled but identically zero must be bit-for-bit identical.
+cat > "$work/t0off.run"  <<EOF
+Basis cc-pVDZ
+NEOTrap false
+EOF
+cat > "$work/t0zero.run" <<EOF
+Basis cc-pVDZ
+NEOTrap true
+TrapOmegaUnit Eh
+TrapOmegaPar 0.0
+TrapOmegaPerp 0.0
+TrapG 0.0
+EOF
+"$HN" "$work/t0off.run"  > "$work/t0off.out"  2>&1
+"$HN" "$work/t0zero.run" > "$work/t0zero.out" 2>&1
+eoff=$(cienergy "$work/t0off.out"); ezero=$(cienergy "$work/t0zero.out")
+if [ -n "$eoff" ] && [ "$eoff" = "$ezero" ]; then
+  echo "PASS T0 CI-energy bit-identical  ($eoff)"; tally 0
+else
+  echo "FAIL T0 CI-energy differ  off=$eoff  zero=$ezero"; tally 1
+fi
+
+echo; echo "======================== T1 : isotropic harmonic (E0 = 3/2 w) ================="
+w=0.01; matched_basis $w "$work/s.gbs"
+cat > "$work/t1.run" <<EOF
+Basis cc-pVDZ
+ProtonBasis $work/s.gbs
+NEOTrap true
+TrapOmegaUnit Eh
+TrapOmegaPar $w
+TrapOmegaPerp $w
+TrapG 0.0
+EOF
+"$HN" "$work/t1.run" > "$work/t1.out" 2>&1
+assert_close "T1 E0=3/2 w" "$(root "$work/t1.out" 0)" "$(python3 -c "print(1.5*$w)")" 1e-8; tally $?
+
+echo; echo "=================== T3 : quartic, exact single-Gaussian expectation ==========="
+# Isotropic g: <z^4>+<(x^2+y^2)^2> = 3/(4 m^2 w^2)+2/(m^2 w^2) => dE = (11/4) g w
+g=0.001
+cat > "$work/t3g.run" <<EOF
+Basis cc-pVDZ
+ProtonBasis $work/s.gbs
+NEOTrap true
+TrapOmegaUnit Eh
+TrapOmegaPar $w
+TrapOmegaPerp $w
+TrapG $g
+EOF
+"$HN" "$work/t3g.run" > "$work/t3g.out" 2>&1
+assert_close "T3 isotropic quartic" "$(root "$work/t3g.out" 0)" \
+  "$(python3 -c "print(1.5*$w + 2.75*$g*$w)")" 1e-8; tally $?
+# Pure cross term: dE = lam_cross * <z^2(x^2+y^2)> = lam_cross / (2 m^2 w^2)
+L=0.01
+cat > "$work/t3c.run" <<EOF
+Basis cc-pVDZ
+ProtonBasis $work/s.gbs
+NEOTrap true
+TrapOmegaUnit Eh
+TrapOmegaPar $w
+TrapOmegaPerp $w
+TrapG 0.0
+TrapLambdaCross $L
+EOF
+"$HN" "$work/t3c.run" > "$work/t3c.out" 2>&1
+assert_close "T3 cross quartic" "$(root "$work/t3c.out" 0)" \
+  "$(python3 -c "mp=$mp;w=$w;print(1.5*w + $L/(2*mp*mp*w*w))")" 1e-8; tally $?
+
+echo; echo "============= T2 : cylindrical harmonic (E0 -> w_perp + 1/2 w_par) ============="
+wpar=0.02; wperp=0.01; et_basis "$work/et.gbs"
+cat > "$work/t2.run" <<EOF
+Basis cc-pVDZ
+ProtonBasis $work/et.gbs
+NEOTrap true
+TrapOmegaUnit Eh
+TrapOmegaPar $wpar
+TrapOmegaPerp $wperp
+TrapG 0.0
+EOF
+"$HN" "$work/t2.run" > "$work/t2.out" 2>&1
+E0=$(root "$work/t2.out" 0); E1=$(root "$work/t2.out" 1); E2=$(root "$work/t2.out" 2)
+# Ground state converges from above to w_perp + 1/2 w_par.
+assert_close "T2 E0=w_perp+w_par/2" "$E0" "$(python3 -c "print($wperp+0.5*$wpar)")" 5e-4; tally $?
+# First excitation is a doubly-degenerate pi mode at w_perp above E0.
+assert_close "T2 E1-E0 = w_perp" "$(python3 -c "print($E1-($E0))")" "$wperp" 2e-3; tally $?
+assert_close "T2 pi degeneracy E2=E1" "$E2" "$E1" 1e-7; tally $?
+
+echo; echo "==============================================================================="
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Adds a static, one-body external confining potential on the quantum proton so a single electron + single proton can be solved (BO proton spectrum and `hneoci` FCI) with the proton held in a tunable **cylindrical harmonic + C∞ᵥ quartic** trap. This turns a free 1e + 1p system into an anchored, contamination-free laboratory for optimizing protonic and near-proton electronic Gaussian exponents.

Only `hneoci.cpp` is touched (+87/−1). No changes to `neo.cpp`, the two-particle e–p integrals, the optimizer, or the electronic basis handling.

## The operator

```
V(r) = 1/2 m [ w_perp^2 (x^2+y^2) + w_par^2 z^2 ]
     + lam_par z^4 + lam_perp (x^2+y^2)^2 + lam_cross z^2 (x^2+y^2)
```

with `lam_par = g m^2 w_par^3`, `lam_perp = g m^2 w_perp^3` from the dimensionless anharmonicity `g`. Assembled from Cartesian moment integrals up to order 4 in the protonic AO basis via the existing `BasisSet::moment` engine, then added to the proton core Hamiltonian `H0p = Tp + Vp + Vtrap`. It is therefore seen by **both** the BO "Quantum proton spectrum" **and** the CI (`H0p → H0p_mo → H0_ci`), entering exactly like `Tp`.

## Keywords

`NEOTrap`, `TrapOmegaUnit` (`cm-1`/`Eh`), `TrapOmegaPar`, `TrapOmegaPerp`, `TrapG`, `TrapLambdaCross`, `TrapCenter`. `NEOTrap false` (or `w = g = 0`) reproduces the baseline bit-for-bit. v1 supports a single quantum proton (set `TrapCenter` explicitly otherwise). The low protonic roots are also emitted at full precision for downstream sweeps.

See `README_TRAP.md` for the full operator, the `g→λ` mapping, and unit conversion.

## Validation — `tests/trap_tests.sh` (T0–T3, 7/7 passing)

| test | got | expected |
|---|---|---|
| T0 regression | CI energy bit-identical | trap-off ≡ trap-zero |
| T1 isotropic harmonic | `1.5000000000e-02` | `1.5·w` |
| T3 isotropic quartic | `1.5027500000e-02` | `1.5w + (11/4)g·w` |
| T3 cross quartic | `1.5014830385e-02` | `1.5w + λ_cross/(2m²w²)` |
| T2 E₀ | `2.0069e-02` | `w_perp + ½w_par = 0.02` (from above) |
| T2 π excitation | `1.0054e-02`, doubly degenerate | `w_perp` |

T1/T3 are exact to 10 significant figures (single matched Gaussian → energy = expectation value), pinning every 2nd- and 4th-order moment and coefficient; T2 confirms the anisotropy wiring (`w_par↔z`, `w_perp↔xy`) and clean m_ℓ degeneracies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)