### PR TITLE
neo_dump: apply the particle's charge in the verifier; fix the shared-pivot Cholesky environment

### DIFF
--- a/src/cintenv.cpp
+++ b/src/cintenv.cpp
@@ -85,6 +85,10 @@ CintEnv::CintEnv(const std::vector<GaussianShell> & sh, bool build_opts) {
   build(sh, sh.size(), build_opts);
 }
 
+CintEnv::CintEnv(const std::vector<GaussianShell> & sh, size_t Nsh_orbital, bool build_opts) {
+  build(sh, Nsh_orbital, build_opts);
+}
+
 CintEnv::OptSet::~OptSet() {
   for(size_t i=0;i<opts.size();i++)
     if(opts[i]) {

--- a/src/cintenv.h
+++ b/src/cintenv.h
@@ -150,6 +150,10 @@ class CintEnv {
   CintEnv(const BasisSet & basis, const BasisSet & aux, bool build_opts=true);
   /// Construct for an explicit list of shells
   explicit CintEnv(const std::vector<GaussianShell> & shells, bool build_opts=true);
+  /// Construct for an explicit list of shells, of which the first
+  /// Nsh_orbital are the orbital shells and the rest auxiliary: the
+  /// auxiliary shells are then addressed as get_Nsh_orb() + i
+  CintEnv(const std::vector<GaussianShell> & shells, size_t Nsh_orbital, bool build_opts=true);
 
   /// Is the environment initialized?
   bool is_filled() const;

--- a/src/contrib/neo_dump.cpp
+++ b/src/contrib/neo_dump.cpp
@@ -485,13 +485,17 @@ void neo_dump(const std::string & filename,
       }
     }
 
-    // p-p Coulomb and exchange (high-spin protons)
-    double Ecoul_pp = 0.5 * arma::dot(dp_vec, Gpp * dp_vec);
+    // p-p Coulomb and exchange (high-spin): the mean field between two
+    // particles of charge q carries q^2
+    const double q2 = proton_charge*proton_charge;
+    double Ecoul_pp = 0.5 * q2 * arma::dot(dp_vec, Gpp * dp_vec);
     arma::mat Kp = calcK_from_G(Gpp, Dp);
-    double Eexch_pp = -0.5 * arma::trace(Kp * Dp);
+    double Eexch_pp = -0.5 * q2 * arma::trace(Kp * Dp);
 
-    // e-p coupling: attractive sign applied here (q_e*q_p = -1)
-    double E_ep = - arma::dot(de_vec, Gep * dp_vec);
+    // e-p coupling: the product of the charges of the electron and of
+    // the quantum particle, q_e*q_p = -q. The two-particle integrals in
+    // the dump are sign-free, so the charge is applied here.
+    double E_ep = -proton_charge * arma::dot(de_vec, Gep * dp_vec);
 
     double E_recon = E1e + E1p + Ecoul_ee + Eexch_ee + Ecoul_pp + Eexch_pp + E_ep + e_classical;
     double diff = E_recon - e_scf;

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -779,8 +779,10 @@ size_t DensityFit::fill_cholesky_shared(const BasisSet & orbbas,
     std::vector<GaussianShell> allsh(orbbas.get_shells());
     const size_t Norb=allsh.size();
     allsh.insert(allsh.end(),piv_shells.begin(),piv_shells.end());
-    cenv=CintEnv(allsh);
-    (void) Norb;
+    // The pivot shells follow the orbital shells: they are addressed as
+    // Norb + is, which is what DirectCDBlocks expects of a shared pivot
+    // basis
+    cenv=CintEnv(allsh,Norb);
   }
 
   // Same object as fill_cholesky produces -- L = X^T (piv|mu nu) with the


### PR DESCRIPTION
Fixes the `neo_dump` verifier defect reported against #144, plus a second, more serious bug found while testing it.

## 1. The verifier hardcoded the proton's charge (the reported bug)

The dump itself is correct — its two-particle quantities are sign-free, as the format prescribes — but the self-consistency check reconstructed the energy with a proton's charge:

```cpp
double Ecoul_pp = 0.5 * arma::dot(dp_vec, Gpp * dp_vec);   // missing q^2
double Eexch_pp = -0.5 * arma::trace(Kp * Dp);             // missing q^2
double E_ep = - arma::dot(de_vec, Gep * dp_vec);           // hardcoded -1, should be -q
```

so it threw for the first particle that was not a proton (a muonic lithium calculation, off by exactly twice the coupling term — an exact sign flip). Now `-q` and `q²` respectively, which is the same pair of rules #144 applied to the SCF.

**Why #144's validation missed it**, which is the useful part: `-q` is invisible at q = +1 (it *is* −1 there), and `q²` is invisible at any |q| = 1 *and* cancels entirely for a single quantum particle. #144's table varied one condition at a time — a charge-2 run with one particle, and a two-particle run at q = 1 — so each case missed the other by exactly one condition. Seeing these needs a **negative charge** and **two particles with |q| ≠ 1**.

## 2. The shared-pivot Cholesky environment was wrong (found while testing)

More serious, and mine, from #143: `fill_cholesky_shared` builds its libcint environment as *orbital shells followed by pivot shells*, but used the single-list `CintEnv` constructor — which declares **all** of them orbital shells. `DirectCDBlocks` then computes `piv_offset_ = 0` and addresses the pivot shells as orbital shells: it reads the integrals of the wrong shells, out of the bounds of the block whenever the shells differ in size. It aborts on a build with assertions (this is how I found it) and **would silently corrupt the dump without them**. `CintEnv` now takes the split explicitly.

This is on master and affects every multicomponent shared-pivot Cholesky run, so it wants merging regardless of the verifier fix.

## Validation

Energy reconstructed from the dumped tensors versus the SCF energy:

| case | difference |
|---|---|
| one proton (q = +1) | 1.1e-13 |
| one particle of charge −1 | −5.7e-14 *(used to throw)* |
| two particles, q = 1.1 | 5.7e-14 |
| two particles, q = 1.2 | 2.8e-14 |

The last two exercise the `q²` of the particle–particle mean field; the second exercises the sign of the coupling. Both single-particle runs also confirm the coupling flips sign with the charge (−5.656 attractive at q = +1, +5.559 repulsive at q = −1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)