### PR TITLE
CD forces: fix pivot double-counting in the derivative kernels

### DIFF
--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -942,10 +942,16 @@ void DensityFit::accumulate_2c_metric_force(arma::vec & f, M_lookup && M, double
           double accum = 0.0;
           for(size_t ii=0; ii<Ni; ii++)
             for(size_t jj=0; jj<Nj; jj++) {
+              // cd_pivot_index is symmetric, so within a diagonal
+              // shellpair both (ii, jj) and (jj, ii) map to the same
+              // pivot; keep one orientation, or the pivot gets counted
+              // twice against the once-per-pivot metric convention.
+              if(is == js && jj < ii) continue;
               const arma::uword pidx = cd_pivot_index(i0+ii, j0+jj);
               if(pidx == cd_pivot_sentinel) continue;
               for(size_t kk=0; kk<Nk; kk++)
                 for(size_t ll=0; ll<Nl; ll++) {
+                  if(ks == ls && ll < kk) continue;
                   const arma::uword qidx = cd_pivot_index(k0+kk, l0+ll);
                   if(qidx == cd_pivot_sentinel) continue;
                   accum += (*erip)[((ii*Nj+jj)*Nk+kk)*Nl+ll] * M(pidx, qidx);
@@ -1050,6 +1056,13 @@ void DensityFit::accumulate_3c_force_CD(const BasisSet & basis, arma::vec & f, d
             const size_t col = ii*Nj + jj;
             for(size_t kk=0; kk<Nk; kk++)
               for(size_t ll=0; ll<Nl; ll++) {
+                // cd_pivot_index is symmetric, so within a diagonal
+                // pivot shellpair both (kk, ll) and (ll, kk) map to
+                // the same pivot; keep one orientation, or the pivot
+                // gets counted twice against the once-per-pivot
+                // 3-index convention. (The orbital (ii, jj) side is a
+                // genuine ordered-pair sum -- no restriction there.)
+                if(ks == ls && ll < kk) continue;
                 const arma::uword qidx = cd_pivot_index(k0+kk, l0+ll);
                 if(qidx == cd_pivot_sentinel) continue;
                 accum += (*erip)[((ii*Nj+jj)*Nk+kk)*Nl+ll] * Q_ip(qidx, col);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,3 +54,22 @@ else()
   target_link_libraries(integraltest ${LIBINT_LIBRARIES})
   target_link_libraries(integraltest ${HDF5_LIBRARIES})
 endif()
+
+add_executable(cdforcetest cdforcetest.cpp)
+# The name of the executable is
+set_target_properties(cdforcetest PROPERTIES OUTPUT_NAME "cdforcetest${SUFFIX}")
+target_link_libraries(cdforcetest liberkale_emd)
+target_link_libraries(cdforcetest liberkale)
+
+# Link libraries
+if(BUILD_SHARED_LIBS)
+else()
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(cdforcetest -lrt)
+  endif()
+  target_link_libraries(cdforcetest ${GSL_LIBRARIES})
+  target_link_libraries(cdforcetest ${LAPACK_LIBRARIES})
+  target_link_libraries(cdforcetest ${LIBXC_LIBRARIES})
+  target_link_libraries(cdforcetest ${LIBINT_LIBRARIES})
+  target_link_libraries(cdforcetest ${HDF5_LIBRARIES})
+endif()

--- a/src/test/cdforcetest.cpp
+++ b/src/test/cdforcetest.cpp
@@ -1,0 +1,114 @@
+/*
+ * White-box finite-difference check of DensityFit::forceJ_cholesky and
+ * DensityFit::forceK in two-step Cholesky (CD) mode.
+ *
+ * forceK / forceJ_cholesky compute the EXPLICIT (fixed-density) nuclear
+ * gradient of the fitted exchange / Coulomb energy. We verify them against a
+ * finite difference of the very same energy, with the density (C, occ) frozen
+ * and the CD tensor rebuilt at each displaced geometry:
+ *
+ *   E_J = (1/2) tr(P J),   J = calcJ(P)            -> forceJ_cholesky
+ *   E_K = -(1/4) tr(P K),  K = calcK(C, occ)       -> forceK
+ *
+ * calcK sums over all pivots, so the energy FD is insensitive to pivot
+ * reordering.
+ *
+ * This test caught a pivot double-counting bug in the CD derivative kernels
+ * (accumulate_2c_metric_force / accumulate_3c_force_CD): cd_pivot_index is
+ * symmetric, so within a diagonal pivot shellpair both (kappa, lambda) and
+ * (lambda, kappa) mapped to the same pivot rank and the derivative
+ * contractions accumulated it twice, whereas the value-side metric / 3-index
+ * builds assign (once per pivot). forceK was off by ~2.4e-3 on H2O/cc-pVDZ HF
+ * regardless of CholeskyThr. forceJ_cholesky shares the kernels but appeared
+ * correct on C2v water, because by symmetry the total density has zero
+ * fitting coefficient on the affected (same-shell off-diagonal) pivot
+ * products -- use a distorted geometry to actually exercise the J path.
+ * With the fixed kernels both forces match FD to ~1e-8.
+ *
+ * Usage: cdforcetest <chkfile> <orbital-basis-name> [CholeskyThr=1e-12] [delta=1e-5]
+ */
+
+#include "../basis.h"
+#include "../basislibrary.h"
+#include "../checkpoint.h"
+#include "../density_fitting.h"
+#include "../eriworker.h"
+#include "../settings.h"
+
+#include <armadillo>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+Settings settings;
+
+static const double cholshthr = 0.01;
+static const double intthr    = 1e-10;
+static const double fitcholthr= 1e-14;  // full rank
+
+static double & coordref(nucleus_t & n, int x) {
+  return (x==0) ? n.r.x : (x==1 ? n.r.y : n.r.z);
+}
+
+static double energy(const std::vector<nucleus_t> & nuc, const BasisSetLibrary & baslib,
+                     const arma::mat & C, const std::vector<double> & occs,
+                     const arma::mat & P, double cholthr, char which) {
+  BasisSet b; construct_basis(b, nuc, baslib);
+  DensityFit dfit;
+  dfit.fill_cholesky(b, false, cholthr, cholshthr, intthr, fitcholthr, false);
+  if(which=='J') { arma::mat J=dfit.calcJ(P); return 0.5*arma::trace(P*J); }
+  arma::mat K=dfit.calcK(C,occs); return -0.25*arma::trace(P*K);
+}
+
+int main(int argc, char ** argv) {
+  if(argc<3) { fprintf(stderr,"usage: %s <chkfile> <basis> [CholeskyThr=1e-12] [delta=1e-5]\n",argv[0]); return 1; }
+  const std::string chkf=argv[1], basisname=argv[2];
+  const double cholthr=(argc>3)?atof(argv[3]):1e-12;
+  const double delta  =(argc>4)?atof(argv[4]):1e-5;
+
+  init_libint_base();
+  init_libderiv_base();
+  settings.add_scf_settings();
+
+  Checkpoint chk(chkf,false);
+  BasisSet basis_chk; chk.read(basis_chk);
+  arma::mat C; chk.read("C",C);
+  int Nela=0; chk.read("Nel-a",Nela);
+  printf("Loaded %s: Nbf=%i Nel-a=%i\n",chkf.c_str(),(int)basis_chk.get_Nbf(),Nela);
+
+  std::vector<double> occs(C.n_cols,0.0); arma::vec occv(C.n_cols,arma::fill::zeros);
+  for(int i=0;i<Nela;i++){occs[i]=2.0; occv(i)=2.0;}
+  const arma::mat P=C*arma::diagmat(occv)*C.t();
+
+  BasisSetLibrary baslib; baslib.load_basis(basisname);
+  const std::vector<nucleus_t> nuc0=basis_chk.get_nuclei();
+  const size_t Nnuc=nuc0.size();
+
+  BasisSet b0; construct_basis(b0,nuc0,baslib);
+  if(b0.get_Nbf()!=basis_chk.get_Nbf()){ fprintf(stderr,"basis mismatch\n"); return 1; }
+
+  DensityFit dfit0; dfit0.fill_cholesky(b0,false,cholthr,cholshthr,intthr,fitcholthr,false);
+  const arma::vec fJ=dfit0.forceJ_cholesky(b0,P);
+  const arma::vec fK=dfit0.forceK(b0,C,occs,1.0);
+
+  const size_t npiv0=dfit0.find_cholesky_pivots(b0,cholthr,cholshthr,intthr,false).size();
+  { std::vector<nucleus_t> nud=nuc0; coordref(nud[0],2)+=delta;
+    BasisSet bd; construct_basis(bd,nud,baslib); DensityFit dfd;
+    const size_t npivd=dfd.find_cholesky_pivots(bd,cholthr,cholshthr,intthr,false).size();
+    printf("Pivot shellpairs: R0=%i displaced=%i => %s\n",(int)npiv0,(int)npivd,(npiv0==npivd)?"STABLE":"CHANGED"); }
+
+  arma::vec fdJ(3*Nnuc), fdK(3*Nnuc);
+  for(size_t a=0;a<Nnuc;a++) for(int x=0;x<3;x++){
+    std::vector<nucleus_t> p=nuc0,m=nuc0; coordref(p[a],x)+=delta; coordref(m[a],x)-=delta;
+    fdJ(3*a+x)=(energy(p,baslib,C,occs,P,cholthr,'J')-energy(m,baslib,C,occs,P,cholthr,'J'))/(2*delta);
+    fdK(3*a+x)=(energy(p,baslib,C,occs,P,cholthr,'K')-energy(m,baslib,C,occs,P,cholthr,'K'))/(2*delta);
+  }
+  auto report=[&](const char* tag,const arma::vec& a,const arma::vec& f){
+    double mm=0; for(size_t i=0;i<a.n_elem;i++) mm=std::max(mm,std::min(std::fabs(a(i)-f(i)),std::fabs(a(i)+f(i))));
+    printf("%-34s sign-robust max mismatch = %.3e\n",tag,mm);
+  };
+  report("forceJ_cholesky (control)",fJ,fdJ);
+  report("forceK (suspect)",fK,fdK);
+  return 0;
+}


### PR DESCRIPTION
## Summary

The two-step Cholesky derivative kernels (`accumulate_2c_metric_force` CD branch, `accumulate_3c_force_CD` in `density_fitting.cpp`) count selected pivot products by looking up `cd_pivot_index` inside shell-quartet loops. `cd_pivot_index` is symmetric, so within a **diagonal pivot shellpair** both (κ,λ) and (λ,κ) map to the same pivot rank, and the derivative contractions **accumulated** the pivot twice — whereas the value-side builds (pivot metric, `(piv|μν)` blocks) **assign** each pivot once. Same-shell off-diagonal pivots therefore entered dM/dR and d(piv|μν)/dR with twice their weight, making `forceK` wrong by ~2×10⁻³ on H₂O/cc-pVDZ HF independent of the decomposition threshold. The fix skips the redundant orientation in the derivative loops.

`forceJ_cholesky` shares the kernels but had slipped through finite-difference validation: on C2v water the total density has exactly zero fitting coefficient on the affected (A2-symmetry, e.g. pₓ·p_y) pivot products, so the Coulomb gradient was blind to the bug. The per-orbital exchange intermediates (G, V) have no such zeros, which is why only `forceK` appeared broken.

## Validation

- New whitebox checker `src/test/cdforcetest.cpp` (built as `cdforcetest${SUFFIX}`): finite-difference check of the fixed-density CD Coulomb/exchange gradients against a checkpoint, rebuilding the decomposition at each displaced geometry. With the fix, both forces match FD to ~1e-8–1e-9 on symmetric **and distorted** water for CholeskyThr 1e-7…1e-12 (pre-fix: forceK off by 2.3e-3).
- The bug was cornered by contracting FD derivatives of the raw dense ERI tensor against the code's own intermediates: the 2-center kernel matched a "weight 2 on same-shell pivots" contraction to 1e-11. (Term-resolved FD of the fitted energy itself is ill-conditioned — the near-null eigenspace of the pivot metric rotates violently under displacement — so the raw-tensor route is the meaningful per-term reference.)
- Frozen-density CD J/K forces now agree with exact four-index forces to the fit accuracy even at the default CholeskyThr 1e-7; the analytic `JKMethod Cholesky` HF force from `erkale_geom` matches `JKMethod Exact` and the numerical gradient to all printed digits.
- Full test suite passes (182/182).

🤖 Generated with [Claude Code](https://claude.com/claude-code)