### PR TITLE
neo: the mass and the charge of the quantum particle are input parameters

### DIFF
--- a/neo_dump_format.md
+++ b/neo_dump_format.md
@@ -162,7 +162,8 @@ operator: every two-particle quantity in it is sign-free (§2.3).
 | `restricted_electrons`     | bool   | `true` = RHF (one electron set); `false` = UHF (α/β sets) |
 | `n_quantum_protons`        | int    | number of quantum protons |
 | `proton_spin_treatment`    | string | `"high-spin"` |
-| `proton_mass`              | double | proton mass (atomic units) scaling the nuclear kinetic operator |
+| `proton_mass`              | double | mass of the quantum particle (atomic units) scaling its kinetic operator |
+| `proton_charge`            | double | charge of the quantum particle (atomic units); +1 for a proton |
 | `naux_e`                   | int    | electron fit dimension (only in `btensor` mode) |
 | `naux_p`                   | int    | proton fit dimension (only in `btensor` mode) |
 | `shared_aux`               | bool   | `true` = `B_e`/`B_p` share a vector index, `eri_ep` omitted (§1.3) |
@@ -205,7 +206,9 @@ Proton group: `nmo`, `nocc` (`= n_quantum_protons`), `C`, `occ`, `hcore`.
   *classical* nuclei only. The e-p attraction is **not** here (two-particle, via
   `eri_ep`).
 - **Proton `hcore`** `= T_p/m_p + V_p(classical)` — mass-scaled kinetic + repulsion
-  from classical nuclei (`+` sign for the positive test charge), `m_p = proton_mass`.
+  from classical nuclei (scaled by the particle's charge `q = proton_charge`, so
+  the sign follows it), `m_p = proton_mass`. The electron-particle attraction
+  likewise carries the factor `-q`, and the particle-particle mean field `q^2`.
 
 **No Fock matrix and no orbital energies are dumped.** The right proton reference
 operator is use-case dependent, and baking one in silently corrupts the density:

--- a/src/contrib/hneoci.cpp
+++ b/src/contrib/hneoci.cpp
@@ -27,6 +27,7 @@
 #include "properties.h"
 #include "sap.h"
 #include "settings.h"
+#include "neo_particle.h"
 #include "stringutil.h"
 #include "timer.h"
 
