### PR TITLE
neo_dump: export the core Hamiltonian and the SCF orbitals, not a Fock matrix

### DIFF
--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -84,10 +84,15 @@ mode the species have independent Cholesky spaces and the SCF computes e-p
 
 ### 1.4 MO ordering and occupations
 
-- MOs in `C`/`eps` are **energy-ordered** (aufbau): occupied first, then virtual.
+- `C` holds the **SCF orbitals verbatim**, reordered so that the **occupied ones
+  come first**. They are orthonormal (`Cᵀ S C = I`) but are **not** canonical
+  with respect to any particular Fock matrix — see §2.3.
 - `nmo ≤ nbf`: linearly dependent AO directions are removed by canonical
   orthogonalization, so `C` is `(nbf, nmo)` with no padding.
-- Occupation vectors are **not stored** — they follow from `nocc` and the species rule:
+- Occupation is defined by **column order**: the first `nocc` columns are
+  occupied, the rest are virtual. The `occ` vector stores the same information
+  explicitly (and lets a reader assert it); the writer rejects fractional or
+  non-aufbau occupations, which the column convention cannot express.
 
 | Species block        | occ per occupied MO | `nocc` | density `D` |
 |----------------------|---------------------|--------|-------------|
@@ -109,9 +114,8 @@ multiplies by `q_e·q_p = -1`:
 E_ep  =  - Σ_{μν∈e}  Σ_{ab∈p}   eri_ep[μ,ν,a,b] · D^e[μ,ν] · D^p[a,b]
 ```
 
-The `fock` matrices in this file *do* already include the mean-field e-p attraction
-with its `-` sign (they are the converged SCF Fock matrices — §2.3); only the raw
-`eri_ep` tensor is sign-free.
+No Fock matrix is stored, so this file contains **no** sign-carrying mean-field
+operator: every two-particle quantity in it is sign-free (§2.3).
 
 ---
 
@@ -156,44 +160,53 @@ Electron group, **RHF** (`restricted_electrons = true`):
 | Dataset | Shape        | Notes |
 |---------|--------------|-------|
 | `nmo`,`nocc` | scalar int | `nocc = n_electrons/2` |
-| `C`     | `(nbf,nmo)`  | canonical AO→MO, energy-ordered (§2.3) |
-| `eps`   | `(nmo,)`     | canonical MO energies |
+| `C`     | `(nbf,nmo)`  | SCF AO→MO, occupied columns first (§1.4, §2.3) |
+| `occ`   | `(nmo,)`     | SCF occupations (`2.0` × `nocc`, then zeros) |
 | `hcore` | `(nbf,nbf)`  | one-particle core (§2.3) |
-| `fock`  | `(nbf,nbf)`  | converged Fock (§2.3) |
-
-`C`/`eps` are the **canonical** orbitals: the writer diagonalizes the stored
-`fock` in the `overlap` metric, so they satisfy `F C = S C diag(eps)`,
-`Cᵀ S C = I`, `Cᵀ F C = diag(eps)` (validated at write time, residuals printed).
-`nocc` is the integer particle count of the block (occupied = lowest `nocc`
-canonical orbitals).
 
 Electron group, **UHF** (`restricted_electrons = false`): the same, suffixed `_a`/`_b`
-— `nmo_a/nmo_b`, `nocc_a/nocc_b`, `C_a/C_b`, `eps_a/eps_b`, `hcore` (spin-independent,
-single copy), `fock_a/fock_b`.
+— `nmo_a/nmo_b`, `nocc_a/nocc_b`, `C_a/C_b`, `occ_a/occ_b`, `hcore` (spin-independent,
+single copy).
 
-Proton group: `nmo`, `nocc` (`= n_quantum_protons`), `C`, `eps`, `hcore`, `fock`.
+Proton group: `nmo`, `nocc` (`= n_quantum_protons`), `C`, `occ`, `hcore`.
 
-### 2.3 What `hcore` and `fock` contain
+### 2.3 What `hcore` contains, and why there is no `fock`
 
 - **Electron `hcore`** `= T_e + V_e(classical)` — kinetic + attraction to the
   *classical* nuclei only. The e-p attraction is **not** here (two-particle, via
   `eri_ep`).
 - **Proton `hcore`** `= T_p/m_p + V_p(classical)` — mass-scaled kinetic + repulsion
   from classical nuclei (`+` sign for the positive test charge), `m_p = proton_mass`.
-- **Electron `fock`** is the converged self-consistent AO Fock with all mean-field
-  two-particle terms at their physical signs (including the `−` e-p attraction):
-  `fock_e = hcore_e + J_ee[D^e] − ½K_ee[D^e] − J_ep[D^p]` (RHF; UHF uses
-  `J_ee[D^e] − K_ee[D^{σ}]` per spin). Its generalized eigenvalues in `overlap`
-  equal `eps`, and `C` are the eigenvectors (§2.2).
-- **Proton `fock`** is the **self-interaction-free** one-particle-per-orbital
-  operator `fock_p = hcore_p − J_pe[D^e]` (kinetic + classical-nucleus repulsion +
-  the electron mean-field attraction `−J_pe`), with **no** proton–proton `J_p/K_p`.
-  A single quantum proton has no proton–proton interaction; including its own
-  Coulomb/exchange leaves the occupied orbital and the total SCF energy unchanged
-  but spuriously unbinds the proton virtuals. Excluding it gives a physically bound
-  proton spectrum (occupied + virtual `eps` below the free-proton dissociation
-  threshold), which is what the CC consumer needs. The proton–proton interaction,
-  if needed, is available exactly from `proton/B` (`eri_pp`).
+
+**No Fock matrix and no orbital energies are dumped.** The right proton reference
+operator is use-case dependent, and baking one in silently corrupts the density:
+
+- A correlation model *without* a proton–proton fluctuation potential wants the
+  **self-interaction-free** `f_p = hcore_p − J_pe[D^e]`.
+- A model *with* one wants the **J/K-dressed** SCF Fock
+  `f_p = hcore_p − J_pe[D^e] + J_pp[D^p] − K_pp[D^p]`.
+
+These two operators share an occupied subspace **only for a single quantum proton**
+(where `J_pp + K_pp` annihilates the occupied orbital by exact self-interaction
+cancellation). For two or more protons they do not, so canonicalizing the SI-free
+operator — as this writer used to do — yields an occupied subspace that is *not*
+the SCF one, and hence a reconstructed density and reference energy that are wrong
+(observed: 5.5 mHa for CH₄ with two quantum protons).
+
+The dump therefore exports the **SCF orbitals themselves**, which define the SCF
+density by construction, and leaves the choice of reference operator to the
+consumer. The consumer:
+
+1. builds `D^e`, `D^p` from the first `nocc` columns of `C` (§1.4);
+2. builds whichever `f` it wants from `hcore`, `B` and `eri_ep`;
+3. **semicanonicalizes** — diagonalizes `f` separately within the occupied and the
+   virtual block — and takes `eps = diag(Cᵀ f C)`. This leaves both subspaces, and
+   hence the density, untouched.
+
+Step 3 is mandatory: the dumped orbitals are *not* eigenvectors of the SI-free
+proton operator. `erkale_neo` prints `max|f_ia|`, the surviving occupied–virtual
+coupling, at write time — it is at the SCF convergence level for one proton and
+`O(10⁻²)` for two.
 
 ---
 
@@ -211,9 +224,31 @@ spin and for the high-spin protons. The `(pq|rs)` come from `eri_xx` (`dense`) o
 reconstructed from `B` (`btensor`).
 
 `erkale_neo` with `NEODumpVerify true` reconstructs `E` from the on-disk tensors and
-asserts agreement with `e_scf`. Because the dumped integrals match the SCF's own
+asserts agreement with `e_scf`. `tests/neo_dump_check.py <dump.h5>` does the same from
+outside ERKALE and is the reference implementation of the consumer contract: it builds
+the densities from the dumped orbitals, rebuilds both reference Fock matrices,
+semicanonicalizes them, and checks all of it. Run it against any new dump.
+
+Because the dumped integrals match the SCF's own
 engine (B-tensors / engine-reconstructed dense, and an engine-consistent `eri_ep`),
-the residual is at the SCF convergence level (≈ `1e-9`) for both RI and Cholesky.
+the residual is at machine precision for Cholesky (`≈1e-14`, any proton count) and
+for RI with a single quantum proton.
+
+**RI with ≥2 quantum protons** shows a residual of `≈1e-8`. This is a conditioning
+artifact, not an inconsistency: `def2-universal-jkfit` is an *electronic* auxiliary
+basis and fits the tight protonic pair densities very poorly. For CH₄/PB4-F1 the
+proton fit factor `proton/B` has condition number `2.6e12` (vs `3.1e4` for Cholesky),
+so the two algebraically-equivalent ways of contracting `J_pp` — via `B·Bᵀ` here, via
+the metric solve in the SCF — differ at that level. With one proton the p-p Coulomb
+and exchange cancel exactly, so the error is invisible; with two it is not.
+
+Note also that the RI p-p energy itself is inaccurate, not merely ill-conditioned:
+for CH₄ with two quantum protons, `J_pp` is `5.460` under RI against `5.750` under
+Cholesky, a `0.29 Eh` fitting error that shifts the total energy by `1.1 mEh`. **Use
+`JKMethod Cholesky` for NEO dumps with more than one quantum proton.** A future
+superbasis Cholesky (one decomposition over the union of the electronic and protonic
+bases, segmented into `B_e`/`B_p` sharing a common vector index) would remove both
+problems and make `eri_ep` exact by construction rather than by aux-basis coincidence.
 
 ---
 
@@ -223,3 +258,52 @@ the residual is at the SCF convergence level (≈ `1e-9`) for both RI and Choles
   exported — the e-p operator would be screened, not bare `1/r12`. The writer throws.
 - **Dense `eri_ep` / dense mode.** No permutational-symmetry packing — intended for
   small systems (one/two quantum protons, modest electronic basis).
+- **RI with ≥2 quantum protons is inaccurate** (§3). Prefer `JKMethod Cholesky`.
+
+---
+
+## 5. Schema changelog
+
+### v2 — core Hamiltonian + SCF orbitals (breaking)
+
+Motivation: the writer used to store `C` as the canonical orbitals of the
+self-interaction-free proton Fock. That operator does not share the SCF occupied
+subspace once there is more than one quantum proton, so the reconstructed proton
+density — and any correlation treatment built on it — was wrong. Measured on CH₄
+with two quantum protons: `NEODumpVerify` off by `5.5e-3 Eh`. Single-proton dumps
+were unaffected (exact self-interaction cancellation makes the two operators share
+the occupied orbital), which is why it went unnoticed.
+
+**Removed** (consumers must stop reading these):
+
+| Dataset | Old shape | Replacement |
+|---------|-----------|-------------|
+| `electron/fock`, `electron/fock_a`, `electron/fock_b` | `(nbf,nbf)` | rebuild from `hcore` + `B` + `eri_ep` |
+| `proton/fock`   | `(nbf,nbf)` | rebuild from `proton/hcore` + `eri_ep` (+ `proton/B` for a dressed Fock) |
+| `electron/eps`, `electron/eps_a`, `electron/eps_b`   | `(nmo,)` | `diag(Cᵀ f C)` after semicanonicalization |
+| `proton/eps`    | `(nmo,)` | `diag(Cᵀ f C)` after semicanonicalization |
+
+**Added:**
+
+| Dataset | Shape | Meaning |
+|---------|-------|---------|
+| `electron/occ` (or `occ_a`/`occ_b`) | `(nmo,)` | SCF occupations, `2.0`/`1.0` × `nocc` then zeros |
+| `proton/occ` | `(nmo,)` | SCF occupations, `1.0` × `nocc` then zeros |
+
+**Changed semantics** (same name, same shape):
+
+| Dataset | Was | Is |
+|---------|-----|-----|
+| `electron/C`, `proton/C` | canonical eigenvectors of the dumped `fock` | the SCF orbitals, occupied columns first; orthonormal but **not** canonical |
+
+Unchanged: `nbf`, `nmo`, `nocc`, `hcore`, `overlap`, `B`, `eri_ep`, `eri_ee`,
+`eri_pp`, and every `/meta` attribute.
+
+**Consumer migration.** A reader that previously did *load `F`, `eps` → assert
+canonical → MO-transform* must now: build `D` from the first `nocc` columns of `C`;
+build `f` itself (`f_e = h + J − ½K − V_pe`, `f_p = h − V_ep`, plus `J_pp − K_pp` if
+the model carries a proton–proton fluctuation potential); **semicanonicalize** by
+diagonalizing `f` within the occupied and virtual blocks separately, rotating `C`
+accordingly; and take `eps = diag(Cᵀ f C)`. Asserting `‖f C − S C diag(eps)‖ ≈ 0` on
+the *dumped* `C` will now fail by design — assert orthonormality instead, and assert
+canonicality only after the semicanonical rotation.

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -1153,52 +1153,25 @@ int main_guarded(int argc, char **argv) {
       bool restricted_e = (M==1);
       size_t Nmat = fock.size();
 
-      // Proton block (last) in the AO basis
+      // The converged SCF orbitals, in the AO basis. These -- not the canonical
+      // orbitals of some rebuilt Fock -- are what define the SCF density, so
+      // they are what gets dumped. No reference Fock is exported: the proton's
+      // depends on whether the correlation model carries a proton-proton
+      // fluctuation potential, so the consumer builds it from the dumped core
+      // Hamiltonian and two-particle factors.
       arma::mat Cp_ao = Xp * dm.first[Nmat-1];
       arma::vec occp = dm.second[Nmat-1];
-      arma::vec Ep = arma::diagvec(dm.first[Nmat-1].t() * fock[Nmat-1] * dm.first[Nmat-1]);
-      arma::mat Dp = Cp_ao * arma::diagmat(occp) * Cp_ao.t();
 
-      // Electron block(s) in the AO basis + total electron density
-      std::vector<arma::mat> Ce, Focke;
-      std::vector<arma::vec> occe_v, Ee_v;
-      arma::mat De(X.n_rows, X.n_rows, arma::fill::zeros);
+      std::vector<arma::mat> Ce;
+      std::vector<arma::vec> occe_v;
       size_t nblk = restricted_e ? 1 : 2;
       for(size_t s=0;s<nblk;s++) {
-        arma::mat Cs = X * dm.first[s];
-        arma::vec os = dm.second[s];
-        Ce.push_back(Cs);
-        occe_v.push_back(os);
-        Ee_v.push_back(arma::diagvec(dm.first[s].t() * fock[s] * dm.first[s]));
-        De += Cs * arma::diagmat(os) * Cs.t();
+        Ce.push_back(X * dm.first[s]);
+        occe_v.push_back(dm.second[s]);
       }
 
-      // AO Fock matrices, rebuilt from the converged densities with the same
-      // engine the SCF used (the lambdas carry the correct K and e-p signs).
       arma::mat hcore_e = T + Vc;
-      arma::mat Jpe = proton_electron_coulomb(Dp);
-      if(restricted_e) {
-        arma::mat J, K;
-        std::tie(J, K) = electronic_terms(Ce[0], occe_v[0]);
-        Focke.push_back(hcore_e + J + 0.5*K + Jpe);
-      } else {
-        arma::mat Ja, Ka, Jb, Kb;
-        std::tie(Ja, Ka) = electronic_terms(Ce[0], occe_v[0]);
-        std::tie(Jb, Kb) = electronic_terms(Ce[1], occe_v[1]);
-        Focke.push_back(hcore_e + Ja + Jb + Ka + Jpe);
-        Focke.push_back(hcore_e + Ja + Jb + Kb + Jpe);
-      }
       arma::mat hcore_p = Tp + Vpc;
-      arma::mat Jep = electron_proton_coulomb(De);
-      // Self-interaction-free proton Fock for the correlation consumer:
-      // kinetic + classical-nucleus attraction + the electron mean-field
-      // attraction only. The proton-proton J_p/K_p are deliberately excluded
-      // (a single quantum proton has no proton-proton interaction; including
-      // it leaves the occupied orbital unchanged but spuriously unbinds the
-      // proton virtuals). The total SCF energy and the dumped p-p B-tensor are
-      // unaffected -- this only sets the reference operator whose canonical
-      // orbitals/energies are written.
-      arma::mat Fock_p = hcore_p + Jep;
 
 #ifdef SVNRELEASE
       std::string version(SVNREVISION);
@@ -1206,8 +1179,8 @@ int main_guarded(int argc, char **argv) {
       std::string version("unknown");
 #endif
       neo_dump(neodump, settings.get_string("NEODumpIntegrals"), settings.get_bool("NEODumpVerify"),
-               basis, dfit, restricted_e, Ce, occe_v, Ee_v, hcore_e, Focke,
-               pbasis, pfit, Cp_ao, occp, Ep, hcore_p, Fock_p,
+               basis, dfit, restricted_e, Ce, occe_v, hcore_e,
+               pbasis, pfit, Cp_ao, occp, hcore_p,
                Nel, (int) proton_indices.size(), proton_mass,
                scfsolver.get_energy(), Ecnucr,
                density_fitting, omega, alpha, beta, version);

--- a/src/contrib/neo_dump.cpp
+++ b/src/contrib/neo_dump.cpp
@@ -13,7 +13,6 @@
 #include "basis.h"
 #include "density_fitting.h"
 #include "eriworker.h"
-#include "linalg.h"
 
 #include <hdf5.h>
 #include <cstdio>
@@ -178,30 +177,61 @@ namespace {
     return C * arma::diagmat(occ) * C.t();
   }
 
-  // Canonical MOs of a Fock matrix F in the AO overlap metric S: solve the
-  // generalized eigenproblem F C = S C diag(eps) with C^T S C = I and
-  // C^T F C = diag(eps), eps ascending. Canonical (symmetric) orthonormalization
-  // via BasOrth projects out near-linear-dependent directions, so C is
-  // (Nbf x Nmo) with Nmo <= Nbf. The SCF solver returns occupation-ordered
-  // orbitals that do not in general diagonalize the converged Fock (DIIS
-  // extrapolation), so the dump recanonicalizes here.
-  arma::mat canonical_orbitals(const arma::mat & F, const arma::mat & S, arma::vec & eps) {
-    arma::mat X = BasOrth(S);                 // Nbf x Nmo
-    arma::mat Fmo = X.t() * F * X;            // Nmo x Nmo
-    Fmo = 0.5*(Fmo + Fmo.t());                // symmetrize against round-off
-    arma::mat U;
-    arma::eig_sym(eps, U, Fmo);
-    return X * U;                             // Nbf x Nmo, ascending in eps
+  // Reorder the columns so the occupied orbitals come first, preserving the
+  // relative order within each group (arma::find returns ascending indices).
+  // The dump's occupation contract is purely positional.
+  void occupied_first(arma::mat & C, arma::vec & occ) {
+    arma::uvec perm = arma::join_cols(arma::find(occ > 0.0), arma::find(occ <= 0.0));
+    C = C.cols(perm);
+    occ = occ(perm);
   }
 
-  // Max-norm residuals of the canonical conditions, for validation/printing.
-  void canonical_residuals(const arma::mat & C, const arma::mat & S,
-                           const arma::mat & F, const arma::vec & eps,
-                           double & orthonormality, double & eigres, double & offdiag) {
+  // The consumer reads occupations off the column order: the first nocc columns
+  // carry occ_full, the rest are empty. Fractional or non-aufbau occupations
+  // cannot be expressed that way, so reject them rather than dump a file whose
+  // stated nocc does not reproduce the SCF density.
+  size_t checked_nocc(const arma::vec & occ, double occ_full, const std::string & label) {
+    size_t nocc = (size_t) arma::accu(occ > 0.0);
+    for(size_t i=0;i<occ.n_elem;i++) {
+      double want = (i<nocc) ? occ_full : 0.0;
+      if(std::abs(occ(i)-want) > 1e-10) {
+        std::ostringstream oss;
+        oss << "neo_dump: " << label << " orbital " << i << " has occupation " << occ(i)
+            << ", expected " << want << ".\nFractional or non-aufbau occupations cannot be"
+            << " expressed by the occupied-first column convention.\n";
+        throw std::runtime_error(oss.str());
+      }
+    }
+    return nocc;
+  }
+
+  // Max-norm deviation from orthonormality in the AO overlap metric.
+  double orthonormality(const arma::mat & C, const arma::mat & S) {
     arma::mat I(C.n_cols, C.n_cols, arma::fill::eye);
-    orthonormality = arma::abs(C.t()*S*C - I).max();
-    eigres = arma::abs(F*C - S*C*arma::diagmat(eps)).max();
-    offdiag = arma::abs(C.t()*F*C - arma::diagmat(eps)).max();
+    return arma::abs(C.t()*S*C - I).max();
+  }
+
+  // Semicanonical orbital energies: diagonalize F separately within the
+  // occupied and the virtual block. This is the operation the consumer performs
+  // after rebuilding its own reference Fock. It leaves both subspaces -- and
+  // hence the density -- untouched, so it is valid for any F, including one the
+  // SCF orbitals do not diagonalize. The surviving occupied-virtual coupling
+  // max|F_ia| is returned; it measures how far the SCF orbitals are from being
+  // canonical with respect to F.
+  arma::vec semicanonical_eps(const arma::mat & C, const arma::mat & F, size_t nocc,
+                              double & occvir) {
+    arma::mat Fmo = C.t()*F*C;
+    Fmo = 0.5*(Fmo + Fmo.t());
+    size_t nmo = C.n_cols;
+
+    occvir = (nocc>0 && nocc<nmo) ? arma::abs(Fmo.submat(0,nocc,nocc-1,nmo-1)).max() : 0.0;
+
+    arma::vec eps(nmo);
+    if(nocc)
+      eps.subvec(0,nocc-1) = arma::eig_sym(Fmo.submat(0,0,nocc-1,nocc-1));
+    if(nocc<nmo)
+      eps.subvec(nocc,nmo-1) = arma::eig_sym(Fmo.submat(nocc,nocc,nmo-1,nmo-1));
+    return eps;
   }
 
 } // anonymous namespace
@@ -213,13 +243,10 @@ void neo_dump(const std::string & filename,
               bool restricted_e,
               const std::vector<arma::mat> & Ce,
               const std::vector<arma::vec> & occe,
-              const std::vector<arma::vec> & epse,
               const arma::mat & hcore_e,
-              const std::vector<arma::mat> & focke,
               const BasisSet & pbasis, const DensityFit & pfit,
               const arma::mat & Cp, const arma::vec & occp,
-              const arma::vec & epsp, const arma::mat & hcore_p,
-              const arma::mat & fock_p,
+              const arma::mat & hcore_p,
               int n_electrons, int n_protons, double proton_mass,
               double e_scf, double e_classical,
               bool density_fitting, double omega, double alpha, double beta,
@@ -257,66 +284,88 @@ void neo_dump(const std::string & filename,
     Gep = exact_ep(ebasis, pbasis, omega, alpha, beta);
   }
 
-  // ---- canonical MOs consistent with the dumped Fock + AO overlaps ----
   // AO overlap is the metric each species' basis lives in (also dumped).
   arma::mat S_e = ebasis.overlap();
   arma::mat S_p = pbasis.overlap();
 
-  // Diagonalize the final converged Fock for each species so the stored MOs
-  // satisfy F C = S C diag(eps), C^T S C = I, C^T F C = diag(eps). The SCF
-  // solver returns occupation-ordered orbitals that do not diagonalize the
-  // rebuilt Fock; recanonicalize. The proton Fock passed in is already
-  // self-interaction-free (h_p + V_ep[D_e]), so its canonical virtuals are
-  // physically bound.
-  // Aufbau occupations on the canonical (energy-ordered) orbitals. The number
-  // of occupied orbitals is the integer particle count of the block (the sum of
-  // the SCF occupations, which may be spread fractionally over near-degenerate
-  // solver orbitals), NOT the count of nonzero entries -- otherwise a
-  // fractionally split orbital would be double-counted.
-  std::vector<arma::mat> Cc(Ce.size());
-  std::vector<arma::vec> epsc(Ce.size()), occc(Ce.size());
+  // ---- SCF orbitals, reordered occupied-first ----
+  // The coefficients are written verbatim: they are the ones that produced the
+  // SCF density. They are deliberately NOT recanonicalized against some Fock,
+  // because which Fock is "the" reference is use-case dependent. In particular
+  // the self-interaction-free proton Fock h_p + V_ep[D_e] does not share the
+  // SCF occupied subspace once there is more than one quantum proton, so
+  // diagonalizing it would silently hand the consumer a density that is not the
+  // SCF density. The consumer rebuilds its own reference operator instead.
   double occ_e = restricted_e ? 2.0 : 1.0;
-  for(size_t s=0;s<Ce.size();s++) {
-    Cc[s] = canonical_orbitals(focke[s], S_e, epsc[s]);
-    size_t nocc = (size_t) std::lround(arma::accu(occe[s]) / occ_e);
-    occc[s].zeros(Cc[s].n_cols);
-    if(nocc) occc[s].subvec(0,nocc-1).fill(occ_e);
-  }
-  arma::vec epsp_c;
-  arma::mat Cp_c = canonical_orbitals(fock_p, S_p, epsp_c);
-  size_t nocc_p = (size_t) std::lround(arma::accu(occp));
-  arma::vec occp_c(Cp_c.n_cols, arma::fill::zeros);
-  if(nocc_p) occp_c.subvec(0,nocc_p-1).ones();
+  std::vector<arma::mat> Cc(Ce);
+  std::vector<arma::vec> occc(occe);
+  std::vector<size_t> nocc_e(Ce.size());
+  arma::mat Cp_o(Cp);
+  arma::vec occp_o(occp);
 
-  // Validation: canonical conditions (a,b,c) and a bound proton spectrum.
-  printf("\nNEO dump canonicalization check (max-norm residuals):\n");
+  printf("\nNEO dump orbital check:\n");
   for(size_t s=0;s<Cc.size();s++) {
-    double rI,rFC,rOD;
-    canonical_residuals(Cc[s], S_e, focke[s], epsc[s], rI,rFC,rOD);
     const char * lbl = (Ce.size()==1) ? "electron" : (s==0 ? "electron alpha" : "electron beta");
-    printf("  %-14s ||C'SC-I||=%.2e  ||FC-SCe||=%.2e  ||C'FC-diag||=%.2e\n", lbl, rI,rFC,rOD);
-    if(rI>1e-8 || rFC>1e-6 || rOD>1e-6)
-      throw std::runtime_error("neo_dump: electron canonicalization residual too large!\n");
+    occupied_first(Cc[s], occc[s]);
+    nocc_e[s] = checked_nocc(occc[s], occ_e, lbl);
+    double rI = orthonormality(Cc[s], S_e);
+    printf("  %-14s nocc %3i / nmo %3i   ||C'SC-I||=%.2e\n",
+           lbl, (int) nocc_e[s], (int) Cc[s].n_cols, rI);
+    if(rI>1e-8)
+      throw std::runtime_error("neo_dump: electron orbitals are not orthonormal!\n");
   }
+  occupied_first(Cp_o, occp_o);
+  size_t nocc_p = checked_nocc(occp_o, 1.0, "proton");
   {
-    double rI,rFC,rOD;
-    canonical_residuals(Cp_c, S_p, fock_p, epsp_c, rI,rFC,rOD);
-    printf("  %-14s ||C'SC-I||=%.2e  ||FC-SCe||=%.2e  ||C'FC-diag||=%.2e\n", "proton", rI,rFC,rOD);
-    if(rI>1e-8 || rFC>1e-6 || rOD>1e-6)
-      throw std::runtime_error("neo_dump: proton canonicalization residual too large!\n");
+    double rI = orthonormality(Cp_o, S_p);
+    printf("  %-14s nocc %3i / nmo %3i   ||C'SC-I||=%.2e\n",
+           "proton", (int) nocc_p, (int) Cp_o.n_cols, rI);
+    if(rI>1e-8)
+      throw std::runtime_error("neo_dump: proton orbitals are not orthonormal!\n");
+  }
+  fflush(stdout);
+
+  // ---- SCF densities (the quantities the dumped orbitals must reproduce) ----
+  arma::mat De(Ne, Ne, arma::fill::zeros);
+  std::vector<arma::mat> Dspin;
+  for(size_t s=0;s<Cc.size();s++) {
+    Dspin.push_back(density(Cc[s], occc[s]));
+    De += Dspin.back();
+  }
+  arma::mat Dp = density(Cp_o, occp_o);
+  arma::vec de_vec = arma::vectorise(De); // symmetric => pair index mu*Ne+nu
+  arma::vec dp_vec = arma::vectorise(Dp);
+
+  // ---- diagnostic: the self-interaction-free proton spectrum ----
+  // Built here from exactly the quantities that go on disk (h_p and the e-p
+  // tensor contracted with the electron density), i.e. along the same path the
+  // consumer takes. Nothing below is written to the file.
+  {
+    arma::mat Vep(-arma::reshape(Gep.t()*de_vec, Np, Np));
+    arma::mat Fp_si = hcore_p + 0.5*(Vep + Vep.t());
+    double occvir;
+    arma::vec eps = semicanonical_eps(Cp_o, Fp_si, nocc_p, occvir);
+
+    printf("\nSelf-interaction-free proton spectrum (h_p + V_ep[D_e], semicanonical):\n");
+    printf("  highest occupied  % .6f\n", nocc_p ? eps(nocc_p-1) : 0.0);
     // Dissociation threshold for a quantum proton is 0 (free proton at rest,
     // vanishing potential at infinity); bound orbitals have eps < 0.
     const double thr = 0.0;
-    if(nocc_p < (size_t) Cp_c.n_cols) {
-      double lowest_virtual = epsp_c(nocc_p);
-      size_t nbound = (size_t) arma::accu(epsp_c.subvec(nocc_p, Cp_c.n_cols-1) < thr);
-      printf("  proton spectrum: highest occ %.4f, lowest virtual %.4f, %i bound virtual(s) below threshold %.1f\n",
-             epsp_c(nocc_p-1), lowest_virtual, (int) nbound, thr);
+    if(nocc_p < (size_t) Cp_o.n_cols) {
+      double lowest_virtual = eps(nocc_p);
+      size_t nbound = (size_t) arma::accu(eps.subvec(nocc_p, Cp_o.n_cols-1) < thr);
+      printf("  lowest virtual    % .6f  (%i bound virtual(s) below %.1f)\n",
+             lowest_virtual, (int) nbound, thr);
       if(lowest_virtual >= thr)
         throw std::runtime_error("neo_dump: lowest proton virtual is unbound -- proton self-interaction not removed?\n");
     }
+    // Nonzero for more than one quantum proton: the SCF orbitals diagonalize the
+    // J/K-dressed proton Fock, not this one. The consumer must semicanonicalize
+    // whichever reference operator it builds -- it must not assume the dumped
+    // orbitals are canonical.
+    printf("  max|F_ia| (occ-vir coupling) %.2e\n", occvir);
+    fflush(stdout);
   }
-  fflush(stdout);
 
   // ---- write the file ----
   hid_t file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
@@ -350,18 +399,16 @@ void neo_dump(const std::string & filename,
   write_mat(eg, "overlap", S_e);
   if(restricted_e) {
     write_int(eg, "nmo", (int) Cc[0].n_cols);
-    write_int(eg, "nocc", (int) arma::accu(occc[0] > 0.0));
+    write_int(eg, "nocc", (int) nocc_e[0]);
     write_mat(eg, "C", Cc[0]);
-    write_vec(eg, "eps", epsc[0]);
-    write_mat(eg, "fock", focke[0]);
+    write_vec(eg, "occ", occc[0]);
   } else {
     const char * suf[2] = {"_a", "_b"};
     for(int s=0;s<2;s++) {
       write_int(eg, std::string("nmo")+suf[s], (int) Cc[s].n_cols);
-      write_int(eg, std::string("nocc")+suf[s], (int) arma::accu(occc[s] > 0.0));
+      write_int(eg, std::string("nocc")+suf[s], (int) nocc_e[s]);
       write_mat(eg, std::string("C")+suf[s], Cc[s]);
-      write_vec(eg, std::string("eps")+suf[s], epsc[s]);
-      write_mat(eg, std::string("fock")+suf[s], focke[s]);
+      write_vec(eg, std::string("occ")+suf[s], occc[s]);
     }
   }
   if(!dense)
@@ -370,12 +417,11 @@ void neo_dump(const std::string & filename,
   // /proton
   hid_t pg = H5Gcreate2(file, "/proton", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
   write_int(pg, "nbf", (int) Np);
-  write_int(pg, "nmo", (int) Cp_c.n_cols);
-  write_int(pg, "nocc", (int) arma::accu(occp_c > 0.0));
-  write_mat(pg, "C", Cp_c);
-  write_vec(pg, "eps", epsp_c);
+  write_int(pg, "nmo", (int) Cp_o.n_cols);
+  write_int(pg, "nocc", (int) nocc_p);
+  write_mat(pg, "C", Cp_o);
+  write_vec(pg, "occ", occp_o);
   write_mat(pg, "hcore", hcore_p);
-  write_mat(pg, "fock", fock_p);
   write_mat(pg, "overlap", S_p);
   if(!dense)
     write_B(pg, Bp, Np);
@@ -407,20 +453,9 @@ void neo_dump(const std::string & filename,
 
   // ---- verify: reconstruct the SCF energy from the dumped quantities ----
   if(do_verify) {
-    // electron density (total) and per-spin densities, from the canonical
-    // occupied orbitals (same occupied subspace as the SCF solution).
-    arma::mat De(Ne, Ne, arma::fill::zeros);
-    std::vector<arma::mat> Dspin;
-    for(size_t s=0;s<Cc.size();s++) {
-      arma::mat Ds = density(Cc[s], occc[s]);
-      Dspin.push_back(Ds);
-      De += Ds;
-    }
-    arma::mat Dp = density(Cp_c, occp_c);
-
-    arma::vec de_vec = arma::vectorise(De); // symmetric => pair index mu*Ne+nu
-    arma::vec dp_vec = arma::vectorise(Dp);
-
+    // The densities come from the dumped occupied orbitals, so this checks the
+    // whole contract: the file reproduces the SCF energy using only the core
+    // Hamiltonians, the two-particle factors and the occupied orbital columns.
     // one-particle
     double E1e = arma::trace(De * hcore_e);
     double E1p = arma::trace(Dp * hcore_p);

--- a/src/contrib/neo_dump.h
+++ b/src/contrib/neo_dump.h
@@ -27,18 +27,27 @@ class DensityFit;
  * Write a converged NEO-SCF to an HDF5 dump.
  *
  * The electron blocks are passed as vectors: size 1 for restricted (RHF),
- * size 2 (alpha,beta) for unrestricted (UHF). Coefficients are AO x MO in
- * the full AO basis, energy-ordered (occupied first). Fock/hcore are AO.
+ * size 2 (alpha,beta) for unrestricted (UHF). Coefficients are AO x MO in the
+ * full AO basis; they are written verbatim (reordered occupied-first), because
+ * they are the orbitals that produced the SCF density.
+ *
+ * No Fock matrix or orbital energy is dumped. The reference one-particle
+ * operator is use-case dependent -- a correlation model without a
+ * proton-proton fluctuation potential wants the self-interaction-free proton
+ * Fock h_p + V_ep[D_e], one with it wants the J/K-dressed Fock -- so the
+ * consumer builds whichever it needs from the core Hamiltonian, the dumped
+ * two-particle factors and the occupied densities, and takes its orbital
+ * energies from the diagonal of the resulting MO Fock.
  *
  * \param filename        output HDF5 file
  * \param representation  "btensor" (engine CD/RI factors) or "dense" (full rank-4)
  * \param do_verify       reconstruct the SCF energy from the dumped tensors and check
  * \param ebasis,dfit     electron basis and its (converged) density-fit/Cholesky engine
  * \param restricted_e    true=RHF (one electron block), false=UHF (two blocks)
- * \param Ce,occe,epse,focke  per-block electron MOs, occupations, energies, AO Fock
+ * \param Ce,occe         per-block electron SCF MOs and occupations
  * \param hcore_e         electron AO core Hamiltonian (spin-independent)
  * \param pbasis,pfit     proton basis and engine
- * \param Cp,occp,epsp,fock_p,hcore_p  proton MOs, occupations, energies, AO Fock, core
+ * \param Cp,occp,hcore_p proton SCF MOs, occupations, AO core Hamiltonian
  * \param n_electrons,n_protons,proton_mass  counts / mass
  * \param e_scf,e_classical  SCF total energy and classical nuclear repulsion
  * \param density_fitting omega/alpha/beta select the e-p (and p-p) operator
@@ -52,14 +61,11 @@ void neo_dump(const std::string & filename,
               bool restricted_e,
               const std::vector<arma::mat> & Ce,
               const std::vector<arma::vec> & occe,
-              const std::vector<arma::vec> & epse,
               const arma::mat & hcore_e,
-              const std::vector<arma::mat> & focke,
               // protons
               const BasisSet & pbasis, const DensityFit & pfit,
               const arma::mat & Cp, const arma::vec & occp,
-              const arma::vec & epsp, const arma::mat & hcore_p,
-              const arma::mat & fock_p,
+              const arma::mat & hcore_p,
               // scalars
               int n_electrons, int n_protons, double proton_mass,
               double e_scf, double e_classical,

--- a/tests/neo_dump_check.py
+++ b/tests/neo_dump_check.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate a neo_dump.h5 the way a correlation consumer must read it.
+
+This is the reference implementation of the contract in neo_dump_format.md
+(v2): the dump stores the SCF orbitals and the core Hamiltonians, and the
+consumer rebuilds its own reference Fock and semicanonicalizes.
+
+Checks, per species:
+  C1  orthonormality           C^T S C = I
+  C2  occupation contract      occ = (occ_full,)*nocc + (0,)*(nmo-nocc)
+  C3  density trace            Tr[D S] = particle count
+  C4  reference energy         rebuilt from hcore + B + eri_ep equals e_scf
+  C5  semicanonicalization     leaves the density invariant, and the
+                               semicanonical F is block diagonal
+
+C4 is the one that catches a wrong occupied subspace: if the dumped orbitals
+do not span the SCF occupied space, the mean-field energy does not come back.
+
+Usage:  tests/neo_dump_check.py <dump.h5> [<dump.h5> ...]
+"""
+import sys
+
+import h5py
+import numpy as np
+
+npass = nfail = 0
+
+
+def chk(name, ok, detail=""):
+    global npass, nfail
+    print("%s %-46s %s" % ("PASS" if ok else "FAIL", name, detail))
+    if ok:
+        npass += 1
+    else:
+        nfail += 1
+
+
+def close(name, got, exp, tol):
+    d = abs(got - exp)
+    chk(name, d <= tol, "got %.12e  exp %.12e  |d|=%.2e (tol %.0e)" % (got, exp, d, tol))
+
+
+def species(f, grp, suffix=""):
+    """Read one species block. Occupation lives in the column order."""
+    g = f[grp]
+    C = g["C" + suffix][:]
+    occ = g["occ" + suffix][:]
+    nocc = int(g["nocc" + suffix][()])
+    return dict(C=C, occ=occ, nocc=nocc, S=g["overlap"][:], H=g["hcore"][:],
+                B=g["B"][:] if "B" in g else None, name=grp.strip("/") + suffix)
+
+
+def density(r):
+    """D = C diag(occ) C^T -- the SCF density, by construction of the dump."""
+    return (r["C"] * r["occ"]) @ r["C"].T
+
+
+def jk(B, D):
+    """Coulomb and exchange from the engine factor B[P,mu,nu]."""
+    J = np.einsum("Qmn,Qls,ls->mn", B, B, D, optimize=True)
+    K = np.einsum("Qml,ls,Qsn->mn", B, D, B, optimize=True)
+    return J, K
+
+
+def semicanonicalize(C, F, nocc):
+    """Diagonalize F within the occupied and the virtual block separately.
+    Returns rotated C and eps. Leaves both subspaces -- hence D -- untouched."""
+    Fmo = C.T @ F @ C
+    Fmo = 0.5 * (Fmo + Fmo.T)
+    nmo = C.shape[1]
+    U = np.zeros((nmo, nmo))
+    eps = np.zeros(nmo)
+    for lo, hi in ((0, nocc), (nocc, nmo)):
+        if hi <= lo:
+            continue
+        w, v = np.linalg.eigh(Fmo[lo:hi, lo:hi])
+        eps[lo:hi] = w
+        U[lo:hi, lo:hi] = v
+    return C @ U, eps
+
+
+def check_species(r, occ_full, nparticle):
+    n = r["C"].shape[1]
+    orth = np.abs(r["C"].T @ r["S"] @ r["C"] - np.eye(n)).max()
+    chk("C1 %s orthonormal" % r["name"], orth < 1e-8, "||C'SC-I||=%.2e" % orth)
+
+    want = np.array([occ_full] * r["nocc"] + [0.0] * (n - r["nocc"]))
+    chk("C2 %s occupation contract" % r["name"], np.abs(r["occ"] - want).max() < 1e-10)
+
+    D = density(r)
+    close("C3 %s Tr[D S]" % r["name"], float(np.trace(D @ r["S"])), nparticle, 1e-10)
+    return D
+
+
+def coulomb_exchange(f, r, D):
+    """(J,K) for one species, from the B factor or the dense rank-4 tensor."""
+    if r["B"] is not None:
+        return jk(r["B"], D)
+    eri = f["/eri_ee" if r["name"].startswith("electron") else "/eri_pp"][:]
+    return (np.einsum("mnls,ls->mn", eri, D, optimize=True),
+            np.einsum("mlsn,ls->mn", eri, D, optimize=True))
+
+
+def main():
+    global npass, nfail
+    for path in sys.argv[1:]:
+        print("\n=== %s ===" % path)
+        f = h5py.File(path, "r")
+        restricted = bool(f.attrs["restricted_electrons"])
+        nel = int(f.attrs["n_electrons"])
+        npr = int(f.attrs["n_quantum_protons"])
+        e_scf = float(f.attrs["e_scf"])
+        e_cls = float(f.attrs["e_classical"])
+
+        # electron blocks: one (RHF, occ 2) or two (UHF, occ 1 each)
+        if restricted:
+            eblk = [species(f, "/electron")]
+            occ_full = [2.0]
+        else:
+            eblk = [species(f, "/electron", "_a"), species(f, "/electron", "_b")]
+            occ_full = [1.0, 1.0]
+        p = species(f, "/proton")
+
+        Ds = [check_species(r, o, o * r["nocc"]) for r, o in zip(eblk, occ_full)]
+        De = sum(Ds)
+        close("C3 electron total Tr[D S]", float(np.trace(De @ eblk[0]["S"])), nel, 1e-10)
+        Dp = check_species(p, 1.0, npr)
+
+        eri_ep = f["/eri_ep"][:]
+        Jp, Kp = coulomb_exchange(f, p, Dp)
+        Je, _ = coulomb_exchange(f, eblk[0], De)          # Coulomb from the total density
+        Ks = [coulomb_exchange(f, r, d)[1] for r, d in zip(eblk, Ds)]
+
+        # cross-species Coulomb, bare and positive; the -1 sign is applied here
+        Vpe = np.einsum("mnab,ab->mn", eri_ep, Dp, optimize=True)  # on electrons
+        Vep = np.einsum("mnab,mn->ab", eri_ep, De, optimize=True)  # on protons
+
+        # C4: the SCF mean-field energy, rebuilt entirely from dumped quantities.
+        # c_x = 1/4 on the total density for RHF; 1/2 per spin for UHF and for
+        # the high-spin protons.
+        Eexch = (-0.25 * np.sum(De * Ks[0]) if restricted
+                 else -0.5 * sum(np.sum(d * k) for d, k in zip(Ds, Ks)))
+        E = (sum(np.sum(d * r["H"]) for d, r in zip(Ds, eblk)) + np.sum(Dp * p["H"])
+             + 0.5 * np.sum(De * Je) + Eexch
+             + 0.5 * np.sum(Dp * Jp) - 0.5 * np.sum(Dp * Kp)
+             - np.sum(De * Vpe) + e_cls)
+        close("C4 reference energy == e_scf", E, e_scf, 1e-6)
+
+        # C5: rebuild each reference Fock and semicanonicalize.
+        # electron: the true SCF Fock. proton: self-interaction-free (no Jp/Kp).
+        blocks = [(r, d, r["H"] + Je - (0.5 if restricted else 1.0) * k - Vpe)
+                  for r, d, k in zip(eblk, Ds, Ks)]
+        blocks.append((p, Dp, p["H"] - Vep))
+        for r, D, F in blocks:
+            Cs, eps = semicanonicalize(r["C"], F, r["nocc"])
+            Ds_new = (Cs * r["occ"]) @ Cs.T
+            chk("C5 %s semicanonical D invariant" % r["name"],
+                np.abs(Ds_new - D).max() < 1e-10, "max|dD|=%.2e" % np.abs(Ds_new - D).max())
+            Fmo = Cs.T @ F @ Cs
+            no = r["nocc"]
+            blk = max(np.abs(Fmo[:no, :no] - np.diag(np.diag(Fmo[:no, :no]))).max(),
+                      np.abs(Fmo[no:, no:] - np.diag(np.diag(Fmo[no:, no:]))).max())
+            ov = np.abs(Fmo[:no, no:]).max() if no < len(eps) else 0.0
+            chk("C5 %s blocks diagonalized" % r["name"], blk < 1e-10,
+                "max offdiag %.2e ; surviving occ-vir |F_ia| %.2e" % (blk, ov))
+            print("       %-14s eps[occ] = %s" % (r["name"], np.array2string(eps[:no], precision=6)))
+        f.close()
+
+    print("\nRESULT: %i passed, %i failed" % (npass, nfail))
+    return 1 if nfail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The bug

`neo_dump.cpp` canonicalized a self-interaction-free proton Fock `h_p + V_ep[D_e]` and occupied its lowest `nocc_p` eigenvectors. That operator shares the SCF occupied subspace **only for a single quantum proton**, where `J_pp + K_pp` annihilates the occupied orbital by exact self-interaction cancellation. With ≥2 protons it does not, so the reconstructed proton density was not the SCF density and the correlation consumer got a non-variational reference.

`NEODumpVerify` caught it (5.5 mHa on CH₄ with two quantum protons); the canonicalization residual check did not, because the orbitals *were* canonical with respect to the very operator that was wrong.

## The fix

The right proton Fock is use-case dependent — self-interaction-free for correlation models without a proton–proton fluctuation potential, J/K-dressed for models with one. So don't bake a choice into the dump. Export the **core Hamiltonians** and the **SCF orbitals verbatim** (reordered occupied-first), and let the consumer build whichever reference operator it needs and semicanonicalize it.

`neo.cpp` no longer rebuilds any Fock matrix — those existed only to feed the dumper.

## HDF5 schema deltas (breaking; `neocc/src/integrals.cc` needs a lockstep update)

**Removed:** `electron/fock{,_a,_b}`, `proton/fock`, `electron/eps{,_a,_b}`, `proton/eps`
**Added:** `electron/occ{,_a,_b}`, `proton/occ` — shape `(nmo,)`
**Changed semantics** (same name, same shape): `electron/C`, `proton/C` are now the SCF orbitals — orthonormal, occupied columns first, **not canonical**
**Unchanged:** `nbf`, `nmo`, `nocc`, `hcore`, `overlap`, `B`, `eri_ep`, `eri_ee`, `eri_pp`, all `/meta`

Consumer migration: drop `fock`/`eps` from `load_raw`; turn `assert_canonical` into an orthonormality assert (the canonicality assert will now fail *by design* on the proton); make `rebuild_neo_fock` unconditional; semicanonicalize before taking `eps = diag(F_MO)`. `add_proton_ppMF` is unaffected.

## Validation

`NEODumpVerify` differences:

| case | difference |
|---|---|
| CH₄, 2 protons, Cholesky | `-6.4e-14`  (old code: **aborts**, `5.6e-03`) |
| CH₄, 2 protons, RI | `2.0e-08` (see below) |
| H₂O, 2 protons, RI | `1.5e-08` |
| HeHHe⁺, 1 proton, Cholesky | `8.9e-15` |
| HeHHe⁺, 1 proton, dense/4index | `3.6e-15` |
| HeHHe⁺, doublet UHF, RI | `2.7e-14` |

Single-proton dumps are unregressed: against the pre-change reference file the occupied subspaces are identical (occupied-block overlap singular values `1.0`), the proton occupied orbital matches to `|<old|new>| = 1.0`, `e_scf` is bit-identical, and `hcore`/`overlap`/`eri_ep` are unchanged.

New `tests/neo_dump_check.py` is the reference implementation of the consumer contract — build densities from the dumped orbitals, rebuild both Fock matrices, semicanonicalize, reconstruct the reference energy. **77/77** over RHF/UHF × Cholesky/RI/dense × one and two protons.

The write-time diagnostic now prints `max|F_ia|`, the surviving occupied–virtual coupling of the SI-free proton Fock. That is the defect made visible: **6.4e-03** for two protons, **2.7e-08** for one.

## A pre-existing defect found along the way

The `~1e-8` residual under RI with ≥2 protons is **not** introduced here. `def2-universal-jkfit` is an *electronic* auxiliary basis and fits tight PB4-F1 protonic pair densities badly: for CH₄ the proton `B` factor has condition number `2.6e12` (Cholesky: `3.1e4`), and `J_pp` comes out `5.460` vs `5.750` — a `0.29 Eh` fitting error shifting the total energy by `1.1 mEh`. With one proton `J_pp + K_pp` cancels exactly and none of it is visible. The old binary shows the same few×`1e-9` residual on a single-proton CH₄/RI deck. Documented in `neo_dump_format.md` §3, with a recommendation to use `JKMethod Cholesky` for multi-proton dumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)