### PR TITLE
neo: vpp defaults to Auto, and vpp false is refused with more than one proton

### DIFF
--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -118,6 +118,16 @@ is set and `naux_e == naux_p`.
 spatial orbital, full p-p exchange) — a fully spin-polarized determinant of identical
 fermions. For one proton the p-p Coulomb+exchange self-interaction cancels exactly.
 
+That cancellation is why `vpp` (the proton-proton mean field in the SCF Fock)
+defaults to **`Auto`**: off for a single quantum proton, on from two. With one
+proton `J_pp + K_pp` annihilates the occupied orbital and contributes nothing to
+the energy, so switching it on changes no number in this file — it only pushes the
+protonic virtuals above the dissociation threshold, since they would then see the
+proton's own charge. From two protons the interaction is physical and `vpp` is on.
+`proton/B` is exported either way. Note that `NEODump` with **more than one**
+quantum proton requires `vpp`: the energy reconstruction of §3 includes the p-p
+Coulomb and exchange, which an SCF that skipped them would not reproduce.
+
 ### 1.5 Sign of the electron-proton interaction
 
 `eri_ep` is the **bare, positive** `(μν|ab)`. The physical interaction is attractive

--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -123,10 +123,14 @@ defaults to **`Auto`**: off for a single quantum proton, on from two. With one
 proton `J_pp + K_pp` annihilates the occupied orbital and contributes nothing to
 the energy, so switching it on changes no number in this file — it only pushes the
 protonic virtuals above the dissociation threshold, since they would then see the
