### PR TITLE
neo: shared-pivot Cholesky decomposition for the electronic and protonic integrals

### DIFF
--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -72,15 +72,29 @@ between species.
 These are reconstructed from the same engine factors (`= Σ_P B·B`), i.e. they carry
 the SCF's fitting/Cholesky approximation, not a separate exact recomputation.
 
-**Electron-proton — always dense, in both representations:**
+**Electron-proton.** Governed by `/meta:shared_aux`.
+
+When the two species expand in **one shared auxiliary space** (`shared_aux = 1`),
+their `B` factors carry a **common vector index** and the e-p tensor is exactly
+
+```
+(μν|ab) = Σ_P B_e[P,μ,ν] · B_p[P,a,b]
+```
+
+so it is **not stored** — it would cost `nbf_e²·nbf_p²` for something already on
+disk. That is the case for density fitting (both species fitted in the same
+Gaussian aux basis) and for the shared-pivot Cholesky decomposition
+(`NEOSharedCholesky`, §6). Reconstruct it, or better, contract with it directly.
+
+Otherwise (`shared_aux = 0`, or `integral_representation = "dense"` where no `B`
+exists to rebuild from) it is written out:
 
 | Dataset  | Shape (C-order)              | Element |
 |----------|------------------------------|---------|
 | `eri_ep` | `(nbf_e,nbf_e,nbf_p,nbf_p)`  | `(μν\|ab)`, electrons on `r1`, protons on `r2`, **bare positive** |
 
-(In DF mode the SCF shares one aux basis, so `(μν|ab)=Σ_P B_e[P,μν]B_p[P,ab]`; in CD
-mode the species have independent Cholesky spaces and the SCF computes e-p
-*exactly* — so `eri_ep` is dumped dense to stay engine-consistent either way.)
+Check `H5Lexists(file, "/eri_ep")` rather than assuming; when absent, `shared_aux`
+is set and `naux_e == naux_p`.
 
 ### 1.4 MO ordering and occupations
 
@@ -137,6 +151,7 @@ operator: every two-particle quantity in it is sign-free (§2.3).
 | `proton_mass`              | double | proton mass (atomic units) scaling the nuclear kinetic operator |
 | `naux_e`                   | int    | electron fit dimension (only in `btensor` mode) |
 | `naux_p`                   | int    | proton fit dimension (only in `btensor` mode) |
+| `shared_aux`               | bool   | `true` = `B_e`/`B_p` share a vector index, `eri_ep` omitted (§1.3) |
 | `e_scf`                    | double | converged NEO-SCF total energy printed by ERKALE |
 | `e_classical`              | double | Coulomb repulsion among the *classical* (non-quantum) nuclei only |
 | `erkale_version`           | string | ERKALE version / git description |
@@ -245,10 +260,9 @@ and exchange cancel exactly, so the error is invisible; with two it is not.
 Note also that the RI p-p energy itself is inaccurate, not merely ill-conditioned:
 for CH₄ with two quantum protons, `J_pp` is `5.460` under RI against `5.750` under
 Cholesky, a `0.29 Eh` fitting error that shifts the total energy by `1.1 mEh`. **Use
-`JKMethod Cholesky` for NEO dumps with more than one quantum proton.** A future
-superbasis Cholesky (one decomposition over the union of the electronic and protonic
-bases, segmented into `B_e`/`B_p` sharing a common vector index) would remove both
-problems and make `eri_ep` exact by construction rather than by aux-basis coincidence.
+`JKMethod Cholesky` for NEO dumps** — which then also gets you the shared-pivot
+decomposition of §6, and with it an `eri_ep` that is exact by construction rather
+than by aux-basis coincidence.
 
 ---
 
