### PR TITLE
geometry: default the finite-difference step to 1e-4

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -440,7 +440,7 @@ int main_guarded(int argc, char **argv) {
   settings.set_string("JKMethod","RI");
   settings.add_bool("NumGrad","Use finite-difference gradient?",false);
   settings.add_int("Stencil","Order of finite-difference stencil for numgrad",2);
-  settings.add_double("Stepsize","Finite-difference stencil step size",1e-6);
+  settings.add_double("Stepsize","Finite-difference stencil step size",1e-4);
   settings.add_double("LineStepFac","Line search step length factor",sqrt(10.0));
   settings.add_double("InitialStep","Initial step size in bohr",0.2);
   settings.add_double("ParaThr","Threshold for parabolic fit interval in bohr (dimer only)",1e-2);


### PR DESCRIPTION
Follow-up to the force validation done during #141. The ~20% wB97X analytic-vs-numerical force discrepancy flagged there turned out to be a broken *reference*, not a broken force: `NumGrad`'s default `Stepsize` of 1e-6 bohr amplifies fit-truncation and SCF-convergence noise (~1e-8..1e-6 Ha; density-fitted surfaces are additionally discontinuous at the fit threshold when auxiliary Cholesky pivots change between displaced geometries) into up to ~1e-2 of force noise.

Evidence, on mildly distorted C1 water (cc-pVDZ, 99/590 grid): analytic forces for HF, PBE, and wB97X agree between Exact and DF backends and with the numerical gradient on the *exact* surface to print precision; the numerical gradient on the *DF* surface was off by ~3e-2 at h=1e-6 and comes back to <1e-3 at h=1e-4. The DF J and K force kernels (full-range and short-range erfc) were independently verified against finite differences of the fitted energy at frozen density to 2e-9.

The default step is changed to 1e-4 bohr, where the O(h²) central-difference truncation error is still negligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)