-proton's own charge. From two protons the interaction is physical and `vpp` is on.
-`proton/B` is exported either way. Note that `NEODump` with **more than one**
-quantum proton requires `vpp`: the energy reconstruction of §3 includes the p-p
-Coulomb and exchange, which an SCF that skipped them would not reproduce.
+proton's own charge.
+
+From two protons the protons genuinely repel, and `vpp false` is **rejected**:
+omitting a 1.05 Eh interaction (H₂ with both nuclei quantum) is not an
+approximation but a different Hamiltonian. So `vpp` can only ever be off for a
+single proton, and the dump's energy reconstruction (§3) — which includes the p-p
+Coulomb and exchange — is unaffected by it either way. `proton/B` is exported
+regardless.
 
 ### 1.5 Sign of the electron-proton interaction
 

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -111,7 +111,7 @@ int main_guarded(int argc, char **argv) {
   settings.add_string("SaveChk", "Checkpoint file to save to", "neo.chk");
   settings.add_string("LoadChk", "Checkpoint file to load from", "");
   settings.add_bool("FiniteProton", "Use a finite proton model", false);
-  settings.add_string("vpp", "Include the proton-proton mean field J_pp/K_pp? true/false, or Auto: on only for two or more quantum protons", "Auto");
+  settings.add_string("vpp", "Include the proton-proton mean field J_pp/K_pp? Auto (on from two quantum protons), true, or false (single proton only)", "Auto");
   settings.add_bool("NEOSharedCholesky", "Decompose the electronic and protonic integrals against one shared set of Cholesky vectors; ignored unless JKMethod is Cholesky with point protons", true);
   settings.add_string("NEODump", "Dump converged NEO-SCF to this HDF5 file for post-SCF correlation codes (empty = off)", "");
   settings.add_string("NEODumpIntegrals", "Integral representation in NEODump: btensor (engine CD/RI factors) or dense", "btensor");
@@ -195,6 +195,18 @@ int main_guarded(int argc, char **argv) {
   } else {
     std::ostringstream oss;
     oss << "Could not parse the truth value " << vppstr << " for setting vpp; use true, false or Auto.\n";
+    throw std::runtime_error(oss.str());
+  }
+
+  // Switching the mean field off is only defensible for a single proton, where it
+  // is exactly zero on the occupied space. With two or more the protons genuinely
+  // repel -- 1.05 Eh for H2 with both nuclei quantum -- and omitting that is not
+  // an approximation but a different, unphysical Hamiltonian. Refuse rather than
+  // silently converge to it.
+  if(!vpp && proton_indices.size() > 1) {
+    std::ostringstream oss;
+    oss << "vpp false is not allowed with " << proton_indices.size() << " quantum protons:\n"
+        << "the proton-proton Coulomb and exchange cancel only for a single proton.\n";
     throw std::runtime_error(oss.str());
   }
 
@@ -1217,12 +1229,9 @@ int main_guarded(int argc, char **argv) {
     // Optional export of the converged NEO-SCF for an external correlation code
     std::string neodump = settings.get_string("NEODump");
     if(neodump.size()) {
-      // The dump's energy reconstruction includes the p-p Coulomb and exchange.
-      // With one quantum proton those cancel exactly, so vpp is immaterial; with
-      // more they do not, and an SCF that skipped them would not reconstruct.
-      if(!vpp && proton_indices.size() > 1)
-        throw std::runtime_error("NEODump with more than one quantum proton requires vpp: the SCF energy would omit the proton-proton mean field that the dumped integrals contain.\n");
-
+      // No vpp check here: it can only be off for a single quantum proton, whose
+      // p-p Coulomb and exchange cancel exactly, so the dump's energy
+      // reconstruction is unaffected either way.
       bool restricted_e = (M==1);
       size_t Nmat = fock.size();
 

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -111,7 +111,7 @@ int main_guarded(int argc, char **argv) {
   settings.add_string("SaveChk", "Checkpoint file to save to", "neo.chk");
   settings.add_string("LoadChk", "Checkpoint file to load from", "");
   settings.add_bool("FiniteProton", "Use a finite proton model", false);
-  settings.add_bool("vpp", "Include JK terms for protons?", true);
+  settings.add_string("vpp", "Include the proton-proton mean field J_pp/K_pp? true/false, or Auto: on only for two or more quantum protons", "Auto");
   settings.add_bool("NEOSharedCholesky", "Decompose the electronic and protonic integrals against one shared set of Cholesky vectors; ignored unless JKMethod is Cholesky with point protons", true);
   settings.add_string("NEODump", "Dump converged NEO-SCF to this HDF5 file for post-SCF correlation codes (empty = off)", "");
   settings.add_string("NEODumpIntegrals", "Integral representation in NEODump: btensor (engine CD/RI factors) or dense", "btensor");
@@ -137,7 +137,7 @@ int main_guarded(int argc, char **argv) {
   std::string savechk = settings.get_string("SaveChk");
   bool finiteproton = settings.get_bool("FiniteProton");
   bool density_fitting = (JKBuilder::resolve_method(settings)==JKBuilder::Method::DensityFitting);
-  bool vpp = settings.get_bool("vpp");
+  std::string vppstr = settings.get_string("vpp");
   bool shared_cholesky = settings.get_bool("NEOSharedCholesky");
 
   Checkpoint chkpt(savechk,true);
@@ -175,6 +175,28 @@ int main_guarded(int argc, char **argv) {
   }
   for(size_t i=0; i<quantum_protons.size(); i++)
     quantum_protons[i].num=i;
+
+  // Resolve vpp, which needs the proton count. A single quantum proton has no
+  // proton-proton interaction: J_pp + K_pp annihilates its occupied orbital and
+  // its Coulomb and exchange energies cancel exactly, so the mean field changes
+  // no SCF number. It does change the protonic virtuals, which then see the
+  // proton's own charge and come out unbound. Auto therefore leaves it off for a
+  // single proton and switches it on from two, where the interaction is physical.
+  bool vpp;
+  if(stricmp(vppstr,"Auto")==0) {
+    vpp = (proton_indices.size() > 1);
+    printf("vpp Auto: %s for %i quantum proton%s.\n", vpp ? "on" : "off",
+           (int) proton_indices.size(), proton_indices.size()==1 ? "" : "s");
+    fflush(stdout);
+  } else if(stricmp(vppstr,"true")==0 || stricmp(vppstr,"on")==0 || stricmp(vppstr,"yes")==0) {
+    vpp = true;
+  } else if(stricmp(vppstr,"false")==0 || stricmp(vppstr,"off")==0 || stricmp(vppstr,"no")==0) {
+    vpp = false;
+  } else {
+    std::ostringstream oss;
+    oss << "Could not parse the truth value " << vppstr << " for setting vpp; use true, false or Auto.\n";
+    throw std::runtime_error(oss.str());
+  }
 
   // Collect classical nuclei
   std::vector<std::tuple<int,double,double,double>> classical_nuclei;
@@ -314,7 +336,10 @@ int main_guarded(int argc, char **argv) {
       Npairs_e=dfit.fill_cholesky(basis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose);
       if(finiteproton)
         pfit.set_range_separation(omega, alpha, beta);
-      if(vpp)
+      // The protonic factor is needed by the Fock build only when vpp is on, but
+      // the dump exports it regardless -- a correlation treatment needs B_p even
+      // when the reference SCF omitted the proton-proton mean field.
+      if(vpp || settings.get_string("NEODump").size())
         Npairs_p=pfit.fill_cholesky(pbasis,direct,cholthr,cholshthr,shtol,fitcholthr,verbose);
     }
   }
@@ -1192,8 +1217,11 @@ int main_guarded(int argc, char **argv) {
     // Optional export of the converged NEO-SCF for an external correlation code
     std::string neodump = settings.get_string("NEODump");
     if(neodump.size()) {
-      if(!vpp)
-        throw std::runtime_error("NEODump requires vpp=true: the proton-proton integrals are part of the dump.\n");
+      // The dump's energy reconstruction includes the p-p Coulomb and exchange.
+      // With one quantum proton those cancel exactly, so vpp is immaterial; with
+      // more they do not, and an SCF that skipped them would not reconstruct.
+      if(!vpp && proton_indices.size() > 1)
+        throw std::runtime_error("NEODump with more than one quantum proton requires vpp: the SCF energy would omit the proton-proton mean field that the dumped integrals contain.\n");
 
       bool restricted_e = (M==1);
       size_t Nmat = fock.size();


### PR DESCRIPTION
## Why

A single quantum proton has no proton–proton interaction. `J_pp + K_pp` annihilates its occupied orbital and its Coulomb and exchange energies cancel exactly, so the mean field changes **no SCF number**. What it *does* change is the protonic virtuals: they then see the proton's own charge and come out unbound.

From two protons the protons genuinely repel, and the interaction is large.

So:

- `vpp` becomes a string keyword taking `Auto` / `true` / `false`, defaulting to **`Auto`**: off for one quantum proton, on from two.
- **`vpp false` is refused with more than one quantum proton.** Omitting a 1.05 Eh interaction is not an approximation but a different, unphysical Hamiltonian — and the SCF converges happily to it. The check sits where `vpp` is resolved, so it fires before any integrals are built. `Auto` never produces the combination; only an explicit `vpp false` can.

## Verification

| system | setting | result |
|---|---|---|
| HeHHe⁺ (1 proton) | `Auto` (→ off) | `-5.7729855078` |
| HeHHe⁺ (1 proton) | `vpp true` | `-5.7729855078` |
| HeHHe⁺ (1 proton) | `vpp false` | `-5.7729855078`, dump verifies `-2.7e-15` |
| H₂ (2 protons) | `Auto` (→ on) | `-1.0516996159`, dump verifies `4.9e-15` |
| H₂ (2 protons) | `vpp true` | `-1.0516996159` |
| H₂ (2 protons) | `vpp false` | **throws**, with and without `NEODump` |

The single-proton rows are the physics claim made explicit: all three agree to the printed digits. Before this PR, the last row converged to `-2.0978407726` against the correct `-1.0516996159`.

## Consequences for the dump

`Auto` turns `vpp` off in the common single-proton case, which had two knock-on effects:

1. **The dump needs `B_p` whether or not the Fock build used it.** The non-shared Cholesky path now fills `pfit` when either `vpp` or `NEODump` is set. (The shared-pivot and density-fitting paths already filled it unconditionally.)

2. **`NEODump` needs no `vpp` check at all.** Since `vpp` can only be off for a single proton, whose p-p Coulomb and exchange cancel exactly, the dump's energy reconstruction is unaffected either way. The old `NEODump requires vpp=true` guard is gone — it would have started firing on exactly the single-proton dumps it was meant to protect.

Single-proton dumps still carry `/proton/B` and verify at `-5.3e-15` on both the shared-pivot and the independent-CD path (`13/13` in `tests/neo_dump_check.py`).

Confined to `src/contrib/neo.cpp` plus the format spec — no `liberkale` change. OpenMP and serial builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)