@@ -307,3 +321,63 @@ diagonalizing `f` within the occupied and virtual blocks separately, rotating `C
 accordingly; and take `eps = diag(Cᵀ f C)`. Asserting `‖f C − S C diag(eps)‖ ≈ 0` on
 the *dumped* `C` will now fail by design — assert orthonormality instead, and assert
 canonicality only after the semicanonical rotation.
+
+---
+
+## 6. Shared-pivot Cholesky (`NEOSharedCholesky`, default on)
+
+With `JKMethod Cholesky` and point protons, ERKALE decomposes the electronic and
+protonic two-particle integrals against **one shared set of Cholesky vectors**.
+`naux_e == naux_p`, `shared_aux = 1`, and `eri_ep` is omitted (§1.3).
+
+The object decomposed is the Gram matrix of the **union of the two same-species
+pair spaces** under the Coulomb metric,
+
+```
+M = [ (ee|ee)  (ee|pp) ]
+    [ (pp|ee)  (pp|pp) ]
+```
+
+*not* the pair space of the union of the two basis sets. The latter would also
+generate cross products `μa` of one electronic and one protonic function. Those
+have large diagonals — protonic functions are tight and sit on the electronic
+ones — so they would attract pivots, and they reconstruct `(μa|νb)` integrals no
+NEO model uses: electrons and protons are distinguishable, so there is no e-p
+exchange.
+
+ERKALE's CD is two-step, i.e. density fitting in an auxiliary basis of pivot
+orbital products, so this is implemented as a **shared pivot basis** rather than
+as an explicit decomposition of `M` followed by slicing. Pivots are selected per
+species and unioned; one metric `(piv|piv)` and one orthogonaliser `X = M^{-1/2}`
+are built over the union; each species then holds `L = Xᵀ (piv | μν)` over its own
+orbital basis. The union is bounded at the same threshold as a joint pivoting by
+the standard Cholesky bound `|Δ(μν|ab)| ≤ √(Δ_μν · Δ_ab)`, and the joint canonical
+orthogonalization prunes the redundancy it introduces. That orthogonalization
+normalizes the metric to unit diagonal first, which is what keeps the ~10⁶
+disparity between tight protonic and diffuse electronic pivot self-energies from
+discarding independent electronic functions by sheer magnitude.
+
+**Accuracy**, HeHHe⁺ / cc-pVDZ / PB4-F1, against the exact four-center e-p tensor
+and against independent per-species CDs:
+
+| quantity | deviation |
+|---|---|
+| `(μν\|ab)` = `B_e·B_pᵀ` vs exact four-center | max abs `4.2e-09`, max rel `8.8e-10` |
+| `(μν\|λσ)` vs independent CD | `1.5e-08` |
+| `(ab\|cd)` vs independent CD | `1.7e-08` |
+| `e_scf` vs independent CD | `6.4e-11` |
+
+**Cost.** Each species' `B` widens to the union: for CH₄ with two quantum protons,
+377 electronic + 362 protonic pivots orthogonalize to 717 shared vectors, so `B_e`
+grows 377→717 and `B_p` 362→717. But `eri_ep` disappears, and it was the dominant
+term: the dump falls from 56.4 MB to 28.9 MB, and the `O(nbf_e²·nbf_p²)` scaling is
+eliminated rather than merely reduced.
+
+**Restrictions.** One decomposition decomposes one operator, so the shared vectors
+serve the e-e, p-p and e-p blocks only when all three carry the bare `1/r12`. The
+keyword therefore stands down (with a printed reason) under `JKMethod RI`, under
+`FiniteProton` (a screened e-p kernel cannot reuse bare-Coulomb vectors), and when
+there are no quantum protons. It is **independent of `vpp`**: whether `J_pp/K_pp`
+enter the SCF Fock is separate from whether the protonic block is decomposed, and a
+downstream correlation treatment needs `B_p` either way. CD gradients are
+unavailable on a shared-pivot fit and throw if called.

--- a/src/b_tensor.cpp
+++ b/src/b_tensor.cpp
@@ -245,8 +245,26 @@ DirectCDBlocks::DirectCDBlocks(size_t Nbf, size_t Naux,
                                arma::mat pivot_X,
                                double omega, double alpha, double beta,
                                int max_am, int max_contr)
+    : DirectCDBlocks(Nbf, Naux, std::move(shellpairs), std::move(firsts), std::move(sizes),
+                     orb_shells, orb_shells, std::move(pivot_shellpairs),
+                     std::move(pivot_index), pivot_sentinel, std::move(pivot_X),
+                     omega, alpha, beta, max_am, max_contr) {}
+
+DirectCDBlocks::DirectCDBlocks(size_t Nbf, size_t Naux,
+                               std::vector<std::pair<size_t, size_t>> shellpairs,
+                               std::vector<std::pair<size_t, size_t>> firsts,
+                               std::vector<std::pair<size_t, size_t>> sizes,
+                               std::vector<GaussianShell> orb_shells,
+                               std::vector<GaussianShell> piv_shells,
+                               std::vector<std::pair<size_t, size_t>> pivot_shellpairs,
+                               arma::umat pivot_index,
+                               arma::uword pivot_sentinel,
+                               arma::mat pivot_X,
+                               double omega, double alpha, double beta,
+                               int max_am, int max_contr)
     : BTensorBlocksBase(Nbf, Naux, std::move(shellpairs), std::move(firsts), std::move(sizes)),
       orb_shells_(std::move(orb_shells)),
+      piv_shells_(std::move(piv_shells)),
       pivot_shellpairs_(std::move(pivot_shellpairs)),
       pivot_index_(std::move(pivot_index)),
       pivot_sentinel_(pivot_sentinel),
@@ -309,12 +327,12 @@ arma::mat DirectCDBlocks::get_block(size_t ip) const {
   for(size_t pp=0; pp<pivot_shellpairs_.size(); pp++) {
     const size_t ks = pivot_shellpairs_[pp].first;
     const size_t ls = pivot_shellpairs_[pp].second;
-    const size_t Nk = orb_shells_[ks].get_Nbf();
-    const size_t Nl = orb_shells_[ls].get_Nbf();
-    const size_t k0 = orb_shells_[ks].get_first_ind();
-    const size_t l0 = orb_shells_[ls].get_first_ind();
+    const size_t Nk = piv_shells_[ks].get_Nbf();
+    const size_t Nl = piv_shells_[ls].get_Nbf();
+    const size_t k0 = piv_shells_[ks].get_first_ind();
+    const size_t l0 = piv_shells_[ls].get_first_ind();
 
-    eri->compute(&orb_shells_[imus], &orb_shells_[inus], &orb_shells_[ks], &orb_shells_[ls]);
+    eri->compute(&orb_shells_[imus], &orb_shells_[inus], &piv_shells_[ks], &piv_shells_[ls]);
     const std::vector<double> * erip = eri->getp();
 
     for(size_t ii=0; ii<Nmu; ii++)

--- a/src/b_tensor.h
+++ b/src/b_tensor.h
@@ -175,11 +175,16 @@ public:
  * outlives the DensityFit that built it.
  */
 class DirectCDBlocks : public BTensorBlocksBase {
-  /// Orbital shells, owned copy.
+  /// Orbital shells, owned copy. These carry the (mu nu) bra.
   std::vector<GaussianShell> orb_shells_;
-  /// Pivot shellpairs to iterate over inside get_block.
+  /// Shells the pivot products are built from, owned copy. Normally the
+  /// same as orb_shells_; for a multicomponent (NEO) shared pivot basis
+  /// they belong to whichever species contributed the pivot, which need
+  /// not be the species carrying the bra.
+  std::vector<GaussianShell> piv_shells_;
+  /// Pivot shellpairs to iterate over inside get_block, indexing piv_shells_.
   std::vector<std::pair<size_t, size_t>> pivot_shellpairs_;
-  /// (Nbf x Nbf) lookup: (mu, nu) -> pivot rank or pivot_sentinel_.
+  /// Lookup over the *pivot* basis: (mu, nu) -> pivot rank or pivot_sentinel_.
   arma::umat pivot_index_;
   /// Sentinel value used in pivot_index_ (Nselected = pivot_index_xt.n_rows).
   arma::uword pivot_sentinel_;
@@ -204,11 +209,30 @@ class DirectCDBlocks : public BTensorBlocksBase {
   size_t Nselected_;
 
  public:
+  /// Single-species: the pivot products are built from the orbital shells.
   DirectCDBlocks(size_t Nbf, size_t Naux,
                  std::vector<std::pair<size_t, size_t>> shellpairs,
                  std::vector<std::pair<size_t, size_t>> firsts,
                  std::vector<std::pair<size_t, size_t>> sizes,
                  std::vector<GaussianShell> orb_shells,
+                 std::vector<std::pair<size_t, size_t>> pivot_shellpairs,
+                 arma::umat pivot_index,
+                 arma::uword pivot_sentinel,
+                 arma::mat pivot_X,
+                 double omega, double alpha, double beta,
+                 int max_am, int max_contr);
+
+  /// Foreign pivot basis: the (mu nu) bra comes from orb_shells, the pivot
+  /// products from piv_shells, and pivot_index is indexed over the pivot
+  /// basis. max_am / max_contr must cover both. Used by the NEO shared-pivot
+  /// decomposition, where one pivot set spans the electronic and protonic
+  /// pair spaces at once.
+  DirectCDBlocks(size_t Nbf, size_t Naux,
+                 std::vector<std::pair<size_t, size_t>> shellpairs,
+                 std::vector<std::pair<size_t, size_t>> firsts,
+                 std::vector<std::pair<size_t, size_t>> sizes,
+                 std::vector<GaussianShell> orb_shells,
+                 std::vector<GaussianShell> piv_shells,
                  std::vector<std::pair<size_t, size_t>> pivot_shellpairs,
                  arma::umat pivot_index,
                  arma::uword pivot_sentinel,

--- a/src/contrib/CMakeLists.txt
+++ b/src/contrib/CMakeLists.txt
@@ -187,7 +187,7 @@ if(OPENORBITAL_HEADER)
   endif()
   message(STATUS "Eigen3 headers for OpenOrbitalOptimizer targets: ${EIGEN3_INCLUDE_DIR}")
 
-  add_executable (erkale_neo neo.cpp neo_dump.cpp)
+  add_executable (erkale_neo neo.cpp neo_dump.cpp neo_cholesky.cpp)
   target_include_directories(erkale_neo PUBLIC "${EIGEN3_INCLUDE_DIR}")
   set_target_properties(erkale_neo PROPERTIES OUTPUT_NAME "erkale_neo${SUFFIX}")
   target_include_directories(erkale_neo PUBLIC "${OPENORBITAL_HEADER}")

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -33,6 +33,7 @@
 #include "density_fitting.h"
 #include "jkbuilder.h"
 #include "neo_dump.h"
+#include "neo_cholesky.h"
 
 // Needed for libint init
 #include "eriworker.h"
@@ -111,6 +112,7 @@ int main_guarded(int argc, char **argv) {
   settings.add_string("LoadChk", "Checkpoint file to load from", "");
   settings.add_bool("FiniteProton", "Use a finite proton model", false);
   settings.add_bool("vpp", "Include JK terms for protons?", true);
+  settings.add_bool("NEOSharedCholesky", "Decompose the electronic and protonic integrals against one shared set of Cholesky vectors; ignored unless JKMethod is Cholesky with point protons", true);
   settings.add_string("NEODump", "Dump converged NEO-SCF to this HDF5 file for post-SCF correlation codes (empty = off)", "");
   settings.add_string("NEODumpIntegrals", "Integral representation in NEODump: btensor (engine CD/RI factors) or dense", "btensor");
   settings.add_bool("NEODumpVerify", "Reconstruct the energy from the NEODump tensors and check it against the SCF energy", true);
@@ -136,6 +138,7 @@ int main_guarded(int argc, char **argv) {
   bool finiteproton = settings.get_bool("FiniteProton");
   bool density_fitting = (JKBuilder::resolve_method(settings)==JKBuilder::Method::DensityFitting);
   bool vpp = settings.get_bool("vpp");
+  bool shared_cholesky = settings.get_bool("NEOSharedCholesky");
 
   Checkpoint chkpt(savechk,true);
 
@@ -244,6 +247,36 @@ int main_guarded(int argc, char **argv) {
   double fitthr=settings.get_double("FittingThreshold");
   double cholfitthr=settings.get_double("FittingCholeskyThreshold");
 
+  // One decomposition decomposes one operator, so a shared pivot set can serve
+  // the e-e, p-p and e-p blocks only when all three carry the bare 1/r12. The
+  // keyword defaults on, so quietly stand down where that does not hold rather
+  // than reject decks that never asked for it.
+  //
+  // vpp is deliberately not a precondition: it governs whether J_pp/K_pp enter
+  // the Fock build, not whether the protonic block gets decomposed. The shared
+  // vectors are worth having either way -- a downstream correlation treatment
+  // needs them even when the reference SCF omitted the proton-proton mean field.
+  if(shared_cholesky) {
+    const char * why = nullptr;
+    if(density_fitting)
+      why = "JKMethod is not Cholesky";
+    else if(finiteproton)
+      why = "FiniteProton screens the e-p operator, which bare-Coulomb vectors cannot represent";
+    else if(!Sp.n_elem)
+      why = "there are no quantum protons";
+    if(why) {
+      printf("NEOSharedCholesky disabled: %s.\n", why);
+      fflush(stdout);
+      shared_cholesky = false;
+    }
+  }
+
+  // The e-p Coulomb is factorized -- B_e B_p^T over a common vector index --
+  // when the two species share an auxiliary expansion. Density fitting shares a
+  // Gaussian aux basis; the shared-pivot Cholesky shares a pivot basis. Without
+  // one, e-p is evaluated exactly from four-center integrals.
+  const bool factorized_ep = density_fitting || shared_cholesky;
+
   if(density_fitting) {
     fitlib.load_basis(settings.get_string("FittingBasis"));
     {
@@ -271,11 +304,19 @@ int main_guarded(int argc, char **argv) {
     double cholshthr=settings.get_double("CholeskyShThr");
     double shtol=settings.get_double("IntegralThresh");
     double fitcholthr=settings.get_double("FittingCholeskyThreshold");
-    Npairs_e=dfit.fill_cholesky(basis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose);
-    if(finiteproton)
-      pfit.set_range_separation(omega, alpha, beta);
-    if(vpp)
-      Npairs_p=pfit.fill_cholesky(pbasis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose);
+    if(shared_cholesky) {
+      Npairs_e=0;
+      Npairs_p=0;
+      neo_shared_cholesky(basis,pbasis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose,dfit,pfit);
+      Npairs_e=basis.compute_screening(shtol).shpairs.size();
+      Npairs_p=pbasis.compute_screening(shtol).shpairs.size();
+    } else {
+      Npairs_e=dfit.fill_cholesky(basis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose);
+      if(finiteproton)
+        pfit.set_range_separation(omega, alpha, beta);
+      if(vpp)
+        Npairs_p=pfit.fill_cholesky(pbasis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose);
+    }
   }
 
   printf("%i electronic shell pairs out of %i are significant.\n",(int) Npairs_e, (int) basis.get_unique_shellpairs().size());
@@ -472,7 +513,11 @@ int main_guarded(int argc, char **argv) {
     return Jt;
   };
 
-  std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb_ri = [&](const arma::mat & Pe) {
+  // c = B_e^T P_e in the shared auxiliary/pivot space, then J = -B_p c: the
+  // cross-species Coulomb over a common vector index. Exact to the Cholesky
+  // threshold when the pivot set is shared, the DF analogue when the shared
+  // space is a Gaussian aux basis.
+  std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb_factorized = [&](const arma::mat & Pe) {
     arma::vec c(dfit.compute_expansion(Pe));
     arma::mat J=-pfit.calcJ_vector(c);
     return J;
@@ -482,10 +527,10 @@ int main_guarded(int argc, char **argv) {
     return J;
   };
   std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb = [&](const arma::mat & Pe) {
-    return density_fitting ? electron_proton_coulomb_ri(Pe) : electron_proton_coulomb_exact(Pe);
+    return factorized_ep ? electron_proton_coulomb_factorized(Pe) : electron_proton_coulomb_exact(Pe);
   };
 
-  std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb_ri = [&dfit, &pfit](const arma::mat & Pp) {
+  std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb_factorized = [&dfit, &pfit](const arma::mat & Pp) {
     arma::vec c(pfit.compute_expansion(Pp));
     arma::mat J=-dfit.calcJ_vector(c);
     return J;
@@ -495,7 +540,7 @@ int main_guarded(int argc, char **argv) {
     return J;
   };
   std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb = [&](const arma::mat & Pp) {
-    return density_fitting ? proton_electron_coulomb_ri(Pp) : proton_electron_coulomb_exact(Pp);
+    return factorized_ep ? proton_electron_coulomb_factorized(Pp) : proton_electron_coulomb_exact(Pp);
   };
 
   OpenOrbitalOptimizer::Armadillo::FockBuilder<double, double> restricted_builder = [&](const OpenOrbitalOptimizer::Armadillo::DensityMatrix<double, double> & dm) {
@@ -1183,7 +1228,7 @@ int main_guarded(int argc, char **argv) {
                pbasis, pfit, Cp_ao, occp, hcore_p,
                Nel, (int) proton_indices.size(), proton_mass,
                scfsolver.get_energy(), Ecnucr,
-               density_fitting, omega, alpha, beta, version);
+               factorized_ep, omega, alpha, beta, version);
     }
   }
 

--- a/src/contrib/neo_cholesky.cpp
+++ b/src/contrib/neo_cholesky.cpp
@@ -1,0 +1,206 @@
+/*
+ *                This source code is part of
+ *
+ *                     E  R  K  A  L  E
+ *                             -
+ *                       HF/DFT from Hel
+ *
+ * Shared-pivot Cholesky decomposition for multicomponent (NEO) systems.
+ * See neo_cholesky.h for the construction and why it is the right object.
+ */
+
+#include "neo_cholesky.h"
+#include "basis.h"
+#include "density_fitting.h"
+#include "eriworker.h"
+#include "linalg.h"
+#include "timer.h"
+
+#include <cstdio>
+#include <set>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace {
+
+  typedef std::pair<size_t, size_t> pivpair_t;
+
+  /// Concatenate the two orbital bases into one pivot shell list with globally
+  /// unique first_ind: electronic functions occupy [0, Ne), protonic [Ne, Ne+Np).
+  /// The pivot index matrix and DirectCDBlocks both address this space.
+  std::vector<GaussianShell> concatenate_shells(const BasisSet & ebasis, const BasisSet & pbasis) {
+    std::vector<GaussianShell> shells = ebasis.get_shells();
+    const size_t Ne = ebasis.get_Nbf();
+    for(GaussianShell sh: pbasis.get_shells()) {
+      sh.set_first_ind(sh.get_first_ind() + Ne);
+      shells.push_back(sh);
+    }
+    return shells;
+  }
+
+  /// (piv|piv) over the combined pivot set. Identical in structure to
+  /// fill_cholesky's phase D, but the shellpairs may belong to either species,
+  /// so the electron-proton cross block is filled by the same loop.
+  arma::mat pivot_metric(const std::vector<GaussianShell> & shells,
+                         const std::vector<pivpair_t> & piv_sp,
+                         const arma::umat & piv_index,
+                         arma::uword sentinel,
+                         size_t Nselected,
+                         int max_am, int max_contr) {
+    arma::mat M(Nselected, Nselected, arma::fill::zeros);
+
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+    {
+      auto eri = make_eri_worker(max_am, max_contr, 0.0, 1.0, 0.0);
+
+#ifdef _OPENMP
+#pragma omp for schedule(dynamic,1)
+#endif
+      for(size_t ip=0; ip<piv_sp.size(); ip++) {
+        const size_t is = piv_sp[ip].first;
+        const size_t js = piv_sp[ip].second;
+        const size_t Ni = shells[is].get_Nbf();
+        const size_t Nj = shells[js].get_Nbf();
+        const size_t i0 = shells[is].get_first_ind();
+        const size_t j0 = shells[js].get_first_ind();
+        for(size_t jp=0; jp<=ip; jp++) {
+          const size_t ks = piv_sp[jp].first;
+          const size_t ls = piv_sp[jp].second;
+          const size_t Nk = shells[ks].get_Nbf();
+          const size_t Nl = shells[ls].get_Nbf();
+          const size_t k0 = shells[ks].get_first_ind();
+          const size_t l0 = shells[ls].get_first_ind();
+
+          eri->compute(&shells[is], &shells[js], &shells[ks], &shells[ls]);
+          const std::vector<double> * erip = eri->getp();
+
+          for(size_t ii=0; ii<Ni; ii++)
+            for(size_t jj=0; jj<Nj; jj++) {
+              const arma::uword pidx = piv_index(i0+ii, j0+jj);
+              if(pidx == sentinel) continue;
+              for(size_t kk=0; kk<Nk; kk++)
+                for(size_t ll=0; ll<Nl; ll++) {
+                  const arma::uword qidx = piv_index(k0+kk, l0+ll);
+                  if(qidx == sentinel) continue;
+                  const double val = (*erip)[((ii*Nj+jj)*Nk+kk)*Nl+ll];
+                  // Each (pidx,qidx) maps to a unique unordered pivot-shellpair
+                  // pair, visited exactly once by the ip / jp<=ip loop.
+                  M(pidx, qidx) = val;
+                  M(qidx, pidx) = val;
+                }
+            }
+        }
+      }
+    }
+    return M;
+  }
+
+} // anonymous namespace
+
+void neo_shared_cholesky(const BasisSet & ebasis, const BasisSet & pbasis,
+                         bool direct,
+                         double cholesky_tol,
+                         double shell_reuse_thr,
+                         double shell_screen_tol,
+                         double fit_cholesky_thr,
+                         bool verbose,
+                         DensityFit & dfit, DensityFit & pfit) {
+  Timer ttot;
+
+  const size_t Ne = ebasis.get_Nbf();
+  const size_t Np = pbasis.get_Nbf();
+  if(!Np)
+    throw std::runtime_error("neo_shared_cholesky: no protonic basis functions.\n");
+
+  // Pivots per species, then unioned. A jointly pivoted selection would pick a
+  // smaller set, but the union is bounded at the same threshold (see header)
+  // and the joint orthogonalisation below prunes the redundancy.
+  DensityFit selector;   // bare 1/r12; the operator must be shared by all blocks
+  arma::uvec pi_e, pi_p;
+  arma::umat invmap_e, invmap_p;
+  std::set<pivpair_t> sp_e, sp_p;
+  const size_t Nsel_e = selector.select_two_step_pivots(ebasis, cholesky_tol, shell_reuse_thr,
+                                                        shell_screen_tol, verbose, pi_e, invmap_e, sp_e);
+  const size_t Nsel_p = selector.select_two_step_pivots(pbasis, cholesky_tol, shell_reuse_thr,
+                                                        shell_screen_tol, verbose, pi_p, invmap_p, sp_p);
+  const size_t Nselected = Nsel_e + Nsel_p;
+
+  const std::vector<GaussianShell> piv_shells = concatenate_shells(ebasis, pbasis);
+  const size_t nesh = ebasis.get_shells().size();
+
+  // Pivot shellpairs: electronic first, then protonic with shell indices shifted
+  // into the concatenated list. Ranks follow the same order, so the electronic
+  // pivots occupy [0, Nsel_e) of the shared vector index.
+  std::vector<pivpair_t> piv_sp(sp_e.begin(), sp_e.end());
+  for(const pivpair_t & q: sp_p)
+    piv_sp.push_back(pivpair_t(q.first + nesh, q.second + nesh));
+
+  const arma::uword sentinel = Nselected;
+  arma::umat piv_index(Ne+Np, Ne+Np);
+  piv_index.fill(sentinel);
+  for(size_t p=0; p<Nsel_e; p++) {
+    const arma::uword pii = pi_e(p);
+    piv_index(invmap_e(0,pii), invmap_e(1,pii)) = p;
+    piv_index(invmap_e(1,pii), invmap_e(0,pii)) = p;
+  }
+  for(size_t p=0; p<Nsel_p; p++) {
+    const arma::uword pii = pi_p(p);
+    piv_index(Ne+invmap_p(0,pii), Ne+invmap_p(1,pii)) = Nsel_e + p;
+    piv_index(Ne+invmap_p(1,pii), Ne+invmap_p(0,pii)) = Nsel_e + p;
+  }
+
+  const int piv_max_am = std::max(ebasis.get_max_am(), pbasis.get_max_am());
+  const int piv_max_contr = std::max(ebasis.get_max_Ncontr(), pbasis.get_max_Ncontr());
+
+  Timer t;
+  arma::mat M = pivot_metric(piv_shells, piv_sp, piv_index, sentinel, Nselected,
+                             piv_max_am, piv_max_contr);
+  const double t_int = t.get();
+
+  // Orthogonalise the joint metric. Normalise to unit diagonal first: the
+  // protonic pivot products are far tighter than the electronic ones, so their
+  // self-energies (A|A) differ by orders of magnitude, and a threshold applied
+  // to the raw metric would discard independent electronic functions purely
+  // because they are small. On the unit-diagonal correlation matrix the
+  // eigenvalues measure genuine linear dependence. Fold the normalisation back
+  // in afterwards, so X^T M X = I on the true metric.
+  t.set();
+  arma::vec dinv(Nselected);
+  for(arma::uword p=0; p<Nselected; p++) {
+    const double dpp = M(p,p);
+    dinv(p) = (dpp > 0.0) ? 1.0/std::sqrt(dpp) : 0.0;
+  }
+  arma::mat Mtilde(M);
+  Mtilde.each_col() %= dinv;
+  Mtilde.each_row() %= dinv.t();
+  arma::mat X = CanonicalOrth(Mtilde, fit_cholesky_thr);
+  X.each_col() %= dinv;
+  const double t_chol = t.get();
+
+  if(verbose) {
+    printf("\nNEO shared-pivot Cholesky decomposition.\n");
+    printf("  pivots: %i electronic + %i protonic = %i, orthogonalised to %i shared vectors.\n",
+           (int) Nsel_e, (int) Nsel_p, (int) Nselected, (int) X.n_cols);
+    printf("  metric build %s (integrals %3.1f %%, linear algebra %3.1f %%).\n",
+           t.elapsed().c_str(),
+           100*t_int/(t_int+t_chol), 100*t_chol/(t_int+t_chol));
+    fflush(stdout);
+  }
+
+  dfit.fill_cholesky_shared(ebasis, piv_shells, piv_sp, piv_index, sentinel, X,
+                            direct, shell_screen_tol, piv_max_am, piv_max_contr, verbose);
+  pfit.fill_cholesky_shared(pbasis, piv_shells, piv_sp, piv_index, sentinel, X,
+                            direct, shell_screen_tol, piv_max_am, piv_max_contr, verbose);
+
+  if(verbose) {
+    printf("NEO shared-pivot Cholesky finished in %s.\n", ttot.elapsed().c_str());
+    fflush(stdout);
+  }
+}

--- a/src/contrib/neo_cholesky.h
+++ b/src/contrib/neo_cholesky.h
@@ -1,0 +1,90 @@
+/*
+ *                This source code is part of
+ *
+ *                     E  R  K  A  L  E
+ *                             -
+ *                       HF/DFT from Hel
+ *
+ * Shared-pivot Cholesky decomposition for multicomponent (NEO) systems.
+ */
+
+#ifndef ERKALE_NEO_CHOLESKY
+#define ERKALE_NEO_CHOLESKY
+
+#include <armadillo>
+
+class BasisSet;
+class DensityFit;
+
+/**
+ * Decompose the electronic and protonic two-particle integrals against one
+ * shared set of Cholesky vectors.
+ *
+ * The object being decomposed is the Gram matrix of the *union of the two
+ * same-species pair spaces* under the Coulomb metric,
+ *
+ *     M = [ (ee|ee)  (ee|pp) ]
+ *         [ (pp|ee)  (pp|pp) ]
+ *
+ * and not the pair space of the union of the two basis sets. The latter would
+ * additionally generate cross products (mu a) of one electronic and one
+ * protonic function. Those have large diagonals -- protonic functions are
+ * tight and sit on the electronic ones -- so they would attract pivots, and
+ * they reconstruct (mu a | nu b) integrals no NEO model uses: electrons and
+ * protons are distinguishable, so there is no electron-proton exchange.
+ *
+ * ERKALE's CD is two-step, i.e. density fitting in an auxiliary basis of pivot
+ * orbital products. So this does not decompose M explicitly and slice the
+ * result; it builds a pivot set spanning both pair spaces, one metric
+ * M = (piv|piv) over it, and one orthogonaliser X = M^{-1/2}. Each species'
+ * DensityFit then holds L = X^T (piv | mu nu) over its own orbital basis, and
+ * the two therefore share a vector index P:
+ *
+ *     (mu nu | la si) = sum_P B_e[P,mu,nu] B_e[P,la,si]
+ *     (a b   | c d)   = sum_P B_p[P,a,b]   B_p[P,c,d]
+ *     (mu nu | a b)   = sum_P B_e[P,mu,nu] B_p[P,a,b]      <-- exact, shared P
+ *
+ * The last line is the point. With independent per-species fits it holds only
+ * when both species happen to be expanded in the same auxiliary basis, and
+ * never for a screened operator.
+ *
+ * The pivots are the *union of the two independently selected pivot sets*
+ * rather than a jointly pivoted selection. The standard Cholesky bound
+ * |dev (mu nu|a b)| <= sqrt(D_munu * D_ab) on the residual diagonals D bounds
+ * the cross block at the same threshold as the diagonal blocks, and the joint
+ * canonical orthogonalisation below removes whatever redundancy the union
+ * introduces. Crucially that orthogonalisation normalises the metric to unit
+ * diagonal first, so the ~10^6 disparity between tight protonic and diffuse
+ * electronic pivot self-energies discards functions by genuine linear
+ * dependence rather than by sheer magnitude.
+ *
+ * Only meaningful when all three blocks share the bare 1/r12 operator, i.e.
+ * point protons. A screened (finite-proton) e-p operator is a different
+ * kernel and cannot reuse these vectors; the caller must not request it.
+ *
+ * Independent of vpp: whether the proton-proton mean field enters the SCF Fock
+ * is a separate question from whether the protonic block is decomposed. A
+ * downstream correlation treatment needs B_p either way.
+ *
+ * On return dfit and pfit are CD-mode DensityFit objects with equal Naux.
+ * CD gradients are unavailable on them (the pivot basis is not the orbital
+ * basis) and throw if called.
+ *
+ * \param ebasis,pbasis      electronic and protonic orbital bases
+ * \param direct             recompute (piv|mu nu) per block instead of caching
+ * \param cholesky_tol       pivoted-CD threshold on the residual diagonal
+ * \param shell_reuse_thr,shell_screen_tol  pivot-selection screening controls
+ * \param fit_cholesky_thr   linear-dependence threshold of the joint metric
+ * \param verbose            print the decomposition summary
+ * \param dfit,pfit          filled on return
+ */
+void neo_shared_cholesky(const BasisSet & ebasis, const BasisSet & pbasis,
+                         bool direct,
+                         double cholesky_tol,
+                         double shell_reuse_thr,
+                         double shell_screen_tol,
+                         double fit_cholesky_thr,
+                         bool verbose,
+                         DensityFit & dfit, DensityFit & pfit);
+
+#endif

--- a/src/contrib/neo_dump.cpp
+++ b/src/contrib/neo_dump.cpp
@@ -249,7 +249,7 @@ void neo_dump(const std::string & filename,
               const arma::mat & hcore_p,
               int n_electrons, int n_protons, double proton_mass,
               double e_scf, double e_classical,
-              bool density_fitting, double omega, double alpha, double beta,
+              bool shared_aux, double omega, double alpha, double beta,
               const std::string & version) {
 
   if(representation != "btensor" && representation != "dense") {
@@ -276,9 +276,9 @@ void neo_dump(const std::string & filename,
   arma::mat Gee = Be * Be.t();
   arma::mat Gpp = Bp * Bp.t();
   arma::mat Gep;
-  if(density_fitting) {
+  if(shared_aux) {
     if(Be.n_cols != Bp.n_cols)
-      throw std::runtime_error("neo_dump: electron and proton density-fitting bases differ -- cannot share the e-p auxiliary expansion.\n");
+      throw std::runtime_error("neo_dump: the electron and proton factors do not share a vector index -- cannot form the e-p expansion.\n");
     Gep = Be * Bp.t();
   } else {
     Gep = exact_ep(ebasis, pbasis, omega, alpha, beta);
@@ -388,6 +388,9 @@ void neo_dump(const std::string & filename,
     write_int_attr(root, "naux_e", (int) Be.n_cols);
     write_int_attr(root, "naux_p", (int) Bp.n_cols);
   }
+  // With a shared auxiliary/pivot space the two B factors carry a common vector
+  // index, so eri_ep is a product of tensors already on disk and is not stored.
+  write_int_attr(root, "shared_aux", shared_aux ? 1 : 0);
   write_dbl_attr(root, "e_scf", e_scf);
   write_dbl_attr(root, "e_classical", e_classical);
   write_str_attr(root, "erkale_version", version);
@@ -426,12 +429,18 @@ void neo_dump(const std::string & filename,
   if(!dense)
     write_B(pg, Bp, Np);
 
-  // electron-proton tensor: always dense (mu nu | a b), bare positive.
-  // Write C-order (Ne,Ne,Np,Np): need row-major of Gep, i.e. column-major of Gep.t().
-  {
+  // Electron-proton tensor, bare positive (mu nu | a b). Omitted when the two B
+  // factors share a vector index, since it is then exactly B_e B_p^T and storing
+  // it would cost Ne^2 Np^2 for nothing. Written dense otherwise -- including in
+  // "dense" representation, where no B factor is on disk to reconstruct it from.
+  if(dense || !shared_aux) {
+    // C-order (Ne,Ne,Np,Np): row-major of Gep is the column-major buffer of Gep.t().
     arma::mat Gept = Gep.t();
     std::vector<hsize_t> dims = { (hsize_t) Ne, (hsize_t) Ne, (hsize_t) Np, (hsize_t) Np };
     write_buffer(file, "eri_ep", Gept.memptr(), dims);
+  } else {
+    printf("eri_ep omitted: shared auxiliary index, (mu nu|a b) = sum_P B_e[P,mu,nu] B_p[P,a,b].\n");
+    fflush(stdout);
   }
 
   // dense per-species tensors. Gee/Gpp are symmetric in (pair<->pair), so their
@@ -500,7 +509,7 @@ void neo_dump(const std::string & filename,
 
     if(std::abs(diff) > 1e-7) {
       bool screened = !(omega == 0.0 && alpha == 1.0 && beta == 0.0);
-      if(density_fitting && screened)
+      if(shared_aux && screened)
         // Finite-proton RI uses dfit's metric for the electron-side expansion and
         // pfit's (screened) 3-center for the proton-side projection; that mixed
         // metric is not exactly B_e B_p^T, so a small residual is expected here.

--- a/src/contrib/neo_dump.h
+++ b/src/contrib/neo_dump.h
@@ -50,7 +50,9 @@ class DensityFit;
  * \param Cp,occp,hcore_p proton SCF MOs, occupations, AO core Hamiltonian
  * \param n_electrons,n_protons,proton_mass  counts / mass
  * \param e_scf,e_classical  SCF total energy and classical nuclear repulsion
- * \param density_fitting omega/alpha/beta select the e-p (and p-p) operator
+ * \param shared_aux      true when both species expand in one auxiliary/pivot
+ *                   space, so (mu nu|a b) = B_e B_p^T; false means e-p is
+ *                   recomputed exactly. omega/alpha/beta select the operator
  * \param version         ERKALE version string for provenance
  */
 void neo_dump(const std::string & filename,
@@ -69,7 +71,7 @@ void neo_dump(const std::string & filename,
               // scalars
               int n_electrons, int n_protons, double proton_mass,
               double e_scf, double e_classical,
-              bool density_fitting, double omega, double alpha, double beta,
+              bool shared_aux, double omega, double alpha, double beta,
               const std::string & version);
 
 #endif

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -748,6 +748,77 @@ size_t DensityFit::fill_cholesky(const BasisSet & basis,
   return orbpairs.size();
 }
 
+size_t DensityFit::fill_cholesky_shared(const BasisSet & orbbas,
+                                        const std::vector<GaussianShell> & piv_shells,
+                                        const std::vector<std::pair<size_t, size_t>> & piv_shellpairs,
+                                        const arma::umat & piv_index,
+                                        arma::uword piv_sentinel,
+                                        const arma::mat & X,
+                                        bool dir,
+                                        double shell_screen_tol,
+                                        int piv_max_am, int piv_max_contr,
+                                        bool verbose) {
+  // Same object as fill_cholesky produces -- L = X^T (piv|mu nu) with the
+  // metric baked in -- but the pivot basis and its orthogonaliser are given,
+  // not derived from this orbital basis. See the header for why.
+  Timer ttot;
+
+  cholesky_mode = true;
+  cd_foreign_pivots = true;
+  init_orbital_state(orbbas, dir);
+  auxshells.clear();
+  maxauxam    = 0;
+  maxauxcontr = 0;
+  maxam       = std::max(maxorbam, piv_max_am);
+  maxcontr    = std::max(maxorbcontr, (size_t) piv_max_contr);
+
+  Naux = X.n_cols;
+  cd_X = X;
+  cd_pivot_index = piv_index;
+  cd_pivot_sentinel = piv_sentinel;
+  cd_pivot_shellpairs_vec = piv_shellpairs;
+  pivot_shellpairs.clear();
+  pivot_shellpairs.insert(piv_shellpairs.begin(), piv_shellpairs.end());
+
+  // The metric is baked into the L blocks, exactly as in fill_cholesky, so
+  // the J/K kernels see an identity metric in CD mode.
+  ab.reset();
+  ab_inv.reset();
+  ab_invh.reset();
+
+  orbpairs = orbbas.compute_screening(shell_screen_tol).shpairs;
+
+  std::vector<std::pair<size_t, size_t>> sp_pairs, sp_firsts, sp_sizes;
+  build_shellpair_descriptor(sp_pairs, sp_firsts, sp_sizes);
+
+  auto builder = std::make_shared<DirectCDBlocks>(
+      Nbf, Naux, sp_pairs, sp_firsts, sp_sizes,
+      orbshells, piv_shells, cd_pivot_shellpairs_vec, cd_pivot_index, cd_pivot_sentinel,
+      cd_X, omega, alpha, beta, maxam, maxcontr);
+  if(dir) {
+    blocks = builder;
+  } else {
+    auto cached = std::make_shared<CachedBlocks>(
+        Nbf, Naux, std::move(sp_pairs), std::move(sp_firsts), std::move(sp_sizes));
+#ifdef _OPENMP
+#pragma omp parallel for schedule(dynamic)
+#endif
+    for(size_t ip=0; ip<orbpairs.size(); ip++) {
+      arma::mat slot = cached->block_mut(ip);
+      slot = builder->get_block(ip);
+    }
+    blocks = cached;
+  }
+
+  if(verbose) {
+    printf("Shared-pivot CD: %i orbital shell pairs against %i shared vectors (%s).\n",
+           (int) orbpairs.size(), (int) Naux, ttot.elapsed().c_str());
+    fflush(stdout);
+  }
+
+  return orbpairs.size();
+}
+
 // Helper for the two CD force loops. Both compute a 4-shell dERIWorker
 // derivative and accumulate into a per-thread fwrk; the only thing
 // that varies is the outer shellpair list and the per-quartet
@@ -993,6 +1064,8 @@ void DensityFit::accumulate_3c_force_CD(const BasisSet & basis, arma::vec & f, d
 arma::vec DensityFit::forceJ_cholesky(const BasisSet & basis, const arma::mat & P) const {
   if(!cholesky_mode)
     throw std::runtime_error("DensityFit::forceJ_cholesky requires fill_cholesky to have been called.\n");
+  if(cd_foreign_pivots)
+    throw std::runtime_error("DensityFit::forceJ_cholesky: the pivot basis is not the orbital basis (shared-pivot CD); CD gradients are not implemented for it.\n");
   if(P.n_rows != Nbf || P.n_cols != Nbf)
     throw std::runtime_error("DensityFit::forceJ_cholesky: density matrix dimension mismatch.\n");
 
@@ -1037,6 +1110,8 @@ arma::vec DensityFit::forceJ_cholesky(const BasisSet & basis, const arma::mat & 
 arma::vec DensityFit::forceK(const BasisSet & basis, const arma::mat & Corig, const std::vector<double> & occo, double kfrac) const {
   if(Corig.n_rows != Nbf)
     throw std::runtime_error("DensityFit::forceK: orbital matrix doesn't match basis set.\n");
+  if(cd_foreign_pivots)
+    throw std::runtime_error("DensityFit::forceK: the pivot basis is not the orbital basis (shared-pivot CD); gradients are not implemented for it.\n");
 
   // Filter to occupied orbitals (drop columns with zero occupation).
   arma::mat C;

--- a/src/density_fitting.h
+++ b/src/density_fitting.h
@@ -145,6 +145,12 @@ class DensityFit {
   /// drive the metric build and the force sweeps.
   std::set<std::pair<size_t, size_t>> pivot_shellpairs;
 
+  /// True when the pivot products were built from a basis other than the
+  /// orbital basis (fill_cholesky_shared). cd_pivot_index is then indexed
+  /// over the pivot basis, not the orbital basis, so the CD gradient
+  /// kernels -- which assume the two coincide -- must refuse to run.
+  bool cd_foreign_pivots = false;
+
   /// Form screening matrix
   void form_screening();
   /// Throw std::logic_error unless P has the Nbf x Nbf density-matrix
@@ -203,20 +209,6 @@ class DensityFit {
   template<typename BuildQ>
   void accumulate_3c_force_CD(const BasisSet & basis, arma::vec & f, double sign, BuildQ && build_q) const;
 
-  /// Two-step CD pivot selection (phases A-C: diagonal, pair
-  /// enumeration, pivoted selection). Pivots-only: populates the
-  /// by-ref outputs (pivot list, product map, pivot shellpairs); the
-  /// (mu nu | piv) integrals are rebuilt per block by the cached/direct
-  /// block builders, not returned here. Honors the instance's range
-  /// separation (set_range_separation).
-  size_t select_two_step_pivots(const BasisSet & basis,
-                                double cholesky_tol,
-                                double shell_reuse_thr,
-                                double shell_screen_tol,
-                                bool verbose,
-                                arma::uvec & pi,
-                                arma::umat & invmap,
-                                std::set<std::pair<size_t, size_t>> & piv_shellpairs) const;
   /// Compute shell in (a|uv) matrix
   arma::mat compute_a_munu(ERIWorker * eri, size_t ip, double * memptr = nullptr) const;
   /// Project P_munu onto the aux basis through one shellpair block:
@@ -325,6 +317,56 @@ class DensityFit {
                        double shell_screen_tol,
                        double fit_cholesky_thr,
                        bool verbose);
+
+  /**
+   * Fill the B tensor from an *externally supplied* pivot basis and metric
+   * orthogonaliser, rather than selecting pivots from this object's own
+   * orbital basis.
+   *
+   * This is what makes a multicomponent (NEO) decomposition possible: one
+   * pivot set spanning the union of the electronic and protonic pair spaces,
+   * with one metric M = (piv|piv) and one orthogonaliser X = M^{-1/2}, is
+   * handed to a DensityFit per species. Each then holds
+   * L = X^T (piv | mu nu) over its own orbital basis, so the two share a
+   * common vector index P and the cross-species integrals come out as
+   * (mu nu | a b) = sum_P B_e[P,mu,nu] B_p[P,a,b] -- exact to the Cholesky
+   * threshold, rather than exact only when both species happen to be fitted
+   * in the same auxiliary basis.
+   *
+   * piv_shells is the concatenated pivot basis with globally unique
+   * first_ind; piv_index is indexed over it. piv_max_am / piv_max_contr must
+   * cover it. The CD force kernels are unavailable on the result (the pivot
+   * and orbital bases no longer coincide) and throw if called.
+   *
+   * Returns the number of significant orbital shell pairs.
+   */
+  size_t fill_cholesky_shared(const BasisSet & orbbas,
+                              const std::vector<GaussianShell> & piv_shells,
+                              const std::vector<std::pair<size_t, size_t>> & piv_shellpairs,
+                              const arma::umat & piv_index,
+                              arma::uword piv_sentinel,
+                              const arma::mat & X,
+                              bool direct,
+                              double shell_screen_tol,
+                              int piv_max_am, int piv_max_contr,
+                              bool verbose);
+
+  /// Two-step CD pivot selection (phases A-C: diagonal, pair
+  /// enumeration, pivoted selection). Pivots-only: populates the
+  /// by-ref outputs (pivot list, product map, pivot shellpairs); the
+  /// (mu nu | piv) integrals are rebuilt per block by the cached/direct
+  /// block builders, not returned here. Honors the instance's range
+  /// separation (set_range_separation). Public so a multicomponent
+  /// decomposition can select pivots per species and union them before
+  /// building one shared metric (see contrib/neo_cholesky.h).
+  size_t select_two_step_pivots(const BasisSet & basis,
+                                double cholesky_tol,
+                                double shell_reuse_thr,
+                                double shell_screen_tol,
+                                bool verbose,
+                                arma::uvec & pi,
+                                arma::umat & invmap,
+                                std::set<std::pair<size_t, size_t>> & piv_shellpairs) const;
 
   /// True iff this object was filled via fill_cholesky (i.e. the
   /// blocks hold CD-derived L vectors, not a genuine aux basis).

--- a/tests/neo_dump_check.py
+++ b/tests/neo_dump_check.py
@@ -126,7 +126,20 @@ def main():
         close("C3 electron total Tr[D S]", float(np.trace(De @ eblk[0]["S"])), nel, 1e-10)
         Dp = check_species(p, 1.0, npr)
 
-        eri_ep = f["/eri_ep"][:]
+        # With a shared auxiliary index eri_ep is not stored: it is exactly
+        # B_e B_p^T. Reconstruct it, which also exercises the shared index.
+        if "/eri_ep" in f:
+            eri_ep = f["/eri_ep"][:]
+        else:
+            if not int(f.attrs.get("shared_aux", 0)):
+                raise RuntimeError("no eri_ep and shared_aux is not set")
+            Be, Bp_ = eblk[0]["B"], p["B"]
+            if Be.shape[0] != Bp_.shape[0]:
+                raise RuntimeError("shared_aux set but naux_e != naux_p")
+            eri_ep = np.einsum("Pmn,Pab->mnab", Be, Bp_, optimize=True)
+            chk("C0 %s eri_ep from shared index" % "e-p", True,
+                "naux=%d, reconstructed (%d,%d,%d,%d)" % ((Be.shape[0],) + eri_ep.shape))
+
         Jp, Kp = coulomb_exchange(f, p, Dp)
         Je, _ = coulomb_exchange(f, eblk[0], De)          # Coulomb from the total density
         Ks = [coulomb_exchange(f, r, d)[1] for r, d in zip(eblk, Ds)]


### PR DESCRIPTION
## What

Decompose the electronic and protonic two-particle integrals against **one shared set of Cholesky vectors**, so their `B` factors carry a **common vector index** and

```
(μν|ab) = Σ_P B_e[P,μ,ν] · B_p[P,a,b]
```

is exact to the Cholesky threshold. Previously this identity held only when both species happened to be fitted in the same Gaussian aux basis (RI), and never for a screened operator; under Cholesky the two species had independent vector spaces, so e-p had to be recomputed exactly and dumped as a dense `nbf_e²·nbf_p²` tensor.

Keyword `NEOSharedCholesky`, **default true**.

## The object being decomposed

The Gram matrix of the union of the two **same-species pair spaces**:

```
M = [ (ee|ee)  (ee|pp) ]
    [ (pp|ee)  (pp|pp) ]
