### PR TITLE
hneoci: per-state protonic moments and CI state averaging

### DIFF
--- a/README_MOMENTS.md
+++ b/README_MOMENTS.md
@@ -1,0 +1,186 @@
+# Per-state protonic moments and state averaging in `hneoci`
+
+`erkale_hneoci` solves a single electron plus a single quantum proton by full CI.
+This document covers the multi-root analysis layered on top of that: for the low
+CI manifold it reports each root's energy, excitation gap and **protonic density
+moments** ⟨z²⟩, ⟨x²+y²⟩, ⟨z⁴⟩, plus a **state-averaged** energy, moment set and
+1-RDM. A machine-readable `.props.json` sidecar carries all of it, so a sweep
+driver parses data rather than prose.
+
+The confining trap these moments are usually measured against is documented
+separately in [`README_TRAP.md`](README_TRAP.md).
+
+## What "state averaging" means here
+
+For a 1e + 1p system `hneoci`'s CISD is FCI, and **FCI roots and their densities
+are invariant to the choice of reference orbitals**. One diagonalization of the
+CI Hamiltonian in the fixed one-particle space yields every root and every
+eigenvector, whether or not the underlying orbitals were state-averaged.
+
+So there is no state-averaged MCSCF here, and there is nothing to gain from one.
+"State averaging" is strictly a **post-diagonalization weighted average over the
+CI roots** — an optimization target, not an orbital-optimization scheme. Were the
+CI ever truncated rather than full, SA orbitals would begin to matter; that is
+out of scope and flagged in the code.
+
+## The protonic 1-RDM
+
+The CI vector of root `I` has coefficients `c^I_{i,P}` over products of an
+electronic and a protonic orbital. Tracing out the electron gives the protonic
+one-particle density matrix in the protonic MO basis,
+
+```
+D^{I,p}_{PQ} = sum_i c^I_{i,P} c^I_{i,Q}
+```
+
+which the protonic MO coefficients back-transform to the AO basis,
+`D^{I,AO} = Cp D^{I,p} Cp^T`. For a normalized single-proton root
+`Tr D^{I,p} = 1`, hence `Tr[D^{I,AO} S_p] = 1` — reported per root as
+`Tr[D S_p]`, and a sharp check on the tracing.
+
+The moment operators are exactly the Cartesian moment matrices the trap is
+assembled from, taken about the **same center** `R0` (`TrapCenter`, or the
+quantum proton's basis center):
+
+```
+<z^2>_I     = Tr[ D^{I,AO} M^{002} ]
+<x^2+y^2>_I = Tr[ D^{I,AO} (M^{200} + M^{020}) ]
+<z^4>_I     = Tr[ D^{I,AO} M^{004} ]
+```
+
+No new integrals are computed: `build_proton_trap` now returns the moment
+matrices it already formed, and they are formed even with the trap off whenever
+the moments are requested. `MomentsFull` additionally reports
+⟨x²⟩, ⟨y²⟩, ⟨x⁴⟩, ⟨y⁴⟩, ⟨x²y²⟩, ⟨x²z²⟩, ⟨y²z²⟩ — free once `D^{I,AO}` is in hand.
+
+The state average is formed as `D_avg = sum_I w_I D^{I,AO}` and contracted once;
+this is identical to averaging the per-root moments, since the contraction is
+linear in `D`.
+
+## Keywords
+
+| keyword        | meaning                                                             | default |
+|----------------|---------------------------------------------------------------------|---------|
+| `NRoots`       | number of CI roots to solve, store and print                        | `1`     |
+| `PrintMoments` | per-state protonic moments ⟨z²⟩, ⟨x²+y²⟩, ⟨z⁴⟩                      | `false` |
+| `MomentsFull`  | also print the full order-2 / order-4 moment set                    | `false` |
+| `StateAverage` | report the weighted `E_avg` and moment averages                     | `false` |
+| `SAWeights`    | per-root weights, renormalized; shorter list zero-pads (empty = equal) | (equal) |
+| `SADensityOut` | write the state-averaged protonic 1-RDM in the AO basis (implies `StateAverage`) | `false` |
+
+**Regression guard.** With the defaults (`NRoots 1`, `PrintMoments false`,
+`StateAverage false`) no multi-root block is printed, no moment integrals are
+formed, and no sidecar is written — the numerical output is exactly that of the
+pre-change `hneoci`. The only textual difference is that `settings.print()`
+echoes the six new keywords, as it does for every registered keyword.
+
+## Output
+
+The per-root table and the average block go to stdout:
+
+```
+ root         E (Eh)             gap (Eh)         Tr[D S_p]        <z^2>         <x^2+y^2>        <z^4>
+    0   0.013405730965   0.000000000000    1.00000000  2.72308511e-02 5.44617021e-02 2.22455775e-03
+    1   0.023405731023   0.010000000058    1.00000000  2.72308511e-02 1.08923404e-01 2.22455775e-03
+...
+State average over 4 roots, SAWeights weights: 0.000000 0.333333 0.333333 0.333333
+  E_avg =  0.023405731023
+  <z^2>_avg = 4.53847518e-02  <x^2+y^2>_avg = 9.07695036e-02  <z^4>_avg = 5.19063475e-03
+```
+
+Alongside them, `<runfile>.props.json` — energies in Hartree, moments in bohr² /
+bohr⁴, all numbers written at round-trip double precision (`%.17g`):
+
+```json
+{
+  "trap": {"enabled": true, "omega_par_au": 0.01, "omega_perp_au": 0.01,
+           "g": 0, "lambda_cross_au": 0, "center": [0, 0, 0]},
+  "roots": [
+    {"index": 0, "E": 0.0134057, "gap": 0, "trace": 1, "z2": 0.0272308, "x2py2": 0.0544617, "z4": 0.00222456}
+  ],
+  "state_average": {"weights": [0, 0.3333, 0.3333, 0.3333], "E": 0.0234057,
+                    "z2": 0.0453848, "x2py2": 0.0907695, "z4": 0.00519063,
+                    "density_file": "..."}
+}
+```
+
+`MomentsFull` adds `x2`, `y2`, `x4`, `y4`, `x2y2`, `x2z2`, `y2z2` to each record
+(note `x2py2` = ⟨x²+y²⟩ versus `x2y2` = ⟨x²y²⟩). `SADensityOut` writes
+`<runfile>.sadens.dat`, the AO-basis `D_avg` as a plain ASCII matrix
+(`numpy.loadtxt`-readable), and records its path in the sidecar.
+
+## A caveat on degenerate roots
+
+Within a degenerate manifold the individual CI eigenvectors are basis dependent
+— LAPACK returns *some* orthonormal set spanning it. Per-state moments of
+degenerate roots are therefore **not** physically meaningful on their own: for a
+cylindrical trap ⟨x²⟩ = ⟨y²⟩ holds per state only for a *nondegenerate* state,
+while inside a π doublet only quantities summed over the manifold are invariant.
+
+This is why the validation below averages over the whole n=1 manifold rather
+than testing an individual π root, and why the σ state is isolated with a
+`TrapLambdaCross` splitting before its moments are compared.
+
+## Validation (`tests/moment_tests.sh`, checks in `tests/moment_check.py`)
+
+Every reference below is **exact to machine precision** — 38/38 assertions pass
+with residuals at the 1e-15 level. Two constructions make that possible.
+
+*Decoupling the electron.* The electron is given a single, very diffuse `s`
+primitive (ζ = 10⁻⁶). Its density is then flat across the proton's extent, so
+the proton feels the trap plus a constant. Crucially, that electronic density is
+*spherical*, so the effective potential it exerts on the proton is radial: it
+cannot couple protonic states of different parity. The protonic CI states are
+therefore exactly the harmonic-oscillator states.
+
+*A protonic basis that is exact, not merely converged.* A single `s` and a single
+`p` primitive at ζ = m w / 2 represent the n = 0 and n = 1 isotropic-oscillator
+states **exactly**. (An *anisotropic* trap cannot be treated this way: its
+eigenfunctions need l = 0, 2, 4, … and isotropic Gaussians converge to them only
+slowly — an ET s–f set still leaves ~6 % error in ⟨z²⟩ while the gaps are already
+within 1 %. Moments converge much more slowly than energies.)
+
+With `b = m w`:
+
+- **V1 — ground-state moments.** ⟨z²⟩₀ = 1/(2b), ⟨x²+y²⟩₀ = 1/b, ⟨z⁴⟩₀ = 3/(4b²).
+- **V2 — excited-state moments.** A negative `TrapLambdaCross` pushes σ_z below
+  the π doublet. Parity keeps the trap block-diagonal in {s, pₓ, p_y, p_z}, so
+  the splitting **reorders the states without mixing them**: root 1 is exactly
+  the σ_z oscillator state, with ⟨z²⟩ = 3/(2b), ⟨z⁴⟩ = 15/(4b²), ⟨x²+y²⟩ = 1/b.
+  The σ/π splitting itself equals |λ_cross|/(2b²), which independently pins the
+  sign and scale of the `M202 + M022` assembly. Confirms the *excited-state* RDM,
+  not just the ground state.
+- **V3 — gaps.** The isotropic n = 1 manifold sits exactly `w` above the ground
+  root. (The anisotropic ladder — π at `w_perp`, σ at `w_par` — is brief-1's T2
+  in `tests/trap_tests.sh`.)
+- **V4 — RDM trace.** `Tr[D^{I,AO} S_p] = 1` for every root. Catches any
+  normalization or tracing error.
+- **V5 — averaging.** Weights `(1,0,0,0)` reproduce the root-0 values exactly;
+  empty `SAWeights` gives the arithmetic mean; the degeneracy-invariant
+  equal-weight average over the n = 1 manifold gives ⟨z²⟩ = 5/(6b),
+  ⟨x²+y²⟩ = 5/(3b), ⟨z⁴⟩ = 7/(4b²). `D_avg` is symmetric, and ⟨x²⟩ = ⟨y²⟩ both
+  for the nondegenerate ground root and summed over the π manifold.
+- **V6 — regression.** A default run prints no multi-root block and writes no
+  sidecar; enabling the machinery leaves the `CI energy` bit-identical.
+
+Run it with:
+
+```bash
+tests/moment_tests.sh                 # autodetects openmp/ or serial/ build
+tests/moment_tests.sh /path/to/erkale_hneoci
+```
+
+## Files touched
+
+`src/contrib/hneoci.cpp` only. `build_proton_trap` now returns a `proton_trap_t`
+carrying the trap center and its moment matrices (previously it returned the bare
+potential and discarded the moments); everything else is new code —
+`proton_rdm`, `proton_moments`, `sa_weights`, `write_props`, and the reporting
+block. The CI Hamiltonian build, the trap operator, the integrals and the orbital
+handling are unchanged.
+
+One pre-existing defect was fixed in passing: `TrapLambdaCross` was registered
+with ERKALE's default `negative=false`, so `settings` rejected negative values.
+λ_cross is an independent coefficient of either sign — only the total `V` need
+stay confining — and negative values are needed to push σ_z below π. It is now
+registered with `negative=true`.

--- a/README_TRAP.md
+++ b/README_TRAP.md
@@ -67,8 +67,11 @@ the CI structure changes.
 | `TrapOmegaPar`    | `w_par` (trap frequency along z)                               | `0.0`   |
 | `TrapOmegaPerp`   | `w_perp` (perpendicular frequency; set `== TrapOmegaPar` for isotropic) | `0.0` |
 | `TrapG`           | dimensionless anharmonicity `g` (sets `lam_par`, `lam_perp`)   | `0.0`   |
-| `TrapLambdaCross` | `z^2 (x^2+y^2)` coefficient (a.u.)                             | `0.0`   |
+| `TrapLambdaCross` | `z^2 (x^2+y^2)` coefficient (a.u.); either sign is allowed      | `0.0`   |
 | `TrapCenter`      | `x y z` in bohr; empty = quantum proton center                | (proton center) |
+
+Per-state protonic moments about the trap center, multi-root energies and state
+averaging are documented in [`README_MOMENTS.md`](README_MOMENTS.md).
 
 `NEOTrap false` (or `NEOTrap true` with `TrapG 0` and `w = 0`) reproduces the
 trap-off `hneoci` result bit-for-bit (`build_proton_trap` returns a zero
@@ -90,12 +93,17 @@ reference code is needed for T0-T3:
 - **T2 — cylindrical harmonic.** `w_par != w_perp` with a converged basis:
   ground state `-> w_perp + 1/2 w_par`; ladder = doubly degenerate `pi` at
   `w_perp`, `sigma` at `w_par`, integer overtones.
-- **T3 — quartic (1D).** Freeze the transverse motion; small `g` gives a
-  ground-state shift `Delta E = (3/4) g w_par`
-  (`<z^4>_0 = 3 / (4 m^2 w_par^2)`, `lam_par = g m^2 w_par^3`).
+- **T3 — quartic.** In a single matched Gaussian the proton energy *is* the
+  expectation value, so the quartic shift is exact for any `g`, not just
+  perturbatively. Isotropic `g` gives `Delta E = (11/4) g w` (pinning `M^{004}`,
+  `M^{400}`, `M^{040}` and the factor 2 on `M^{220}`), and a pure cross term
+  gives `Delta E = lam_cross / (2 m^2 w^2)` (pinning `M^{202} + M^{022}`).
+  A single axis-resolved `g` also drives `lam_perp`, so the transverse motion
+  cannot be frozen through the keyword set; these exact expectation values are a
+  stronger check than the perturbative 1D shift `(3/4) g w_par` would be.
 
 ## Files touched
 
 `src/contrib/hneoci.cpp` only: the keywords, the `build_proton_trap()` matrix
-assembly, and `H0p = Tp + Vp + Vtrap`. No changes to `neo.cpp`, the two-particle
+assembly, and `H0p = Tp + Vp + trap.V`. No changes to `neo.cpp`, the two-particle
 integrals, the optimizer, or the electronic basis handling.

--- a/src/contrib/hneoci.cpp
+++ b/src/contrib/hneoci.cpp
@@ -94,72 +94,235 @@ void analyze_density(const BasisSet & basis, const arma::mat & P, const std::str
   printf("Root-mean-square size of %s wave packet % .6f\n",label.c_str(),sqrt(rsq-dipsq));
 }
 
-// External one-body confining trap on the quantum proton: a cylindrical
-// harmonic + C-inf-v-invariant quartic potential,
+// External one-body confining trap on the quantum proton, together with the
+// Cartesian moment integrals it is assembled from. The same moments serve the
+// per-state protonic moment analysis, so they are formed exactly once and about
+// exactly one center. See README_TRAP.md and README_MOMENTS.md.
+struct proton_trap_t {
+  /// Is the trap active (NEOTrap)?
+  bool enabled;
+  /// Trap frequencies, in Hartree
+  double wpar, wperp;
+  /// Dimensionless quartic anharmonicity, and the z^2 (x^2+y^2) coefficient
+  double g, lam_cross;
+  /// Trap center, in bohr
+  double x0, y0, z0;
+  /// Cartesian moments about the trap center: M[getind(a,b,c)] is
+  /// < mu | (x-x0)^a (y-y0)^b (z-z0)^c | nu >, of total degree 2 resp. 4.
+  /// Empty unless the trap or the moment analysis needs them.
+  std::vector<arma::mat> M2, M4;
+  /// One-body trap matrix in the protonic AO basis; zero matrix if !enabled
+  arma::mat V;
+};
+
+// Build the trap operator
 //   V(r) = 1/2 m [ w_perp^2 (x^2+y^2) + w_par^2 z^2 ]
 //        + lam_par z^4 + lam_perp (x^2+y^2)^2 + lam_cross z^2 (x^2+y^2),
 // with lam_par = g m^2 w_par^3, lam_perp = g m^2 w_perp^3 from the dimensionless
-// anharmonicity g. Assembled from Cartesian moment integrals in the protonic AO
-// basis about the trap center. Returns a zero matrix when NEOTrap is off (so
-// TrapG=0 / trap-off reproduce the baseline bit-for-bit). See README_TRAP.md.
-static arma::mat build_proton_trap(const BasisSet & pbasis, double proton_mass) {
-  const size_t Nbf = pbasis.get_Nbf();
-  arma::mat V(Nbf, Nbf, arma::fill::zeros);
-  if(!settings.get_bool("NEOTrap"))
-    return V;
+// anharmonicity g. V is a zero matrix when NEOTrap is off (so TrapG=0 / trap-off
+// reproduce the baseline bit-for-bit). The moment integrals are also formed when
+// want_moments is set, even with the trap off, so that the protonic moments can
+// be reported for an untrapped proton.
+static proton_trap_t build_proton_trap(const BasisSet & pbasis, double proton_mass, bool want_moments) {
+  proton_trap_t tr;
+  tr.enabled = settings.get_bool("NEOTrap");
+  tr.wpar = tr.wperp = tr.g = tr.lam_cross = 0.0;
+  tr.x0 = tr.y0 = tr.z0 = 0.0;
+  tr.V.zeros(pbasis.get_Nbf(), pbasis.get_Nbf());
+  if(!tr.enabled && !want_moments)
+    return tr;
 
-  // Trap frequencies (convert cm^-1 -> Hartree if requested).
-  double wpar  = settings.get_double("TrapOmegaPar");
-  double wperp = settings.get_double("TrapOmegaPerp");
-  const std::string unit = settings.get_string("TrapOmegaUnit");
-  if(stricmp(unit, "cm-1") == 0) {
-    const double cm2Eh = 4.5563352529e-6;
-    wpar  *= cm2Eh;
-    wperp *= cm2Eh;
-  } else if(stricmp(unit, "Eh") != 0) {
-    throw std::runtime_error("TrapOmegaUnit must be 'cm-1' or 'Eh'.\n");
-  }
-
-  // Quartic couplings from the dimensionless anharmonicity g.
-  const double g  = settings.get_double("TrapG");
-  const double m2 = proton_mass*proton_mass;
-  const double lam_par   = g * m2 * wpar*wpar*wpar;
-  const double lam_perp  = g * m2 * wperp*wperp*wperp;
-  const double lam_cross = settings.get_double("TrapLambdaCross");
-
-  // Trap center: explicit TrapCenter, else the protonic nucleus center.
-  double x0=0.0, y0=0.0, z0=0.0;
+  // Trap center: explicit TrapCenter, else the protonic nucleus center. This
+  // is also the origin the reported protonic moments refer to.
   const std::string tc = settings.get_string("TrapCenter");
   if(tc.size()) {
     std::vector<std::string> tok = splitline(tc);
     if(tok.size() != 3)
       throw std::runtime_error("TrapCenter needs three numbers: x y z (bohr).\n");
-    x0=readdouble(tok[0]); y0=readdouble(tok[1]); z0=readdouble(tok[2]);
+    tr.x0=readdouble(tok[0]); tr.y0=readdouble(tok[1]); tr.z0=readdouble(tok[2]);
   } else {
     std::vector<nucleus_t> nuc = pbasis.get_nuclei();
     if(nuc.size() != 1)
       throw std::runtime_error("NEOTrap v1 supports a single quantum proton; set TrapCenter for a multi-proton trap.\n");
-    x0=nuc[0].r.x; y0=nuc[0].r.y; z0=nuc[0].r.z;
+    tr.x0=nuc[0].r.x; tr.y0=nuc[0].r.y; tr.z0=nuc[0].r.z;
   }
 
-  // Cartesian moment integrals about the trap center. moment(n)[getind(a,b,c)]
-  // is < mu | (x-x0)^a (y-y0)^b (z-z0)^c | nu >.
-  std::vector<arma::mat> M2 = pbasis.moment(2, x0, y0, z0);
-  std::vector<arma::mat> M4 = pbasis.moment(4, x0, y0, z0);
+  tr.M2 = pbasis.moment(2, tr.x0, tr.y0, tr.z0);
+  tr.M4 = pbasis.moment(4, tr.x0, tr.y0, tr.z0);
 
-  V += 0.5*proton_mass*wperp*wperp * (M2[getind(2,0,0)] + M2[getind(0,2,0)]);
-  V += 0.5*proton_mass*wpar *wpar  *  M2[getind(0,0,2)];
-  V += lam_par   *  M4[getind(0,0,4)];
-  V += lam_perp  * (M4[getind(4,0,0)] + 2.0*M4[getind(2,2,0)] + M4[getind(0,4,0)]);
-  V += lam_cross * (M4[getind(2,0,2)] + M4[getind(0,2,2)]);
+  if(!tr.enabled) {
+    printf("Protonic moments referenced to (% .4f % .4f % .4f).\n", tr.x0, tr.y0, tr.z0);
+    fflush(stdout);
+    return tr;
+  }
+
+  // Trap frequencies (convert cm^-1 -> Hartree if requested).
+  tr.wpar  = settings.get_double("TrapOmegaPar");
+  tr.wperp = settings.get_double("TrapOmegaPerp");
+  const std::string unit = settings.get_string("TrapOmegaUnit");
+  if(stricmp(unit, "cm-1") == 0) {
+    const double cm2Eh = 4.5563352529e-6;
+    tr.wpar  *= cm2Eh;
+    tr.wperp *= cm2Eh;
+  } else if(stricmp(unit, "Eh") != 0) {
+    throw std::runtime_error("TrapOmegaUnit must be 'cm-1' or 'Eh'.\n");
+  }
+
+  // Quartic couplings from the dimensionless anharmonicity g.
+  tr.g = settings.get_double("TrapG");
+  const double m2 = proton_mass*proton_mass;
+  const double lam_par   = tr.g * m2 * tr.wpar*tr.wpar*tr.wpar;
+  const double lam_perp  = tr.g * m2 * tr.wperp*tr.wperp*tr.wperp;
+  tr.lam_cross = settings.get_double("TrapLambdaCross");
+
+  tr.V += 0.5*proton_mass*tr.wperp*tr.wperp * (tr.M2[getind(2,0,0)] + tr.M2[getind(0,2,0)]);
+  tr.V += 0.5*proton_mass*tr.wpar *tr.wpar  *  tr.M2[getind(0,0,2)];
+  tr.V += lam_par      *  tr.M4[getind(0,0,4)];
+  tr.V += lam_perp     * (tr.M4[getind(4,0,0)] + 2.0*tr.M4[getind(2,2,0)] + tr.M4[getind(0,4,0)]);
+  tr.V += tr.lam_cross * (tr.M4[getind(2,0,2)] + tr.M4[getind(0,2,2)]);
 
   // The moment integrals are symmetric; enforce it exactly against round-off.
-  V = 0.5*(V + V.t());
+  tr.V = 0.5*(tr.V + tr.V.t());
 
   printf("NEO proton trap: w_par = %.6e Eh, w_perp = %.6e Eh, g = %.5f, lam_cross = %.4e a.u.; center (% .4f % .4f % .4f).\n",
-         wpar, wperp, g, lam_cross, x0, y0, z0);
+         tr.wpar, tr.wperp, tr.g, tr.lam_cross, tr.x0, tr.y0, tr.z0);
   fflush(stdout);
-  return V;
+  return tr;
+}
+
+/// Protonic density moments of a single CI root, in bohr^2 / bohr^4
+struct pmoments_t {
+  double x2, y2, z2, x2py2;
+  double x4, y4, z4, x2y2, x2z2, y2z2;
+};
+
+/// Per-root CI data reported by the multi-root analysis
+struct ciroot_t {
+  /// Total energy and excitation energy from the ground root, in Hartree
+  double E, gap;
+  /// Tr[D S_p], which must be unity for a normalized single-proton root
+  double trace;
+  /// Protonic density moments; zero unless the moments were requested
+  pmoments_t mom;
+};
+
+/// Expectation value Tr[D M] of a symmetric operator over a symmetric density
+static double expval(const arma::mat & D, const arma::mat & M) {
+  return arma::accu(D % M);
+}
+
+/// Protonic density moments of the AO-basis protonic density matrix Dao
+static pmoments_t proton_moments(const arma::mat & Dao, const proton_trap_t & tr) {
+  pmoments_t m;
+  m.x2 = expval(Dao, tr.M2[getind(2,0,0)]);
+  m.y2 = expval(Dao, tr.M2[getind(0,2,0)]);
+  m.z2 = expval(Dao, tr.M2[getind(0,0,2)]);
+  m.x2py2 = m.x2 + m.y2;
+  m.x4 = expval(Dao, tr.M4[getind(4,0,0)]);
+  m.y4 = expval(Dao, tr.M4[getind(0,4,0)]);
+  m.z4 = expval(Dao, tr.M4[getind(0,0,4)]);
+  m.x2y2 = expval(Dao, tr.M4[getind(2,2,0)]);
+  m.x2z2 = expval(Dao, tr.M4[getind(2,0,2)]);
+  m.y2z2 = expval(Dao, tr.M4[getind(0,2,2)]);
+  return m;
+}
+
+// Protonic one-particle density matrix of a CI root, in the protonic AO basis.
+// The CI vector c_{i,I} runs over (electronic MO) x (protonic MO) products, so
+// tracing out the electron gives the protonic RDM in the protonic MO basis,
+//   D^p_{IJ} = sum_i c_{i,I} c_{i,J},
+// which the protonic MO coefficients back-transform to the AO basis. For a
+// normalized root Tr[D^p] = 1, hence Tr[D^AO S_p] = 1.
+static arma::mat proton_rdm(const arma::vec & ci, size_t e_nmo, size_t p_nmo, const arma::mat & Xp_bo) {
+  arma::mat civec(ci);
+  civec.reshape(e_nmo, p_nmo);
+  return Xp_bo * (civec.t()*civec) * Xp_bo.t();
+}
+
+// State-averaging weights over the nr lowest roots. An empty SAWeights means
+// equal weights; a shorter list zero-pads (those roots simply do not
+// contribute). Weights are renormalized to sum to unity.
+static arma::vec sa_weights(size_t nr) {
+  const std::string s = settings.get_string("SAWeights");
+  arma::vec w;
+  if(s.size()) {
+    std::vector<std::string> tok = splitline(s);
+    if(tok.size() > nr)
+      throw std::runtime_error("SAWeights has more entries than there are roots.\n");
+    w.zeros(nr);
+    for(size_t i=0;i<tok.size();i++)
+      w(i) = readdouble(tok[i]);
+  } else
+    w.ones(nr);
+
+  if(arma::any(w < 0.0))
+    throw std::runtime_error("SAWeights must be non-negative.\n");
+  const double sum = arma::sum(w);
+  if(sum <= 0.0)
+    throw std::runtime_error("SAWeights must have a positive sum.\n");
+  return w/sum;
+}
+
+/// Strip the directory-preserving extension off a file name
+static std::string strip_extension(const std::string & fname) {
+  size_t slash = fname.find_last_of("/\\");
+  size_t dot = fname.find_last_of('.');
+  if(dot != std::string::npos && (slash == std::string::npos || dot > slash))
+    return fname.substr(0, dot);
+  return fname;
+}
+
+/// Write the moments of a single state into the JSON sidecar
+static void write_moments_json(FILE *out, const pmoments_t & m, bool full) {
+  fprintf(out, ", \"z2\": %.17g, \"x2py2\": %.17g, \"z4\": %.17g", m.z2, m.x2py2, m.z4);
+  if(full)
+    fprintf(out, ",\n     \"x2\": %.17g, \"y2\": %.17g, \"x4\": %.17g, \"y4\": %.17g,"
+            " \"x2y2\": %.17g, \"x2z2\": %.17g, \"y2z2\": %.17g",
+            m.x2, m.y2, m.x4, m.y4, m.x2y2, m.x2z2, m.y2z2);
+}
+
+// Machine-readable sidecar with the trap parameters, the per-root data and the
+// state average, so that the sweep driver parses data rather than prose.
+// Energies in Hartree, moments in bohr^2 / bohr^4.
+static void write_props(const std::string & fname, const proton_trap_t & tr,
+                        const std::vector<ciroot_t> & roots, bool have_mom, bool full,
+                        bool stateavg, const arma::vec & w, double Eavg,
+                        const pmoments_t & mavg, const std::string & densfile) {
+  FILE *out = fopen(fname.c_str(), "w");
+  if(!out)
+    throw std::runtime_error("Could not open " + fname + " for writing.\n");
+
+  fprintf(out, "{\n");
+  fprintf(out, "  \"trap\": {\"enabled\": %s, \"omega_par_au\": %.17g, \"omega_perp_au\": %.17g,\n"
+          "            \"g\": %.17g, \"lambda_cross_au\": %.17g, \"center\": [%.17g, %.17g, %.17g]},\n",
+          tr.enabled ? "true" : "false", tr.wpar, tr.wperp, tr.g, tr.lam_cross, tr.x0, tr.y0, tr.z0);
+
+  fprintf(out, "  \"roots\": [\n");
+  for(size_t i=0;i<roots.size();i++) {
+    fprintf(out, "    {\"index\": %i, \"E\": %.17g, \"gap\": %.17g, \"trace\": %.17g",
+            (int) i, roots[i].E, roots[i].gap, roots[i].trace);
+    if(have_mom)
+      write_moments_json(out, roots[i].mom, full);
+    fprintf(out, "}%s\n", (i+1<roots.size()) ? "," : "");
+  }
+  fprintf(out, "  ]");
+
+  if(stateavg) {
+    fprintf(out, ",\n  \"state_average\": {\"weights\": [");
+    for(size_t i=0;i<w.n_elem;i++)
+      fprintf(out, "%.17g%s", w(i), (i+1<w.n_elem) ? ", " : "");
+    fprintf(out, "], \"E\": %.17g", Eavg);
+    if(have_mom)
+      write_moments_json(out, mavg, full);
+    if(densfile.size())
+      fprintf(out, ", \"density_file\": \"%s\"", densfile.c_str());
+    fprintf(out, "}");
+  }
+  fprintf(out, "\n}\n");
+  fclose(out);
+
+  printf("Wrote machine-readable properties to %s\n", fname.c_str());
+  fflush(stdout);
 }
 
 int main_guarded(int argc, char **argv) {
@@ -189,8 +352,17 @@ int main_guarded(int argc, char **argv) {
   settings.add_double("TrapOmegaPar", "Trap frequency along the z axis (w_par)", 0.0);
   settings.add_double("TrapOmegaPerp", "Trap frequency perpendicular to z (w_perp)", 0.0);
   settings.add_double("TrapG", "Dimensionless quartic anharmonicity g (sets lam_par, lam_perp)", 0.0);
-  settings.add_double("TrapLambdaCross", "Coefficient of the z^2 (x^2+y^2) quartic, a.u.", 0.0);
+  // lam_cross is an independent coefficient of either sign: it tilts the quartic
+  // between prolate and oblate, and only the total V need stay confining.
+  settings.add_double("TrapLambdaCross", "Coefficient of the z^2 (x^2+y^2) quartic, a.u.", 0.0, true);
   settings.add_string("TrapCenter", "Trap center 'x y z' in bohr (empty = quantum proton center)", "");
+  // Multi-root analysis, protonic moments and state averaging (see README_MOMENTS.md)
+  settings.add_int("NRoots", "Number of CI roots to solve, store and print", 1);
+  settings.add_bool("PrintMoments", "Print the per-state protonic moments <z^2>, <x^2+y^2>, <z^4>", false);
+  settings.add_bool("MomentsFull", "Also print the full order-2 and order-4 protonic moment set", false);
+  settings.add_bool("StateAverage", "Report the weighted state-averaged energy and moments", false);
+  settings.add_string("SAWeights", "Per-root state-averaging weights, renormalized (empty = equal)", "");
+  settings.add_bool("SADensityOut", "Write out the state-averaged protonic 1-RDM in the AO basis", false);
 
   // Parse settings
   settings.parse(std::string(argv[1]),true);
@@ -203,6 +375,26 @@ int main_guarded(int argc, char **argv) {
   bool dimer = settings.get_bool("H2");
   double R = settings.get_double("H2BondLength");
   bool removecom = settings.get_bool("RemoveCOM");
+
+  // Multi-root analysis. Defaults (NRoots 1, no moments, no state average)
+  // reproduce the pre-existing output exactly.
+  int nroots = settings.get_int("NRoots");
+  bool printmom = settings.get_bool("PrintMoments");
+  bool momfull = settings.get_bool("MomentsFull");
+  bool stateavg = settings.get_bool("StateAverage");
+  bool sadens = settings.get_bool("SADensityOut");
+  if(nroots < 1)
+    throw std::runtime_error("NRoots must be at least one.\n");
+  // The averaged density is defined by the state-averaging weights, so asking
+  // for it asks for the state average.
+  if(sadens && !stateavg) {
+    stateavg = true;
+    printf("SADensityOut implies StateAverage.\n");
+    fflush(stdout);
+  }
+  // Moment integrals are only formed if something is going to consume them.
+  bool want_moments = printmom || stateavg;
+  bool report = (nroots > 1) || printmom || stateavg;
 
   // Total mass of the system
   double MT = 1+proton_mass;
@@ -295,11 +487,11 @@ int main_guarded(int argc, char **argv) {
   // External confining trap on the quantum proton (one-body). Added to the
   // proton core Hamiltonian, so both the BO proton spectrum and the CI (which
   // read H0p below) see it. Zero unless NEOTrap is enabled.
-  arma::mat Vtrap = build_proton_trap(pbasis, proton_mass);
+  proton_trap_t trap = build_proton_trap(pbasis, proton_mass, want_moments);
 
   // Core Hamiltonian
   arma::mat H0 = T + V;
-  arma::mat H0p = Tp + Vp + Vtrap;
+  arma::mat H0p = Tp + Vp + trap.V;
 
   // Orthogonalizing matrices
   arma::mat Xe(BasOrth(Se,verbose));
@@ -509,6 +701,98 @@ int main_guarded(int argc, char **argv) {
   printf("\n");
   analyze_density(basis, Pe, "electronic");
   analyze_density(pbasis, Pp, " protonic ");
+
+  // Multi-root analysis: per-root energies, gaps and protonic density moments,
+  // plus their weighted state average.
+  //
+  // The CI is full for these 1e + 1p systems, so the single diagonalization
+  // above already determines every root and its density. FCI roots and their
+  // densities are invariant to the choice of reference orbitals, so a
+  // state-averaged orbital optimization would not change any number below;
+  // "state averaging" here is purely the post-diagonalization weighted average
+  // over the CI roots. (Were the CI ever truncated instead of full, SA orbitals
+  // would then matter -- out of scope.)
+  if(report) {
+    size_t nr = std::min((size_t) nroots, (size_t) E.n_elem);
+    if(nr < (size_t) nroots) {
+      printf("\nOnly %i roots exist in this CI space; reducing NRoots from %i.\n", (int) nr, nroots);
+      fflush(stdout);
+    }
+
+    arma::vec w = sa_weights(nr);
+
+    // Per-root protonic densities and moments, accumulating the state-averaged
+    // density as we go. Averaging the moments and contracting the averaged
+    // density give the same numbers -- the contraction is linear in D.
+    std::vector<ciroot_t> roots(nr);
+    arma::mat Davg(Sp.n_rows, Sp.n_cols, arma::fill::zeros);
+    pmoments_t mavg = {};
+    double Eavg = 0.0;
+    for(size_t I=0;I<nr;I++) {
+      arma::mat Dao = proton_rdm(C.col(I), e_nmo, p_nmo, Xp_bo);
+      roots[I].E = E(I);
+      roots[I].gap = E(I) - E(0);
+      roots[I].trace = expval(Dao, Sp);
+      roots[I].mom = want_moments ? proton_moments(Dao, trap) : pmoments_t();
+      Eavg += w(I)*E(I);
+      Davg += w(I)*Dao;
+    }
+    if(want_moments)
+      mavg = proton_moments(Davg, trap);
+
+    printf("\n root         E (Eh)             gap (Eh)         Tr[D S_p]");
+    if(printmom)
+      printf("        <z^2>         <x^2+y^2>        <z^4>");
+    printf("\n");
+    fflush(stdout);
+    for(size_t I=0;I<nr;I++) {
+      printf(" %4i  % .12f  % .12f    %.8f", (int) I, roots[I].E, roots[I].gap, roots[I].trace);
+      if(printmom)
+        printf("  %14.8e %14.8e %14.8e", roots[I].mom.z2, roots[I].mom.x2py2, roots[I].mom.z4);
+      printf("\n");
+      fflush(stdout);
+    }
+
+    if(printmom && momfull) {
+      // <x^2> == <y^2> holds per state only for a nondegenerate state of a
+      // cylindrical trap; within a degenerate pi manifold only the sum over the
+      // manifold is invariant, since the CI vectors there are basis dependent.
+      printf("\n root        <x^2>          <y^2>          <x^4>          <y^4>"
+             "        <x^2 y^2>      <x^2 z^2>      <y^2 z^2>\n");
+      fflush(stdout);
+      for(size_t I=0;I<nr;I++) {
+        const pmoments_t & m = roots[I].mom;
+        printf(" %4i %14.8e %14.8e %14.8e %14.8e %14.8e %14.8e %14.8e\n",
+               (int) I, m.x2, m.y2, m.x4, m.y4, m.x2y2, m.x2z2, m.y2z2);
+        fflush(stdout);
+      }
+    }
+
+    const std::string jobname = strip_extension(argv[1]);
+    std::string densfile;
+    if(stateavg) {
+      printf("\nState average over %i roots, %s weights:", (int) nr,
+             settings.get_string("SAWeights").size() ? "SAWeights" : "equal");
+      for(size_t I=0;I<nr;I++)
+        printf(" %.6f", w(I));
+      printf("\n  E_avg = % .12f\n", Eavg);
+      if(printmom)
+        printf("  <z^2>_avg = %14.8e  <x^2+y^2>_avg = %14.8e  <z^4>_avg = %14.8e\n",
+               mavg.z2, mavg.x2py2, mavg.z4);
+      fflush(stdout);
+    }
+    if(sadens) {
+      // The state-averaged protonic density in the AO basis: the natural target
+      // density for the protonic basis-set optimizer.
+      densfile = jobname + ".sadens.dat";
+      Davg.save(densfile, arma::raw_ascii);
+      printf("Wrote the state-averaged protonic 1-RDM (AO basis) to %s\n", densfile.c_str());
+      fflush(stdout);
+    }
+
+    write_props(jobname + ".props.json", trap, roots, want_moments,
+                momfull, stateavg, w, Eavg, mavg, densfile);
+  }
 
   printf("\nRunning program took %s.\n",t.elapsed().c_str());
 

--- a/tests/moment_check.py
+++ b/tests/moment_check.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Analytic checks on the per-state protonic moments and state averaging of
+erkale_hneoci.  Driven by tests/moment_tests.sh, which produces the .props.json
+sidecars this script consumes.  See README_MOMENTS.md for the physics.
+
+All references are exact expectation values of the three-dimensional isotropic
+harmonic oscillator of mass m and frequency w, written with b = m w:
+
+    <z^2>_n  = (2 n_z + 1) / (2 b)          <x^2+y^2> = (n_x + n_y + 1) / b
+    <z^4>_n  = 3 (2 n_z^2 + 2 n_z + 1) / (4 b^2)
+"""
+import json
+import sys
+
+npass = nfail = 0
+
+
+def chk(name, got, exp, tol):
+    global npass, nfail
+    d = abs(got - exp)
+    ok = d <= tol
+    print("%s %-34s got %.12e  exact %.12e  |d|=%.2e (tol %.0e)"
+          % ("PASS" if ok else "FAIL", name, got, exp, d, tol))
+    if ok:
+        npass += 1
+    else:
+        nfail += 1
+
+
+def load(work, tag):
+    with open("%s/%s.props.json" % (work, tag)) as f:
+        return json.load(f)
+
+
+def traces(tag, d, tol=1e-12):
+    """V4: the protonic 1-RDM of every root carries exactly one proton."""
+    for r in d["roots"]:
+        chk("V4 %s Tr[D S_p] root %i" % (tag, r["index"]), r["trace"], 1.0, tol)
+
+
+def main():
+    work, mp, w, lam = sys.argv[1], float(sys.argv[2]), float(sys.argv[3]), float(sys.argv[4])
+    b = mp * w
+
+    # -- V6: the multi-root machinery must not perturb the CI ----------------
+    print("\n--- V6: regression, default vs. multi-root run ---")
+    e_def = open("%s/reg_default.out" % work).read()
+    e_multi = open("%s/reg_multi.out" % work).read()
+
+    def ci_energy(txt):
+        for line in txt.splitlines():
+            if line.startswith("CI energy"):
+                return line.split()[2]
+        return None
+
+    global npass, nfail
+    a, c = ci_energy(e_def), ci_energy(e_multi)
+    if a is not None and a == c:
+        print("PASS V6 CI energy bit-identical      (%s)" % a)
+        npass += 1
+    else:
+        print("FAIL V6 CI energy differs: default=%s multi-root=%s" % (a, c))
+        nfail += 1
+
+    # The multi-root block must agree with the legacy scalar print.
+    dm = load(work, "reg_multi")
+    chk("V6 root 0 == printed CI energy", dm["roots"][0]["E"], float(c), 1e-14)
+    traces("reg", dm)
+
+    # -- V1: ground-state moments -------------------------------------------
+    print("\n--- V1: ground-state protonic moments (isotropic trap) ---")
+    d1 = load(work, "v1")
+    r0 = d1["roots"][0]
+    chk("V1 <z^2>_0     = 1/(2b)", r0["z2"], 1.0 / (2 * b), 1e-12)
+    chk("V1 <x^2+y^2>_0 = 1/b", r0["x2py2"], 1.0 / b, 1e-12)
+    chk("V1 <z^4>_0     = 3/(4b^2)", r0["z4"], 3.0 / (4 * b * b), 1e-14)
+    traces("v1", d1)
+
+    # -- V3: gaps of the isotropic ladder ------------------------------------
+    print("\n--- V3: excitation gaps (isotropic n=1 manifold at w) ---")
+    for i in (1, 2, 3):
+        chk("V3 gap root %i = w" % i, d1["roots"][i]["gap"], w, 1e-8)
+
+    # -- V5c: cylindrical symmetry of a nondegenerate state ------------------
+    # Within the degenerate n=1 manifold the individual CI vectors are basis
+    # dependent, so <x^2> == <y^2> holds per state only for root 0; over the
+    # manifold only the sum is invariant.
+    print("\n--- V5c: <x^2> == <y^2> (nondegenerate state, and summed over pi) ---")
+    chk("V5c <x^2>_0 - <y^2>_0", r0["x2"] - r0["y2"], 0.0, 1e-14)
+    sx = sum(d1["roots"][i]["x2"] for i in (1, 2, 3))
+    sy = sum(d1["roots"][i]["y2"] for i in (1, 2, 3))
+    chk("V5c sum_manifold <x^2>-<y^2>", sx - sy, 0.0, 1e-14)
+
+    # -- V5b: manifold average, degeneracy invariant -------------------------
+    # Equal weights over the three n=1 roots. The average is invariant to how
+    # LAPACK orients the degenerate eigenvectors, so this is exact.
+    print("\n--- V5b: equal-weight average over the n=1 manifold ---")
+    sa = d1["state_average"]
+    chk("V5b <z^2>_avg     = 5/(6b)", sa["z2"], 5.0 / (6 * b), 1e-12)
+    chk("V5b <x^2+y^2>_avg = 5/(3b)", sa["x2py2"], 5.0 / (3 * b), 1e-12)
+    chk("V5b <z^4>_avg     = 7/(4b^2)", sa["z4"], 7.0 / (4 * b * b), 1e-14)
+    chk("V5b E_avg         = E_1", sa["E"], d1["roots"][1]["E"], 1e-12)
+
+    # -- V2: excited-state moments, sigma_z resolved by the cross term -------
+    # lam_cross < 0 pushes p_z below the pi doublet without mixing the states
+    # (parity keeps the trap block diagonal in {s, p_x, p_y, p_z}), so root 1
+    # is exactly the sigma_z oscillator state.
+    print("\n--- V2: first sigma excited state (nondegenerate via lam_cross) ---")
+    d2 = load(work, "v2")
+    pz = d2["roots"][1]
+    chk("V2 <z^2>_sigma     = 3/(2b)", pz["z2"], 3.0 / (2 * b), 1e-12)
+    chk("V2 <z^4>_sigma     = 15/(4b^2)", pz["z4"], 15.0 / (4 * b * b), 1e-13)
+    chk("V2 <x^2+y^2>_sigma = 1/b", pz["x2py2"], 1.0 / b, 1e-12)
+    # The splitting itself pins the sign and scale of the M202 + M022 assembly.
+    chk("V2 sigma/pi splitting", d2["roots"][3]["E"] - d2["roots"][1]["E"],
+        abs(0.5 * lam / (b * b)), 1e-12)
+    traces("v2", d2)
+
+    # -- V5a: all weight on root 0 -------------------------------------------
+    print("\n--- V5a: weights (1,0,0,0) reproduce root 0 ---")
+    da = load(work, "v5a")
+    sa = da["state_average"]
+    g0 = da["roots"][0]
+    for key in ("E", "z2", "x2py2", "z4"):
+        chk("V5a %s_avg == root0" % key, sa[key], g0[key], 1e-14)
+
+    # -- V5d: equal weights give the arithmetic mean --------------------------
+    print("\n--- V5d: equal weights give the arithmetic mean ---")
+    de = load(work, "v5d")
+    sa = de["state_average"]
+    n = len(de["roots"])
+    for key in ("E", "z2", "x2py2", "z4"):
+        mean = sum(r[key] for r in de["roots"]) / n
+        chk("V5d %s_avg == mean over %i roots" % (key, n), sa[key], mean, 1e-13)
+
+    print("\nRESULT: %i passed, %i failed" % (npass, nfail))
+    return 1 if nfail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/moment_tests.sh
+++ b/tests/moment_tests.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# Analytic validation of the per-state protonic moments and the state averaging
+# in erkale_hneoci (V1-V6).  See README_MOMENTS.md.
+#
+# The electron is decoupled by giving it a single, very diffuse s primitive: its
+# density is then flat over the proton's extent, so the proton feels the trap
+# plus a constant.  Because that electronic density is spherical, the protonic
+# CI states are *exactly* the harmonic-oscillator states -- the s/p block of the
+# CI Hamiltonian is parity-diagonal -- and every reference below is exact.
+#
+# The protonic basis is a single s and a single p primitive at zeta = m w / 2,
+# which represents the n=0 and n=1 oscillator states exactly.
+#
+# Usage:  tests/moment_tests.sh [path-to-erkale_hneoci]
+# Env:    ERKALE_LIBRARY (basis directory) -- defaults to <repo>/basis
+#
+set -u
+
+here=$(cd "$(dirname "$0")" && pwd)
+root=$(cd "$here/.." && pwd)
+export ERKALE_LIBRARY=${ERKALE_LIBRARY:-$root/basis}
+
+# Locate the hneoci executable (arg overrides autodetection).
+HN=${1:-}
+if [ -z "$HN" ]; then
+  for c in "$root"/openmp/src/contrib/erkale_hneoci_omp \
+           "$root"/serial/src/contrib/erkale_hneoci \
+           "$(command -v erkale_hneoci_omp 2>/dev/null)" \
+           "$(command -v erkale_hneoci 2>/dev/null)"; do
+    [ -n "$c" ] && [ -x "$c" ] && HN="$c" && break
+  done
+fi
+if [ -z "$HN" ] || [ ! -x "$HN" ]; then
+  echo "ERROR: erkale_hneoci not found. Build it, or pass its path as argument."
+  exit 2
+fi
+echo "Using binary : $HN"
+echo "ERKALE_LIBRARY: $ERKALE_LIBRARY"
+
+mp=1836.15267389            # must match ProtonMass default in hneoci.cpp
+w=0.01                      # isotropic trap frequency, Hartree
+lam=-0.02                   # cross-term coefficient used to resolve sigma_z
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# A single, very diffuse electronic s primitive: decouples the electron.
+python3 -c "print('H     0');print('S   1   1.00');print('   %.10e   1.00'%1e-6);print('****')" > "$work/e.gbs"
+# Protonic s + p primitives matched to the trap: zeta = m w / 2.
+python3 -c "
+z=$mp*$w/2
+print('H     0')
+for am in ('S','P'):
+    print('%s   1   1.00'%am); print('   %.12f   1.00'%z)
+print('****')" > "$work/p.gbs"
+
+# run <tag> <extra keywords...>  -- writes <tag>.run, executes, keeps <tag>.out
+run() {
+  local tag=$1; shift
+  { printf '%s\n' "$@"; } > "$work/$tag.run"
+  if ! "$HN" "$work/$tag.run" > "$work/$tag.out" 2>&1; then
+    echo "ERROR: $tag failed:"; tail -3 "$work/$tag.out"; exit 3
+  fi
+}
+
+trapkw="NEOTrap true
+TrapOmegaUnit Eh
+TrapOmegaPar $w
+TrapOmegaPerp $w"
+
+# V6 -- the defaults must not print a root table nor write a sidecar.
+run reg_default "Basis cc-pVDZ"
+if [ -e "$work/reg_default.props.json" ]; then
+  echo "FAIL V6: a sidecar was written for a default run"; exit 1
+fi
+if grep -qE "^ root|state-avg" "$work/reg_default.out"; then
+  echo "FAIL V6: the default run printed the multi-root block"; exit 1
+fi
+echo "PASS V6 defaults print no multi-root block and write no sidecar"
+
+# ... and the multi-root machinery must not perturb the CI energy.
+run reg_multi "Basis cc-pVDZ" "NRoots 4" "PrintMoments true" "StateAverage true"
+
+# V1, V3, V4, V5b, V5c: isotropic trap, equal weights over the n=1 manifold.
+run v1 "Basis $work/e.gbs" "ProtonBasis $work/p.gbs" "$trapkw" \
+       "NRoots 4" "PrintMoments true" "MomentsFull true" \
+       "StateAverage true" "SAWeights 0.0 1.0 1.0 1.0" "SADensityOut true"
+
+# V2: lam_cross < 0 splits sigma_z below the pi doublet without mixing states.
+run v2 "Basis $work/e.gbs" "ProtonBasis $work/p.gbs" "$trapkw" \
+       "TrapLambdaCross $lam" "NRoots 4" "PrintMoments true"
+
+# V5a: all the weight on the ground root.
+run v5a "Basis $work/e.gbs" "ProtonBasis $work/p.gbs" "$trapkw" \
+        "NRoots 4" "PrintMoments true" "StateAverage true" "SAWeights 1.0 0.0 0.0 0.0"
+
+# V5d: equal weights (empty SAWeights) give the arithmetic mean.
+run v5d "Basis $work/e.gbs" "ProtonBasis $work/p.gbs" "$trapkw" \
+        "NRoots 4" "PrintMoments true" "StateAverage true"
+
+# The state-averaged density must still carry exactly one proton.
+python3 - "$work" <<'PY'
+import sys, json
+import itertools
+work = sys.argv[1]
+D = [[float(x) for x in l.split()] for l in open("%s/v1.sadens.dat" % work) if l.strip()]
+n = len(D)
+asym = max(abs(D[i][j]-D[j][i]) for i in range(n) for j in range(n))
+print("%s V5  D_avg symmetric                max|D-D^T| = %.2e" % ("PASS" if asym < 1e-14 else "FAIL", asym))
+PY
+
+python3 "$(dirname "$0")/moment_check.py" "$work" "$mp" "$w" "$lam"


### PR DESCRIPTION
Follow-on to the proton trap (#134). Reports, for the low CI manifold, each root's energy, excitation gap and protonic density moments ⟨z²⟩, ⟨x²+y²⟩, ⟨z⁴⟩, plus a weighted state-averaged energy, moment set and 1-RDM. A `<runfile>.props.json` sidecar carries all of it at round-trip double precision (`%.17g`), so a sweep driver parses data rather than prose.

## Design notes

**No state-averaged MCSCF.** For 1e + 1p the CISD is FCI, and FCI roots and their densities are invariant to the choice of reference orbitals — SA orbitals would change nothing. "State averaging" here is strictly a post-diagonalization weighted average over the CI roots. Noted in code and `README_MOMENTS.md`.

**Nothing recomputed.** The CI already diagonalized the full Hamiltonian, so every root and eigenvector was in hand; the protonic RDM is the existing `civec.t()*civec` generalized to an arbitrary root. `build_proton_trap` now returns a `proton_trap_t` carrying the Cartesian moment matrices it already formed, referenced to the same center as the trap. They are also formed with the trap *off*, so an untrapped proton can be analyzed.

## Keywords

`NRoots`, `PrintMoments`, `MomentsFull`, `StateAverage`, `SAWeights`, `SADensityOut` (implies `StateAverage`).

Defaults print no multi-root block, form no moment integrals and write no sidecar — `CI energy -0.473489625841372` stays bit-identical. The only textual change is `settings.print()` echoing the six new keywords.

## Bug fix carried along

`TrapLambdaCross` was registered with ERKALE's default `add_double(..., negative=false)`, so `settings` **rejected negative values**. The isotropic quartic decomposition only ever needs λ_cross > 0, which is why it never surfaced in #134. It is an independent coefficient of either sign — only the total `V` need stay confining — and negative values are exactly what's needed to push σ_z below the π doublet. Now `negative=true`.

## Validation — `tests/moment_tests.sh`, 38/38, residuals ~1e-15

Two constructions make the references *exact* rather than converged:

- **Decoupling the electron.** A single very diffuse `s` primitive (ζ = 10⁻⁶). Its density is *spherical*, so the potential it exerts on the proton is radial and cannot couple protonic parities — the protonic CI states are exactly harmonic-oscillator states.
- **An exact protonic basis.** A single `s` and `p` primitive at ζ = m w / 2 represents n = 0 and n = 1 exactly.

**The brief's anisotropic σ-state test cannot be a precision check.** An anisotropic Gaussian needs l = 0, 2, 4, …, and isotropic Gaussians converge to it slowly: measured, the ⟨z²⟩ error *plateaus near 6 %* under radial saturation and only moves when lmax grows, while the gaps are already within 1 %. Moments converge much slower than energies.

So V2 is obtained exactly instead: a negative `TrapLambdaCross` reorders σ_z below the π doublet **without mixing the states** — parity keeps the trap block-diagonal in {s, pₓ, p_y, p_z}. Root 1 is then exactly the σ_z oscillator state, with ⟨z²⟩ = 3/(2b), ⟨z⁴⟩ = 15/(4b²), ⟨x²+y²⟩ = 1/b. The σ/π splitting equals |λ_cross|/(2b²), independently pinning the sign and scale of the `M202 + M022` assembly.

Per-state moments of *degenerate* roots are basis-dependent (LAPACK's orientation within the manifold), so ⟨x²⟩ = ⟨y²⟩ is checked on the nondegenerate root and summed over the π manifold, and the excited manifold is validated through its degeneracy-invariant equal-weight average: ⟨z²⟩ = 5/(6b), ⟨x²+y²⟩ = 5/(3b), ⟨z⁴⟩ = 7/(4b²).

Covered: V1 ground-state moments · V2 excited-state moments · V3 gaps · V4 `Tr[D S_p] = 1` every root · V5 averaging (delta weights, arithmetic mean, manifold average, `D_avg` symmetry) · V6 regression.

## Checks

- `tests/moment_tests.sh` → 38/38
- `tests/trap_tests.sh` (#134) → 7/7, unregressed
- OpenMP and serial builds clean
- Error paths give clean diagnostics; `NRoots 99` clamps with a message
- Trap off + `PrintMoments` gives ⟨x²+y²⟩ = 2⟨z²⟩ exactly — the free H-atom proton is isotropic, as it must be

## Scope

`src/contrib/hneoci.cpp` only (+346/−54), plus `README_MOMENTS.md` and the tests. The CI Hamiltonian build, the e–p integrals, the trap operator and the basis handling are untouched; `neo.cpp` is not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)