@@ -338,7 +339,7 @@ int main_guarded(int argc, char **argv) {
 
   settings.add_scf_settings();
   settings.add_string("ProtonBasis", "Protonic basis set", "");
-  settings.add_double("ProtonMass", "Protonic mass", 1836.15267389);
+  add_particle_settings(settings);
   settings.add_int("Verbosity", "Verboseness level", 5);
   settings.add_bool("H2", "Run H2+ instead of H atom?", false);
   settings.add_double("H2BondLength", "Bond length for H2+ in a.u.", 2.0);
@@ -368,7 +369,10 @@ int main_guarded(int argc, char **argv) {
   // Get parameters
   double intthr=settings.get_double("IntegralThresh");
   bool verbose=settings.get_bool("Verbose");
-  double proton_mass = settings.get_double("ProtonMass");
+  const quantum_particle_t particle = get_particle(settings);
+  const double proton_mass = particle.m;
+  const double proton_charge = particle.q;
+  print_particle(particle);
   bool dimer = settings.get_bool("H2");
   double R = settings.get_double("H2BondLength");
   bool removecom = settings.get_bool("RemoveCOM");
@@ -478,7 +482,9 @@ int main_guarded(int argc, char **argv) {
     // Classical nucleus is attractive for electrons
     V = basis.nuclear(classical_nuclei);
     // and repulsive for protons
-    Vp = -pbasis.nuclear(classical_nuclei);
+    // The electronic routines give the potential felt by a particle of
+    // charge -1
+    Vp = -proton_charge*pbasis.nuclear(classical_nuclei);
   }
 
   // External confining trap on the quantum proton (one-body). Added to the
@@ -587,7 +593,9 @@ int main_guarded(int argc, char **argv) {
                 size_t I = I_start+II;
                 size_t J = J_start+JJ;
 
-                double element = -eris[((ii*N_j+jj)*N_I+II)*N_J+JJ];
+                // The product of the charges of the electron and of
+                // the quantum particle
+                double element = -proton_charge*eris[((ii*N_j+jj)*N_I+II)*N_J+JJ];
                 // (ij|IJ)
                 V_ao(BFIDX(i,I),BFIDX(j,J)) = element;
                 // (ij|JI)

--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -34,6 +34,7 @@
 #include "jkbuilder.h"
 #include "neo_dump.h"
 #include "neo_cholesky.h"
+#include "neo_particle.h"
 
 #include "eriworker.h"
 
@@ -101,7 +102,7 @@ int main_guarded(int argc, char **argv) {
   settings.add_int("StepwiseSCFIter", "Number of stepwise SCF macroiterations, 0 to skip to simultaneous solution", 0);
   settings.add_string("QuantumProtons", "Indices of protons to make quantum", "");
   settings.add_string("ErrorNorm", "Error norm to use in the SCF code", "rms");
-  settings.add_double("ProtonMass", "Protonic mass", 1836.15267389);
+  add_particle_settings(settings);
   settings.add_double("InitConvThr", "Initialization convergence threshold", 1e-5);
   settings.add_int("Verbosity", "Verboseness level", 5);
   settings.add_int("MaxInitIter", "Maximum number of iterations in the stepwise solutions", 50);
@@ -123,7 +124,10 @@ int main_guarded(int argc, char **argv) {
   int maxiter = settings.get_int("MaxIter");
   int maxinititer = settings.get_int("MaxInitIter");
   int diisorder = settings.get_int("DIISOrder");
-  double proton_mass = settings.get_double("ProtonMass");
+  const quantum_particle_t particle = get_particle(settings);
+  const double proton_mass = particle.m;
+  const double proton_charge = particle.q;
+  print_particle(particle);
   double intthr = settings.get_double("IntegralThresh");
   double init_convergence_threshold = settings.get_double("InitConvThr");
   double convergence_threshold = settings.get_double("ConvThr");
@@ -365,9 +369,12 @@ int main_guarded(int argc, char **argv) {
   arma::mat Vpc, Tp, Vpsap;
   std::vector<arma::mat> pr;
   if(Sp.n_elem) {
-    Vpc=-pbasis.nuclear(classical_nuclei);
+    // The electronic routines give the potential felt by a particle of
+    // charge -1, so the sign and the magnitude of the particle's charge
+    // carry over to the protonic terms
+    Vpc=-proton_charge*pbasis.nuclear(classical_nuclei);
     Tp=pbasis.kinetic()/proton_mass;
-    Vpsap=-pbasis.sap_potential(potlib);
+    Vpsap=-proton_charge*pbasis.sap_potential(potlib);
     pr=pbasis.moment(1);
   }
 
@@ -408,8 +415,10 @@ int main_guarded(int argc, char **argv) {
     arma::mat P(C*arma::diagmat(occs)*C.t());
     arma::mat J, K;
     if(vpp) {
-      J=pfit.calcJ(P);
-      K=-pfit.calcK(C,arma::conv_to<std::vector<double>>::from(occs));
+      // The interaction of two particles of charge q
+      const double q2=proton_charge*proton_charge;
+      J=q2*pfit.calcJ(P);
+      K=-q2*pfit.calcK(C,arma::conv_to<std::vector<double>>::from(occs));
     } else {
       J.zeros(P.n_rows, P.n_cols);
       K.zeros(P.n_rows, P.n_cols);
@@ -553,24 +562,26 @@ int main_guarded(int argc, char **argv) {
   // space is a Gaussian aux basis.
   std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb_factorized = [&](const arma::mat & Pe) {
     arma::vec c(dfit.compute_expansion(Pe));
-    arma::mat J=-pfit.calcJ_vector(c);
+    // The product of the charges of the electron and of the particle
+    arma::mat J=-proton_charge*pfit.calcJ_vector(c);
     return J;
   };
   std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb_exact = [&](const arma::mat & Pe) {
-    arma::mat J=-multicomponent_coulomb_tei(basis, Pe, pbasis);
+    arma::mat J=-proton_charge*multicomponent_coulomb_tei(basis, Pe, pbasis);
     return J;
   };
   std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb = [&](const arma::mat & Pe) {
     return factorized_ep ? electron_proton_coulomb_factorized(Pe) : electron_proton_coulomb_exact(Pe);
   };
 
-  std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb_factorized = [&dfit, &pfit](const arma::mat & Pp) {
+  std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb_factorized = [&dfit, &pfit, proton_charge](const arma::mat & Pp) {
     arma::vec c(pfit.compute_expansion(Pp));
-    arma::mat J=-dfit.calcJ_vector(c);
+    // The product of the charges of the electron and of the particle
+    arma::mat J=-proton_charge*dfit.calcJ_vector(c);
     return J;
   };
   std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb_exact = [&](const arma::mat & Pp) {
-    arma::mat J=-multicomponent_coulomb_tei(pbasis, Pp, basis);
+    arma::mat J=-proton_charge*multicomponent_coulomb_tei(pbasis, Pp, basis);
     return J;
   };
   std::function<arma::mat(const arma::mat & P)> proton_electron_coulomb = [&](const arma::mat & Pp) {
@@ -1260,7 +1271,7 @@ int main_guarded(int argc, char **argv) {
       neo_dump(neodump, settings.get_string("NEODumpIntegrals"), settings.get_bool("NEODumpVerify"),
                basis, dfit, restricted_e, Ce, occe_v, hcore_e,
                pbasis, pfit, Cp_ao, occp, hcore_p,
-               Nel, (int) proton_indices.size(), proton_mass,
+               Nel, (int) proton_indices.size(), proton_mass, proton_charge,
                scfsolver.get_energy(), Ecnucr,
                factorized_ep, omega, alpha, beta, version);
     }

--- a/src/contrib/neo_dump.cpp
+++ b/src/contrib/neo_dump.cpp
@@ -247,7 +247,7 @@ void neo_dump(const std::string & filename,
               const BasisSet & pbasis, const DensityFit & pfit,
               const arma::mat & Cp, const arma::vec & occp,
               const arma::mat & hcore_p,
-              int n_electrons, int n_protons, double proton_mass,
+              int n_electrons, int n_protons, double proton_mass, double proton_charge,
               double e_scf, double e_classical,
               bool shared_aux, double omega, double alpha, double beta,
               const std::string & version) {
@@ -384,6 +384,7 @@ void neo_dump(const std::string & filename,
   write_int_attr(root, "n_quantum_protons", n_protons);
   write_str_attr(root, "proton_spin_treatment", "high-spin");
   write_dbl_attr(root, "proton_mass", proton_mass);
+  write_dbl_attr(root, "proton_charge", proton_charge);
   if(!dense) {
     write_int_attr(root, "naux_e", (int) Be.n_cols);
     write_int_attr(root, "naux_p", (int) Bp.n_cols);

--- a/src/contrib/neo_dump.h
+++ b/src/contrib/neo_dump.h
@@ -48,7 +48,7 @@ class DensityFit;
  * \param hcore_e         electron AO core Hamiltonian (spin-independent)
  * \param pbasis,pfit     proton basis and engine
  * \param Cp,occp,hcore_p proton SCF MOs, occupations, AO core Hamiltonian
- * \param n_electrons,n_protons,proton_mass  counts / mass
+ * \param n_electrons,n_protons,proton_mass,proton_charge  counts / particle
  * \param e_scf,e_classical  SCF total energy and classical nuclear repulsion
  * \param shared_aux      true when both species expand in one auxiliary/pivot
  *                   space, so (mu nu|a b) = B_e B_p^T; false means e-p is
@@ -69,7 +69,7 @@ void neo_dump(const std::string & filename,
               const arma::mat & Cp, const arma::vec & occp,
               const arma::mat & hcore_p,
               // scalars
-              int n_electrons, int n_protons, double proton_mass,
+              int n_electrons, int n_protons, double proton_mass, double proton_charge,
               double e_scf, double e_classical,
               bool shared_aux, double omega, double alpha, double beta,
               const std::string & version);

--- a/src/contrib/neo_particle.h
+++ b/src/contrib/neo_particle.h
@@ -1,0 +1,77 @@
+/*
+ *                This source code is part of
+ *
+ *                     E  R  K  A  L  E
+ *                             -
+ *                       DFT from Hel
+ *
+ * Written by Susi Lehtola, 2010-2013
+ * Copyright (c) 2010-2013, Susi Lehtola
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ */
+
+#ifndef ERKALE_NEO_PARTICLE
+#define ERKALE_NEO_PARTICLE
+
+#include "../settings.h"
+#include "../stringutil.h"
+
+#include <cstdio>
+
+/// Mass of the proton in atomic units
+#define PROTON_MASS 1836.15267389
+
+/**
+ * The quantum particle treated by the multicomponent codes. It is a
+ * proton by default; a deuteron, a triton, a muon or a positron is
+ * obtained by giving its mass and charge.
+ */
+typedef struct {
+  /// Mass in atomic units (the electron mass is one)
+  double m;
+  /// Charge in atomic units (the electron charge is minus one)
+  double q;
+} quantum_particle_t;
+
+/// Register the settings that define the quantum particle
+inline void add_particle_settings(Settings & set) {
+  set.add_double("ParticleMass", "Mass of the quantum particle (proton by default)", PROTON_MASS);
+  set.add_double("ParticleCharge", "Charge of the quantum particle (proton by default); negative values are allowed", 1.0, true);
+  // Deprecated name of ParticleMass, kept so that old input files run
+  set.add_double("ProtonMass", "Deprecated: use ParticleMass", PROTON_MASS);
+}
+
+/// Get the quantum particle defined by the settings
+inline quantum_particle_t get_particle(const Settings & set) {
+  quantum_particle_t p;
+  p.m = set.get_double("ParticleMass");
+  p.q = set.get_double("ParticleCharge");
+
+  // The deprecated setting wins if it was given, so that old input
+  // files keep working
+  const double pm = set.get_double("ProtonMass");
+  if(pm != PROTON_MASS) {
+    printf("Warning: the setting ProtonMass is deprecated, use ParticleMass instead.\n");
+    fflush(stdout);
+    p.m = pm;
+  }
+
+  if(p.m <= 0.0)
+    throw std::runtime_error("The mass of the quantum particle must be positive.\n");
+  if(p.q == 0.0)
+    throw std::runtime_error("The charge of the quantum particle must be non-zero: a neutral particle does not interact with the electrons.\n");
+
+  return p;
+}
+
+/// Print out the quantum particle
+inline void print_particle(const quantum_particle_t & p) {
+  printf("Quantum particle: mass % .8f, charge % .4f atomic units.\n", p.m, p.q);
+  fflush(stdout);
+}
+
+#endif

--- a/src/contrib/neosp.cpp
+++ b/src/contrib/neosp.cpp
@@ -28,6 +28,7 @@
 #include "properties.h"
 #include "sap.h"
 #include "settings.h"
+#include "neo_particle.h"
 #include "stringutil.h"
 #include "timer.h"
 
@@ -81,7 +82,7 @@ int main_guarded(int argc, char **argv) {
   settings.add_scf_settings();
   settings.add_string("ProtonBasis", "Protonic basis set", "");
   settings.add_string("QuantumProtons", "Indices of protons to make quantum", "");
-  settings.add_double("ProtonMass", "Protonic mass", 1836.15267389);
+  add_particle_settings(settings);
   settings.add_string("LoadChk", "Checkpoint file to load from", "");
   settings.add_bool("FiniteProton", "Use a finite proton model", false);
   settings.add_int("NAvg", "Number of states to average over", 2);
@@ -92,7 +93,10 @@ int main_guarded(int argc, char **argv) {
   int Q = settings.get_int("Charge");
   int M = settings.get_int("Multiplicity");
   int maxiter = settings.get_int("MaxIter");
-  double proton_mass = settings.get_double("ProtonMass");
+  const quantum_particle_t particle = get_particle(settings);
+  const double proton_mass = particle.m;
+  const double proton_charge = particle.q;
+  print_particle(particle);
   double intthr = settings.get_double("IntegralThresh");
   bool verbose = settings.get_bool("Verbose");
   std::string loadchk = settings.get_string("LoadChk");
@@ -186,7 +190,9 @@ int main_guarded(int argc, char **argv) {
   arma::mat Vpc, Tp;
   std::vector<arma::mat> pr;
   if(Sp.n_elem) {
-    Vpc=-pbasis.nuclear(classical_nuclei);
+    // The electronic routines give the potential felt by a particle of
+    // charge -1
+    Vpc=-proton_charge*pbasis.nuclear(classical_nuclei);
     Tp=pbasis.kinetic()/proton_mass;
     pr=pbasis.moment(1);
   }
@@ -294,7 +300,8 @@ int main_guarded(int argc, char **argv) {
   };
 
   std::function<arma::mat(const arma::mat & P)> electron_proton_coulomb = [&](const arma::mat & Pe) {
-    arma::mat J=-multicomponent_coulomb_tei(basis, Pe, pbasis);
+    // The product of the charges of the electron and of the particle
+    arma::mat J=-proton_charge*multicomponent_coulomb_tei(basis, Pe, pbasis);
     return J;
   };
 


### PR DESCRIPTION
The multicomponent codes hardwired the quantum particle to be a proton: its mass was already an input parameter, but its **charge was implicit** in the signs and factors of the Coulomb terms. The particle is now defined by `ParticleMass` and `ParticleCharge`, so a deuteron, triton, muon or positron can be treated too. The old `ProtonMass` keyword still works (and warns).

## Where the charge enters

The electronic routines all express potentials for a particle of charge −1, so the particle's charge `q` carries over as:

| term | factor |
|---|---|
| attraction to the classical nuclei, and to the screened (SAP) potential | `-q` |
| electron–particle attraction | `-q` (product of the charges) |
| mean field between the quantum particles (J and K) | `q²` |
| kinetic energy | `1/m`, as before |

Shared by the three executables (`erkale_neo`, `erkale_neosp`, `erkale_hneoci`) through a new `neo_particle.h`. The HDF5 dump for the post-SCF codes now records `proton_charge` next to `proton_mass`, and `neo_dump_format.md` is updated.

## Validation: the classical limit

As the mass grows the particle localizes into a point charge, so the multicomponent energy must reproduce an ordinary HF calculation with a *classical* nucleus of the same charge. With a tight protonic basis:

| system | NEO (m = 1e12) | reference | difference |
|---|---|---|---|
| water, one quantum proton (q=1) | −76.0267515 | −76.0267721 (plain HF) | 2e-5 |
| water, quantum particle of **charge 2** | −77.5253369 | −77.5253423 (classical charge-2 nucleus, same basis) | 5e-6 |
| water, **both** protons quantum (q=1) | −76.0267585 | −76.0267721 (plain HF) | 1.4e-5 |

The charge-2 case validates that both the attraction to the electrons and the repulsion from the nuclei scale correctly with `q` — a q=1 test alone cannot catch a missing factor. The two-particle case validates the `q²` mean field: in the classical limit it *is* the H–H nuclear repulsion.

Also checked: a proton run reproduces master to the last digit (−75.9866622044, so the parameterization is a no-op at q=+1); the deuteron, proton and muon come out in the physically expected order (−75.9978, −75.9867, −75.9189 — heavier particle, less zero-point energy); and the legacy `ProtonMass` keyword still gives the proton result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)