```

*not* the pair space of the union of the two basis sets. The latter also generates cross products `μa` of one electronic and one protonic function. Their diagonals are large — protonic functions are tight and sit on the electronic ones — so they would attract pivots, and they reconstruct `(μa|νb)` integrals no NEO model uses: electrons and protons are distinguishable, so there is no e-p exchange.

## Why a *shared pivot basis*, not a slice of a big CD

ERKALE's CD is **two-step** — density fitting in an aux basis of pivot orbital products (`density_fitting.cpp:558`). So rather than decomposing `M` explicitly and slicing its rows, pivots are selected per species and unioned; one metric `(piv|piv)` and one orthogonalizer `X = M^{-1/2}` are built over the union; each species' `DensityFit` then holds `L = Xᵀ (piv|μν)` over its own orbital basis. Every downstream J/K kernel is reused verbatim.

Two things make this sound:

- **Union of pivots suffices.** The Cholesky bound `|Δ(μν|ab)| ≤ √(Δ_μν·Δ_ab)` bounds the cross block at the same threshold as a joint pivoting would, and the joint canonical orthogonalization prunes the redundancy the union introduces (CH₄: 739 → 717).
- **The magnitude disparity is already handled.** `fill_cholesky` normalizes the metric to unit diagonal before orthogonalizing, precisely so the threshold "discard[s] functions by sheer magnitude rather than by genuine linear dependence". That is exactly the protection needed when mixing tight protonic and diffuse electronic pivots (~10⁶ in self-energy).

## Accuracy (HeHHe⁺ / cc-pVDZ / PB4-F1)

| quantity | deviation |
|---|---|
| `(μν\|ab)` = `B_e·B_pᵀ` vs **exact four-center** | max abs `4.2e-09`, max rel `8.8e-10` |
| `(μν\|λσ)` vs independent CD | `1.5e-08` |
| `(ab\|cd)` vs independent CD | `1.7e-08` |
| `e_scf` vs independent CD | `6.4e-11` |

`NEODumpVerify`: HeHHe⁺ `-6.2e-15` (RHF), `3.7e-13` (UHF doublet); CH₄ with two quantum protons `1.8e-13`.

## Payoff in the dump

`eri_ep` is now a product of tensors already on disk, so it is **not written**; `/meta:shared_aux` records this. For CH₄ with two quantum protons the file drops **56.4 MB → 28.9 MB**, and the `O(nbf_e²·nbf_p²)` term is *eliminated*, not merely reduced. `B_e` widens 377→717 vectors and `B_p` 362→717 — a linear cost against a quartic saving. `tests/neo_dump_check.py` reconstructs `eri_ep` from the shared index when it is absent.

Downstream (`neocc`) can now contract the e-p ladder directly against the shared factor instead of holding the dense tensor.

## Restrictions (all handled)

One decomposition decomposes one operator, so the shared vectors serve e-e, p-p and e-p only when all three carry the bare `1/r12`. The keyword stands down with a printed reason under `JKMethod RI`, under `FiniteProton` (a screened e-p kernel cannot reuse bare-Coulomb vectors), and when there are no quantum protons.

It is **independent of `vpp`**: `vpp` governs whether `J_pp/K_pp` enter the SCF Fock, not whether the protonic block gets decomposed — a downstream correlation treatment needs `B_p` either way.

CD gradients are unavailable on a shared-pivot fit (`cd_foreign_pivots` guard), since the pivot and orbital bases no longer coincide.

## Library changes are additive

- `DirectCDBlocks` gains an overload taking a pivot shell list distinct from the orbital shells; the single-basis constructor delegates to it.
- `DensityFit::fill_cholesky_shared` accepts an external pivot basis, orthogonalizer and index map.
- `select_two_step_pivots` becomes public so pivots can be selected per species.

Full `ctest` **182/182**, OpenMP and serial builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)