### PR TITLE
tests: cover the multicomponent codes

### DIFF
--- a/src/contrib/neo.cpp
+++ b/src/contrib/neo.cpp
@@ -154,7 +154,7 @@ int main_guarded(int argc, char **argv) {
   BasisSetLibrary potlib;
   potlib.load_basis(settings.get_string("SAPBasis"));
 
-  auto atoms=load_xyz(settings.get_string("System"),!settings.get_bool("InputBohr"));
+  auto atoms=load_system(settings.get_string("System"),!settings.get_bool("InputBohr"));
   std::vector<size_t> proton_indices;
   if(stricmp(settings.get_string("QuantumProtons"),"")!=0) {
     // Check for '*'

--- a/src/contrib/neosp.cpp
+++ b/src/contrib/neosp.cpp
@@ -108,7 +108,7 @@ int main_guarded(int argc, char **argv) {
   if(settings.get_string("ProtonBasis").size())
     pbaslib.load_basis(settings.get_string("ProtonBasis"));
 
-  auto atoms=load_xyz(settings.get_string("System"),!settings.get_bool("InputBohr"));
+  auto atoms=load_system(settings.get_string("System"),!settings.get_bool("InputBohr"));
   std::vector<size_t> proton_indices;
   if(stricmp(settings.get_string("QuantumProtons"),"")!=0) {
     // Check for '*'

--- a/src/xyzutils.cpp
+++ b/src/xyzutils.cpp
@@ -20,6 +20,7 @@
 #include "xyzutils.h"
 #include "stringutil.h"
 #include "zmatrix.h"
+#include "checkpoint.h"
 
 #include <sstream>
 #include <stdexcept>
@@ -163,4 +164,19 @@ void save_xyz(const std::vector<atom_t> & at, const std::string & comment, const
 void print_xyz(const std::vector<atom_t> & at) {
   for(size_t i=0;i<at.size();i++)
     printf("%4i %-4s  % 10.5f  % 10.5f  % 10.5f\n",(int) i+1, at[i].el.c_str(),at[i].x/ANGSTROMINBOHR,at[i].y/ANGSTROMINBOHR,at[i].z/ANGSTROMINBOHR);
+}
+
+std::vector<atom_t> load_system(const std::string & filename, bool inputbohr) {
+  if(file_exists(filename))
+    return load_xyz(filename,inputbohr);
+
+  // The system directory, as used by the main binary
+  const char * sysdir=getenv("ERKALE_SYSDIR");
+  if(sysdir) {
+    const std::string path=std::string(sysdir)+"/"+filename;
+    if(file_exists(path))
+      return load_xyz(path,inputbohr);
+  }
+
+  throw std::runtime_error("Unable to open xyz input file \"" + filename + "\" !\n");
 }

--- a/src/xyzutils.h
+++ b/src/xyzutils.h
@@ -52,4 +52,9 @@ void save_xyz(const std::vector<atom_t> & at, const std::string & comment, const
 /// Print xyz
 void print_xyz(const std::vector<atom_t> & at);
 
+/// Load the geometry named by the System setting, searching the
+/// directory given by ERKALE_SYSDIR if it is not found in the working
+/// directory, as the main binary does
+std::vector<atom_t> load_system(const std::string & filename, bool inputbohr);
+
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,20 @@ function(run_xrs target dep)
   set_property(TEST ${target} APPEND PROPERTY DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${target}.chk)
 endfunction()
 
+# Multicomponent (NEO) tests. The dump's self-consistency check reconstructs
+# the SCF energy from the exported tensors and throws if they disagree, so the
+# run validates the charge and the mass factors by itself; the expected energy
+# guards against numerical drift. The multicomponent codes have no reference
+# checkpoints, so they are not compared with chkcompare.
+function(run_neo target energy)
+  add_test(NAME ${target} COMMAND erkale_neo ${CMAKE_CURRENT_SOURCE_DIR}/${target}.run)
+  set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "ERKALE_SYSDIR=${CMAKE_CURRENT_SOURCE_DIR}/xyz")
+  set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "ERKALE_LIBRARY=${CMAKE_SOURCE_DIR}/basis")
+  set_property(TEST ${target} APPEND PROPERTY DEPENDS erkale_neo)
+  set_property(TEST ${target} APPEND PROPERTY DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${target}.run)
+  set_property(TEST ${target} PROPERTY PASS_REGULAR_EXPRESSION "Converged to energy ${energy}")
+endfunction()
+
 # First, compile and run the basic test
 add_test(build_basictests  "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target basictests)
 add_test(NAME basictests COMMAND basictests)
@@ -39,6 +53,17 @@ add_test(NAME basictests COMMAND basictests)
 # To run any tests we need to check that ERKALE and the test comparison binary have been built
 add_test(build_erkale     "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target erkale)
 add_test(build_chkcompare "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target chkcompare)
+add_test(build_erkale_neo "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target erkale_neo)
+
+# Multicomponent tests: a proton, a particle of negative charge (which fixes
+# the sign of the electron-particle coupling), a deuteron (the mass), and two
+# particles of a charge whose square is not one (the particle-particle mean
+# field). The last two conditions are what it takes to see the charge factors:
+# they are invisible for a single proton.
+run_neo(neo_proton "-75.98665")
+run_neo(neo_negative "-75.32345")
+run_neo(neo_deuteron "-75.99781")
+run_neo(neo_two_particles "-76.34112")
 
 # Generate list with genlist.sh
 include(TestList.txt)

--- a/tests/neo_deuteron.run
+++ b/tests/neo_deuteron.run
@@ -1,0 +1,13 @@
+# Multicomponent SCF with a quantum particle: the dump's self-consistency
+# check reconstructs the SCF energy from the exported tensors and throws if
+# they disagree, so the run itself validates the charge and mass factors.
+System H2O.xyz
+Basis cc-pVDZ
+ProtonBasis PB4-D
+QuantumProtons 2
+Method HF
+ParticleCharge 1.0
+ParticleMass 3670.48
+SaveChk neo_deuteron.chk
+NEODump neo_deuteron.h5
+NEODumpVerify true

--- a/tests/neo_negative.run
+++ b/tests/neo_negative.run
@@ -1,0 +1,13 @@
+# Multicomponent SCF with a quantum particle: the dump's self-consistency
+# check reconstructs the SCF energy from the exported tensors and throws if
+# they disagree, so the run itself validates the charge and mass factors.
+System H2O.xyz
+Basis cc-pVDZ
+ProtonBasis PB4-D
+QuantumProtons 2
+Method HF
+ParticleCharge -1.0
+ParticleMass 1836.15267389
+SaveChk neo_negative.chk
+NEODump neo_negative.h5
+NEODumpVerify true

--- a/tests/neo_proton.run
+++ b/tests/neo_proton.run
@@ -1,0 +1,13 @@
+# Multicomponent SCF with a quantum particle: the dump's self-consistency
+# check reconstructs the SCF energy from the exported tensors and throws if
+# they disagree, so the run itself validates the charge and mass factors.
+System H2O.xyz
+Basis cc-pVDZ
+ProtonBasis PB4-D
+QuantumProtons 2
+Method HF
+ParticleCharge 1.0
+ParticleMass 1836.15267389
+SaveChk neo_proton.chk
+NEODump neo_proton.h5
+NEODumpVerify true

--- a/tests/neo_two_particles.run
+++ b/tests/neo_two_particles.run
@@ -1,0 +1,13 @@
+# Multicomponent SCF with a quantum particle: the dump's self-consistency
+# check reconstructs the SCF energy from the exported tensors and throws if
+# they disagree, so the run itself validates the charge and mass factors.
+System H2O.xyz
+Basis cc-pVDZ
+ProtonBasis PB4-D
+QuantumProtons 2,3
+Method HF
+ParticleCharge 1.2
+ParticleMass 1836.15267389
+SaveChk neo_two_particles.chk
+NEODump neo_two_particles.h5
+NEODumpVerify true


### PR DESCRIPTION
The multicomponent codes were the only part of the tree the 182-test suite did not touch — which is exactly how two charge bugs reached master (#145): the dump verifier's hardcoded `-1` where it should be `-q`, and the shared-pivot Cholesky addressing pivot shells as orbital shells (an out-of-bounds read that would silently corrupt dumps in a build without assertions).

## What the tests do

Four water runs with a quantum particle, each with `NEODumpVerify` on. The verifier reconstructs the SCF energy from the exported tensors and **throws** if they disagree, so the physics validates itself — no reference checkpoints needed. The expected energy (via `PASS_REGULAR_EXPRESSION`) guards against numerical drift. Every run also goes through the shared-pivot Cholesky, so that path is covered too.

| test | what it pins |
|---|---|
| `neo_proton` | the standard path (q = +1) |
| `neo_negative` | **the sign of the electron–particle coupling** — invisible at q = +1, since `-q` *is* −1 there |
| `neo_deuteron` | the mass |
| `neo_two_particles` (q = 1.2) | **the q² of the particle–particle mean field** — invisible at any \|q\| = 1, and it cancels entirely for a single particle |

The last two are not arbitrary: they are the two conditions the validation in #144 missed by varying one at a time. **Reintroducing either bug fails exactly the tests meant to catch it** (`neo_negative` and `neo_two_particles` abort), which I checked by putting each bug back.

Runtime: ~2 minutes for all four.

## Also

The multicomponent codes could not find the suite's geometries — only the main binary honoured `ERKALE_SYSDIR`. The search is now a shared helper (`load_system`) used by all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)