### PR TITLE
Evaluate generally contracted shells together: the radial quartet

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -1168,6 +1168,53 @@ void BasisSet::form_unique_shellpairs() {
   */
 }
 
+std::vector<shellblock_t> BasisSet::get_shell_blocks() const {
+  std::vector<shellblock_t> blocks;
+
+  // Two shells belong to the same block if they sit on the same center,
+  // have the same angular momentum and the same basis (a spherical and
+  // a cartesian shell cannot be evaluated in a single call), and share
+  // their primitives.
+  auto same_block = [](const GaussianShell & lhs, const GaussianShell & rhs) {
+    if(lhs.get_center_ind() != rhs.get_center_ind())
+      return false;
+    if(lhs.get_am() != rhs.get_am())
+      return false;
+    if(lhs.lm_in_use() != rhs.lm_in_use())
+      return false;
+
+    const std::vector<contr_t> & lc=lhs.get_contr_ref();
+    const std::vector<contr_t> & rc=rhs.get_contr_ref();
+    if(lc.size() != rc.size())
+      return false;
+    for(size_t ip=0;ip<lc.size();ip++)
+      if(lc[ip].z != rc[ip].z)
+        return false;
+
+    return true;
+  };
+
+  for(size_t is=0;is<shells.size();is++) {
+    // Does the shell belong to a block we already have? The shells of a
+    // block need not be adjacent in the basis, but they usually are.
+    bool found=false;
+    for(size_t ib=0;ib<blocks.size();ib++)
+      if(same_block(shells[blocks[ib].shells[0]], shells[is])) {
+        blocks[ib].shells.push_back(is);
+        found=true;
+        break;
+      }
+
+    if(!found) {
+      shellblock_t block;
+      block.shells.push_back(is);
+      blocks.push_back(block);
+    }
+  }
+
+  return blocks;
+}
+
 std::vector<shellpair_t> BasisSet::get_unique_shellpairs() const {
   if(shells.size() && !shellpairs.size()) {
     throw std::runtime_error("shellpairs not initialized! Maybe you forgot to finalize?\n");

--- a/src/basis.h
+++ b/src/basis.h
@@ -105,6 +105,16 @@ typedef struct {
 /// Comparison operator for shellpairs: descending angular momentum
 bool operator<(const shellpair_t & lhs, const shellpair_t & rhs);
 
+/// A group of shells that share a center, an angular momentum and a set
+/// of primitives, and differ only in their contraction coefficients: a
+/// generally contracted shell, split into segmented shells by the basis
+/// set library. The integrals over all of them come out of a single
+/// recursion, so they are evaluated together.
+typedef struct {
+  /// The shells in the block, in the order they appear in the basis
+  std::vector<size_t> shells;
+} shellblock_t;
+
 /// Helper for integral sorts
 typedef struct {
   /// First shell
@@ -328,6 +338,11 @@ public:
   void form_unique_shellpairs();
   /// Get list of unique shell pairs
   std::vector<shellpair_t> get_unique_shellpairs() const;
+  /// Group the shells by their center, angular momentum and primitives:
+  /// shells that differ only in their contraction coefficients form a
+  /// generally contracted shell, and their integrals come out of a
+  /// single recursion. A segmented basis gives one shell per block.
+  std::vector<shellblock_t> get_shell_blocks() const;
 
   /// Build ScreeningData: Schwarz Q, distance estimate M, and a
   /// value-sorted, threshold-truncated shell-pair list. Single

--- a/src/cintenv.cpp
+++ b/src/cintenv.cpp
@@ -222,6 +222,10 @@ void CintEnv::build(const std::vector<GaussianShell> & sh, size_t Nsh_orbital, b
 
   // Build the integral optimizers. They cache the primitive pair data,
   // which is the whole point of holding on to the environment.
+  // The generally contracted tables share the data array, so they must
+  // be built before the workers copy it
+  build_gc(sh, build_opts);
+
   if(!build_opts)
     return;
 
@@ -242,6 +246,121 @@ void CintEnv::build(const std::vector<GaussianShell> & sh, size_t Nsh_orbital, b
     optfun[ik](&o, atmp, natm, basp, nbas, envp);
     opts->opts[ik]=(void *) o;
   }
+}
+
+void CintEnv::build_gc(const std::vector<GaussianShell> & sh, bool build_opts) {
+  // Group the shells that share a center, an angular momentum and a set
+  // of primitives: the integrals over their contractions come out of a
+  // single recursion.
+  gc_blocks.clear();
+  shell_block.assign(sh.size(),0);
+  shell_ctr.assign(sh.size(),0);
+
+  auto same_block = [](const GaussianShell & lhs, const GaussianShell & rhs) {
+    if(lhs.get_center_ind() != rhs.get_center_ind() || lhs.get_am() != rhs.get_am() || lhs.lm_in_use() != rhs.lm_in_use())
+      return false;
+    const std::vector<contr_t> & lc=lhs.get_contr_ref();
+    const std::vector<contr_t> & rc=rhs.get_contr_ref();
+    if(lc.size() != rc.size())
+      return false;
+    for(size_t ip=0;ip<lc.size();ip++)
+      if(lc[ip].z != rc[ip].z)
+        return false;
+    return true;
+  };
+
+  for(size_t is=0;is<sh.size();is++) {
+    bool found=false;
+    for(size_t ib=0;ib<gc_blocks.size();ib++)
+      if(same_block(sh[gc_blocks[ib].shells[0]], sh[is])) {
+        shell_block[is]=ib;
+        shell_ctr[is]=gc_blocks[ib].shells.size();
+        gc_blocks[ib].shells.push_back(is);
+        found=true;
+        break;
+      }
+    if(!found) {
+      shellblock_t block;
+      block.shells.push_back(is);
+      shell_block[is]=gc_blocks.size();
+      shell_ctr[is]=0;
+      gc_blocks.push_back(block);
+    }
+  }
+
+  // The generally contracted shell table. The coefficients of the block
+  // sit next to each other in the data array, one contraction after the
+  // other, which is what libcint expects of a shell with NCTR_OF > 1.
+  gc_bas.assign(BAS_SLOTS*gc_blocks.size(), 0);
+  for(size_t ib=0;ib<gc_blocks.size();ib++) {
+    const size_t is0=gc_blocks[ib].shells[0];
+    const size_t nctr=gc_blocks[ib].shells.size();
+
+    // The primitives are shared, so they can be taken from the first shell
+    for(int slot=0;slot<BAS_SLOTS;slot++)
+      gc_bas[ib*BAS_SLOTS+slot]=cint_bas[is0*BAS_SLOTS+slot];
+    gc_bas[ib*BAS_SLOTS+NCTR_OF]=(int) nctr;
+
+    if(nctr==1)
+      continue;
+
+    // The coefficients of the contractions have to be contiguous
+    const int nprim=cint_bas[is0*BAS_SLOTS+NPRIM_OF];
+    gc_bas[ib*BAS_SLOTS+PTR_COEFF]=(int) cint_env.size();
+    for(size_t ic=0;ic<nctr;ic++) {
+      const size_t is=gc_blocks[ib].shells[ic];
+      const int ptr=cint_bas[is*BAS_SLOTS+PTR_COEFF];
+      for(int ip=0;ip<nprim;ip++)
+        cint_env.push_back(cint_env[ptr+ip]);
+    }
+  }
+
+  if(!build_opts || !have_gc())
+    return;
+
+  gc_opts=std::make_shared<OptSet>();
+  gc_opts->opts.assign(CINT_NKERNEL, nullptr);
+  CINTOptimizerFunction * const optfun[CINT_NKERNEL]={
+    int2e_optimizer, int2e_ip1_optimizer, int2e_ip2_optimizer,
+    int3c2e_optimizer, int3c2e_ip1_optimizer, int3c2e_ip2_optimizer,
+    int2c2e_optimizer, int2c2e_ip1_optimizer};
+  for(int ik=0;ik<CINT_NKERNEL;ik++) {
+    CINTOpt * o=nullptr;
+    optfun[ik](&o, cint_atm.data(), get_natm(), gc_bas.data(), (int) gc_blocks.size(), cint_env.data());
+    gc_opts->opts[ik]=(void *) o;
+  }
+}
+
+size_t CintEnv::get_Nblock() const {
+  return gc_blocks.size();
+}
+
+const std::vector<size_t> & CintEnv::get_block_shells(size_t ib) const {
+  return gc_blocks[ib].shells;
+}
+
+size_t CintEnv::get_shell_block(size_t ish) const {
+  return shell_block[ish];
+}
+
+size_t CintEnv::get_shell_ctr(size_t ish) const {
+  return shell_ctr[ish];
+}
+
+bool CintEnv::have_gc() const {
+  return gc_blocks.size() != shell_block.size();
+}
+
+int * CintEnv::get_gc_bas() const {
+  return const_cast<int *>(gc_bas.data());
+}
+
+int CintEnv::get_gc_nbas() const {
+  return (int) gc_blocks.size();
+}
+
+void * CintEnv::get_gc_opt(cint_kernel_t kernel) const {
+  return gc_opts ? gc_opts->opts[kernel] : nullptr;
 }
 
 bool CintEnv::is_filled() const {

--- a/src/cintenv.h
+++ b/src/cintenv.h
@@ -138,8 +138,21 @@ class CintEnv {
   /// Are all the normalization factors unity?
   bool unit_norm;
 
+  /// The generally contracted shell table: the shells of a block share
+  /// their primitives, so the integrals over all their contractions
+  /// come out of a single recursion
+  std::vector<int> gc_bas;
+  /// The blocks: which shells each generally contracted shell holds
+  std::vector<shellblock_t> gc_blocks;
+  /// The block each shell belongs to, and its contraction index in it
+  std::vector<size_t> shell_block, shell_ctr;
+  /// Integral optimizers of the generally contracted tables
+  std::shared_ptr<OptSet> gc_opts;
+
   /// Fill the tables from a list of shells
   void build(const std::vector<GaussianShell> & shells, size_t Nsh_orbital, bool build_opts);
+  /// Build the generally contracted shell tables
+  void build_gc(const std::vector<GaussianShell> & shells, bool build_opts);
 
  public:
   /// Dummy constructor
@@ -190,6 +203,26 @@ class CintEnv {
 
   /// Integral optimizer for the given kernel (a libcint CINTOpt *)
   void * get_opt(cint_kernel_t kernel) const;
+
+  // ---- Generally contracted shells ----
+
+  /// Number of generally contracted shells (blocks)
+  size_t get_Nblock() const;
+  /// The shells of block ib
+  const std::vector<size_t> & get_block_shells(size_t ib) const;
+  /// The block shell ish belongs to
+  size_t get_shell_block(size_t ish) const;
+  /// The contraction index of shell ish within its block
+  size_t get_shell_ctr(size_t ish) const;
+  /// Does any block hold more than one shell?
+  bool have_gc() const;
+  /// The generally contracted shell table
+  int * get_gc_bas() const;
+  /// Number of generally contracted shells
+  int get_gc_nbas() const;
+  /// Integral optimizer of the generally contracted tables
+  void * get_gc_opt(cint_kernel_t kernel) const;
+
 };
 
 #endif

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -357,6 +357,28 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
 
   // Remove active column c: move the last active column into slot c
   // (preserving its nvec built components) and drop the active count.
+  // Group the significant shell pairs by the blocks of their shells: the
+  // integrals of a whole block quartet come out of a single recursion,
+  // so the shell pairs of a block pair are evaluated together. A
+  // segmented basis gives one shell pair per group, and the loop below
+  // is the plain one.
+  std::vector<std::vector<size_t>> brapairs;
+  std::vector<std::pair<size_t,size_t>> brablocks;
+  {
+    std::map<std::pair<size_t,size_t>, size_t> bmap;
+    for(size_t ipair=0;ipair<shpairs.size();ipair++) {
+      const std::pair<size_t,size_t> bp(lcenv.get_shell_block(shpairs[ipair].is),
+                                        lcenv.get_shell_block(shpairs[ipair].js));
+      auto it=bmap.find(bp);
+      if(it==bmap.end()) {
+        bmap[bp]=brapairs.size();
+        brapairs.push_back(std::vector<size_t>(1,ipair));
+        brablocks.push_back(bp);
+      } else
+        brapairs[it->second].push_back(ipair);
+    }
+  }
+
   auto drop_col = [&](arma::uword c) {
     const arma::uword last = actprod.size()-1;
     const arma::uword removed = actprod[c];
@@ -388,10 +410,32 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
     size_t max_ls=basis.find_shell_ind(max_l);
     size_t max_Nk=basis.get_Nbf(max_ks);
     size_t max_Nl=basis.get_Nbf(max_ls);
-    size_t max_k0=basis.get_first_ind(max_ks);
-    size_t max_l0=basis.get_first_ind(max_ls);
 
-    arma::mat A(d.n_elem,max_Nk*max_Nl, arma::fill::zeros);
+    // The shell pairs whose integrals come out of the same recursion as
+    // the one holding the pivot: the shells of a generally contracted
+    // block share their primitives, so the products of every
+    // combination of their contractions are candidates at no further
+    // cost. In a segmented basis this is the shell pair itself, and the
+    // sweep below is the one of the paper.
+    const size_t bk=lcenv.get_shell_block(max_ks);
+    const size_t bl=lcenv.get_shell_block(max_ls);
+    std::vector<std::pair<size_t,size_t>> cols;
+    for(auto ks: lcenv.get_block_shells(bk))
+      for(auto ls: lcenv.get_block_shells(bl)) {
+        // The products of (ks, ls) and of (ls, ks) are the same, so
+        // only one orientation is taken
+        if(bk==bl && ls<ks)
+          continue;
+        cols.push_back(std::make_pair(ks,ls));
+      }
+    const size_t ncol=cols.size();
+
+    // Screening bounds of the whole set
+    double Qblk=0.0;
+    for(size_t ic=0;ic<ncol;ic++)
+      Qblk=std::max(Qblk, Q(cols[ic].first,cols[ic].second));
+
+    arma::mat A(d.n_elem,ncol*max_Nk*max_Nl, arma::fill::zeros);
     t.set();
 #ifdef _OPENMP
 #pragma omp parallel
@@ -403,32 +447,77 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
 #ifdef _OPENMP
 #pragma omp for schedule(dynamic,1)
 #endif
-      for(size_t ipair=0;ipair<shpairs.size();ipair++) {
-        size_t is=shpairs[ipair].is;
-        size_t js=shpairs[ipair].js;
-        double QQ=Q(is,js)*Q(max_ks,max_ls);
-        if(QQ<shell_screen_tol) continue;
-        double MM1=M_screen(is,max_ks)*M_screen(js,max_ls);
-        if(MM1<shell_screen_tol) continue;
-        double MM2=M_screen(is,max_ls)*M_screen(js,max_ks);
-        if(MM2<shell_screen_tol) continue;
-
-        eri->compute(is,js,max_ks,max_ls);
-        erip=eri->getp();
-        size_t Ni(shells[is].get_Nbf());
-        size_t Nj(shells[js].get_Nbf());
-        size_t i0(shells[is].get_first_ind());
-        size_t j0(shells[js].get_first_ind());
-        for(size_t ii=0;ii<Ni;ii++)
-          for(size_t jj=0;jj<Nj;jj++) {
-            size_t i=i0+ii;
-            size_t j=j0+jj;
-            if(prodmap(i,j)>Nbf_local*Nbf_local) continue;
-            for(size_t kk=0;kk<max_Nk;kk++)
-              for(size_t ll=0;ll<max_Nl;ll++) {
-                A(prodmap(i,j),kk*max_Nl+ll)=(*erip)[((ii*Nj+jj)*max_Nk+kk)*max_Nl+ll];
-              }
+      for(size_t ibra=0;ibra<brapairs.size();ibra++) {
+        // The shell pairs of this block pair that are significant for
+        // any of the shell pairs the pivot's block holds
+        bool any=false;
+        for(size_t ipi=0;ipi<brapairs[ibra].size() && !any;ipi++) {
+          const size_t is=shpairs[brapairs[ibra][ipi]].is;
+          const size_t js=shpairs[brapairs[ibra][ipi]].js;
+          if(Q(is,js)*Qblk<shell_screen_tol)
+            continue;
+          for(size_t ic=0;ic<ncol && !any;ic++) {
+            const size_t ks=cols[ic].first, ls=cols[ic].second;
+            if(M_screen(is,ks)*M_screen(js,ls)>=shell_screen_tol &&
+               M_screen(is,ls)*M_screen(js,ks)>=shell_screen_tol)
+              any=true;
           }
+        }
+        if(!any) continue;
+
+        // One recursion for the whole block quartet: every combination
+        // of the contractions of the four blocks comes out of it
+        const size_t bi=brablocks[ibra].first;
+        const size_t bj=brablocks[ibra].second;
+        const bool shared =
+          lcenv.get_block_shells(bi).size()*lcenv.get_block_shells(bj).size()*
+          lcenv.get_block_shells(bk).size()*lcenv.get_block_shells(bl).size() > 1;
+        if(shared)
+          eri->compute_block(bi,bj,bk,bl);
+
+        for(size_t ipi=0;ipi<brapairs[ibra].size();ipi++) {
+          const size_t ipair=brapairs[ibra][ipi];
+          const size_t is=shpairs[ipair].is;
+          const size_t js=shpairs[ipair].js;
+          if(Q(is,js)*Qblk<shell_screen_tol)
+            continue;
+
+          const size_t Ni(shells[is].get_Nbf());
+          const size_t Nj(shells[js].get_Nbf());
+          const size_t i0(shells[is].get_first_ind());
+          const size_t j0(shells[js].get_first_ind());
+
+          for(size_t ic=0;ic<ncol;ic++) {
+            const size_t ks=cols[ic].first, ls=cols[ic].second;
+            if(M_screen(is,ks)*M_screen(js,ls)<shell_screen_tol ||
+               M_screen(is,ls)*M_screen(js,ks)<shell_screen_tol)
+              continue;
+
+            if(shared)
+              erip=eri->get_ctr(is,js,ks,ls);
+            else {
+              eri->compute(is,js,ks,ls);
+              erip=eri->getp();
+            }
+
+            const size_t k0(shells[ks].get_first_ind());
+            const size_t l0(shells[ls].get_first_ind());
+            const size_t Nk(shells[ks].get_Nbf());
+            const size_t Nl(shells[ls].get_Nbf());
+            const size_t coff=ic*max_Nk*max_Nl;
+
+            for(size_t ii=0;ii<Ni;ii++)
+              for(size_t jj=0;jj<Nj;jj++) {
+                const size_t i=i0+ii;
+                const size_t j=j0+jj;
+                if(prodmap(i,j)>Nbf_local*Nbf_local) continue;
+                for(size_t kk=0;kk<Nk;kk++)
+                  for(size_t ll=0;ll<Nl;ll++)
+                    A(prodmap(i,j),coff+kk*Nl+ll)=(*erip)[((ii*Nj+jj)*Nk+kk)*Nl+ll];
+              }
+            (void) k0; (void) l0;
+          }
+        }
       }
     }
     t_int+=t.get();
@@ -447,18 +536,27 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
       double blockerr=0;
       arma::uword blockc=SENT;
       size_t Aind=0;
-      for(size_t kk=0;kk<max_Nk;kk++)
-        for(size_t ll=0;ll<max_Nl;ll++) {
-          const size_t ind=prodmap(kk+max_k0,ll+max_l0);
-          if(ind>Nbf_local*Nbf_local) continue;     // not a significant product
-          const arma::uword c=colof(ind);
-          if(c==SENT) continue;                     // already a pivot, or shed
-          if(d(ind)>blockerr) {
-            Aind=kk*max_Nl+ll;
-            blockc=c;
-            blockerr=d(ind);
+      for(size_t ic=0;ic<ncol;ic++) {
+        const size_t ks=cols[ic].first, ls=cols[ic].second;
+        const size_t k0=shells[ks].get_first_ind();
+        const size_t l0=shells[ls].get_first_ind();
+        const size_t Nk=shells[ks].get_Nbf();
+        const size_t Nl=shells[ls].get_Nbf();
+        const size_t coff=ic*max_Nk*max_Nl;
+
+        for(size_t kk=0;kk<Nk;kk++)
+          for(size_t ll=0;ll<Nl;ll++) {
+            const size_t ind=prodmap(kk+k0,ll+l0);
+            if(ind>Nbf_local*Nbf_local) continue;   // not a significant product
+            const arma::uword c=colof(ind);
+            if(c==SENT) continue;                   // already a pivot, or shed
+            if(d(ind)>blockerr) {
+              Aind=coff+kk*Nl+ll;
+              blockc=c;
+              blockerr=d(ind);
+            }
           }
-        }
+      }
       if(blockerr==0.0 || blockerr<shell_reuse_thr*errmax)
         break;
       const arma::uword piv=actprod[blockc];

--- a/src/eriscreen.cpp
+++ b/src/eriscreen.cpp
@@ -22,6 +22,7 @@
 #include "timer.h"
 
 #include <algorithm>
+#include <map>
 #include <cstdio>
 // For exceptions
 #include <sstream>
@@ -129,7 +130,59 @@ size_t ERIscreen::fill(const BasisSet * basisv, double shtol, bool verbose) {
   deri_pool_.clear();
   deri_pool_.resize(nth);
 
+  // Group the shell pairs by the blocks of their shells, so that the
+  // integrals of a generally contracted basis can be evaluated one
+  // block at a time
+  form_blockpairs();
+
   return shpairs.size();
+}
+
+void ERIscreen::form_blockpairs() {
+  blockpairs.clear();
+  blockpair_blocks.clear();
+  blockpair_Q.clear();
+
+  // A basis without generally contracted shells has nothing to gain
+  if(!cenv.have_gc())
+    return;
+
+  // Group the significant shell pairs by the blocks of their shells
+  std::map<std::pair<size_t,size_t>, size_t> map;
+  for(size_t ip=0;ip<shpairs.size();ip++) {
+    const std::pair<size_t,size_t> bp(cenv.get_shell_block(shpairs[ip].is),
+                                      cenv.get_shell_block(shpairs[ip].js));
+    auto it=map.find(bp);
+    if(it==map.end()) {
+      map[bp]=blockpairs.size();
+      blockpairs.push_back(std::vector<size_t>(1,ip));
+      blockpair_blocks.push_back(bp);
+      blockpair_Q.push_back(shpairs[ip].eri);
+    } else {
+      blockpairs[it->second].push_back(ip);
+      blockpair_Q[it->second]=std::max(blockpair_Q[it->second], shpairs[ip].eri);
+    }
+  }
+
+  // Sort the block pairs by their bound, as the shell pairs are sorted:
+  // the loop can then stop as soon as the bound drops below the
+  // threshold
+  std::vector<size_t> idx(blockpairs.size());
+  for(size_t i=0;i<idx.size();i++)
+    idx[i]=i;
+  std::stable_sort(idx.begin(), idx.end(), [&](size_t a, size_t b) { return blockpair_Q[a] > blockpair_Q[b]; });
+
+  std::vector<std::vector<size_t>> sp(blockpairs.size());
+  std::vector<std::pair<size_t,size_t>> sb(blockpairs.size());
+  std::vector<double> sq(blockpairs.size());
+  for(size_t i=0;i<idx.size();i++) {
+    sp[i]=blockpairs[idx[i]];
+    sb[i]=blockpair_blocks[idx[i]];
+    sq[i]=blockpair_Q[idx[i]];
+  }
+  blockpairs=sp;
+  blockpair_blocks=sb;
+  blockpair_Q=sq;
 }
 
 ERIWorker * ERIscreen::acquire_eri(int ith) const {
@@ -192,6 +245,103 @@ void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & diges
 
     // Integral array
     const std::vector<double> * erip;
+
+    // Reused buffer for the quartets of a block pair
+    std::vector<std::pair<size_t,size_t>> quartets;
+
+    // A generally contracted basis is evaluated one block quartet at a
+    // time: the recursion over the primitives is then shared by every
+    // combination of the contractions. The shell pairs are screened one
+    // by one as in the plain loop, so nothing is lost; only the
+    // evaluation is grouped.
+    if(blockpairs.size()) {
+#ifdef _OPENMP
+#pragma omp for schedule(dynamic)
+#endif
+      for(size_t ib=0;ib<blockpairs.size();ib++) {
+	for(size_t jb=0;jb<=ib;jb++) {
+	  // The bound of the block pair is that of its largest shell pair
+	  if(blockpair_Q[ib]*blockpair_Q[jb]<tol)
+	    break;
+	  if(screen_thresh_>0.0 && blockpair_Q[ib]*blockpair_Q[jb]*Dmax<screen_thresh_)
+	    break;
+
+	  // The quartets of this block pair that survive the screening.
+	  // The buffer is reused: nothing is allocated in the hot loop.
+	  quartets.clear();
+	  for(size_t ipi=0;ipi<blockpairs[ib].size();ipi++)
+	    for(size_t jpi=0;jpi<blockpairs[jb].size();jpi++) {
+	      size_t ip=blockpairs[ib][ipi];
+	      size_t jp=blockpairs[jb][jpi];
+	      // Every unordered pair of shell pairs is visited once
+	      if(jp>ip) {
+		if(ib==jb)
+		  continue;
+		std::swap(ip,jp);
+	      }
+
+	      const size_t is=shpairs[ip].is, js=shpairs[ip].js;
+	      const size_t ks=shpairs[jp].is, ls=shpairs[jp].js;
+
+	      const double QQ=Q(is,js)*Q(ks,ls);
+	      if(QQ<tol)
+		continue;
+	      if(screen_thresh_>0.0 && QQ*Dmax<screen_thresh_)
+		continue;
+
+	      const double MM=std::min(M(is,ks)*M(js,ls), M(is,ls)*M(js,ks));
+	      if(MM<tol)
+		continue;
+
+	      if(screen_thresh_>0.0) {
+		double Dq=D(is,js);
+		Dq=std::max(Dq,D(ks,ls));
+		Dq=std::max(Dq,D(is,ks));
+		Dq=std::max(Dq,D(is,ls));
+		Dq=std::max(Dq,D(js,ks));
+		Dq=std::max(Dq,D(js,ls));
+		if(QQ*Dq<screen_thresh_ || MM*Dq<screen_thresh_)
+		  continue;
+	      }
+
+	      quartets.push_back(std::make_pair(ip,jp));
+	    }
+
+	  if(!quartets.size())
+	    continue;
+
+	  const size_t bi=blockpair_blocks[ib].first;
+	  const size_t bj=blockpair_blocks[ib].second;
+	  const size_t bk=blockpair_blocks[jb].first;
+	  const size_t bl=blockpair_blocks[jb].second;
+
+	  // Nothing is shared if every block holds a single shell: the
+	  // quartet is then evaluated as in a segmented basis, and going
+	  // through the block would only add a copy
+	  const bool shared =
+	    cenv.get_block_shells(bi).size()*cenv.get_block_shells(bj).size()*
+	    cenv.get_block_shells(bk).size()*cenv.get_block_shells(bl).size() > 1;
+
+	  if(shared)
+	    // One recursion for every combination of the contractions
+	    eri->compute_block(bi,bj,bk,bl);
+
+	  for(size_t iq=0;iq<quartets.size();iq++) {
+	    const size_t ip=quartets[iq].first;
+	    const size_t jp=quartets[iq].second;
+	    if(shared)
+	      erip=eri->get_ctr(shpairs[ip].is,shpairs[ip].js,shpairs[jp].is,shpairs[jp].js);
+	    else {
+	      eri->compute(shpairs[ip].is,shpairs[ip].js,shpairs[jp].is,shpairs[jp].js);
+	      erip=eri->getp();
+	    }
+	    for(size_t i=0;i<digest[ith].size();i++)
+	      digest[ith][i]->digest(shpairs,ip,jp,*erip,0);
+	  }
+	}
+      }
+
+    } else {
 
 #ifdef _OPENMP
 #pragma omp for schedule(dynamic)
@@ -257,6 +407,7 @@ void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & diges
 	for(size_t i=0;i<digest[ith].size();i++)
 	  digest[ith][i]->digest(shpairs,ip,jp,*erip,0);
       }
+    }
     }
     // eri is owned by eri_pool_ -- do not delete.
   }

--- a/src/eriscreen.h
+++ b/src/eriscreen.h
@@ -55,6 +55,20 @@ class ERIscreen {
   const BasisSet * basp;
   /// libcint description of the basis, shared by the worker pools
   CintEnv cenv;
+
+  /// Shell pairs grouped by the blocks of their shells: the integrals
+  /// over the shell pairs of a block pair come out of a single
+  /// recursion, so they are evaluated together. Empty for a basis
+  /// without generally contracted shells, which then uses the plain
+  /// shell pair loop.
+  std::vector<std::vector<size_t>> blockpairs;
+  /// The blocks of each block pair
+  std::vector<std::pair<size_t,size_t>> blockpair_blocks;
+  /// The largest Schwarz bound of the shell pairs of each block pair
+  std::vector<double> blockpair_Q;
+
+  /// Group the shell pairs into block pairs, sorted by their bound
+  void form_blockpairs();
   /// Index helper
   std::vector<size_t> iidx;
 

--- a/src/eriworker.cpp
+++ b/src/eriworker.cpp
@@ -283,6 +283,117 @@ void ERIWorker::compute_2c(size_t is, size_t js) {
   normalize(erk,2,1,ints);
 }
 
+void ERIWorker::compute_block(size_t bi, size_t bj, size_t bk, size_t bl) {
+  // libcint gives the integrals over all the contractions of the blocks
+  // in one call: the recursion over the primitives is shared, and only
+  // the contraction step is repeated. As for a single shell, the
+  // reversed quartet gives ERKALE's index order.
+  int shls[4]={(int) bl, (int) bk, (int) bj, (int) bi};
+
+  CINTIntegralFunction * intor=envp->lm_in_use() ? int2e_sph : int2e_cart;
+  CINTOpt * opt=(CINTOpt *) envp->get_gc_opt(CINT_ERI);
+
+  block[0]=bi;
+  block[1]=bj;
+  block[2]=bk;
+  block[3]=bl;
+
+  size_t N=1;
+  for(int q=0;q<4;q++) {
+    const std::vector<size_t> & bsh=envp->get_block_shells(block[q]);
+    // Every shell of a block has the same number of functions
+    block_nctr[q]=bsh.size();
+    block_nbf[q]=envp->get_Nbf(bsh[0]);
+    N*=block_nctr[q]*block_nbf[q];
+  }
+  blockints.resize(N);
+
+  auto evaluate_omega=[&](double omega, std::vector<double> & buf) {
+    env[PTR_RANGE_OMEGA]=omega;
+    const size_t csize=intor(NULL,NULL,shls,envp->get_atm(),envp->get_natm(),envp->get_gc_bas(),envp->get_gc_nbas(),env.data(),NULL,NULL);
+    if(csize>cache.size())
+      cache.resize(csize);
+    if(!intor(buf.data(),NULL,shls,envp->get_atm(),envp->get_natm(),envp->get_gc_bas(),envp->get_gc_nbas(),env.data(),(omega==0.0)?opt:NULL,cache.data()))
+      std::fill(buf.begin(),buf.end(),0.0);
+  };
+
+  if(rs_alpha!=0.0)
+    evaluate_omega(0.0,blockints);
+  else
+    std::fill(blockints.begin(),blockints.end(),0.0);
+
+  if(rs_beta!=0.0) {
+    srbuf.resize(N);
+    evaluate_omega(-rs_omega,srbuf);
+    for(size_t i=0;i<N;i++)
+      blockints[i]=rs_alpha*blockints[i]+rs_beta*srbuf[i];
+  } else if(rs_alpha!=1.0)
+    for(size_t i=0;i<N;i++)
+      blockints[i]*=rs_alpha;
+}
+
+const std::vector<double> * ERIWorker::get_ctr(size_t is, size_t js, size_t ks, size_t ls) {
+  size_t sh[4]={is, js, ks, ls};
+
+  // (ij|kl) = (kl|ij), so a quartet whose bra and ket sit in the ket
+  // and the bra block of the evaluated quartet is served from the same
+  // buffer, with the two halves of the index swapped.
+  bool swapped=false;
+  if(envp->get_shell_block(is) != block[0] || envp->get_shell_block(js) != block[1] ||
+     envp->get_shell_block(ks) != block[2] || envp->get_shell_block(ls) != block[3]) {
+    if(envp->get_shell_block(is) == block[2] && envp->get_shell_block(js) == block[3] &&
+       envp->get_shell_block(ks) == block[0] && envp->get_shell_block(ls) == block[1]) {
+      swapped=true;
+      sh[0]=ks;
+      sh[1]=ls;
+      sh[2]=is;
+      sh[3]=js;
+    } else {
+      ERROR_INFO();
+      throw std::logic_error("The shell does not belong to the evaluated block!\n");
+    }
+  }
+
+  // The contraction each shell is in its block, and the sizes. In the
+  // output of a generally contracted shell the contraction runs slower
+  // than the functions of the shell.
+  size_t ctr[4], nbf[4], nctr[4];
+  for(int q=0;q<4;q++) {
+    ctr[q]=envp->get_shell_ctr(sh[q]);
+    nbf[q]=block_nbf[q];
+    nctr[q]=block_nctr[q];
+  }
+
+  const size_t N=nbf[0]*nbf[1]*nbf[2]*nbf[3];
+  ints.resize(N);
+
+  // The index of a function in the block runs over the contraction and
+  // the functions of the shell; the quartet index runs over the four
+  // shells with the last one fastest, as everywhere in ERKALE. A
+  // swapped quartet is written out with its bra and ket exchanged.
+  for(size_t i=0;i<nbf[0];i++) {
+    const size_t bi=(ctr[0]*nbf[0]+i)*nctr[1]*nbf[1];
+    for(size_t j=0;j<nbf[1];j++) {
+      const size_t bj=(bi+ctr[1]*nbf[1]+j)*nctr[2]*nbf[2];
+      for(size_t k=0;k<nbf[2];k++) {
+        const size_t bk=(bj+ctr[2]*nbf[2]+k)*nctr[3]*nbf[3];
+        for(size_t l=0;l<nbf[3];l++) {
+          const double val=blockints[bk+ctr[3]*nbf[3]+l];
+          if(swapped)
+            ints[((k*nbf[3]+l)*nbf[0]+i)*nbf[1]+j]=val;
+          else
+            ints[((i*nbf[1]+j)*nbf[2]+k)*nbf[3]+l]=val;
+        }
+      }
+    }
+  }
+
+  const size_t erk[4]={is, js, ks, ls};
+  normalize(erk,4,1,ints);
+
+  return &ints;
+}
+
 void ERIWorker::compute_debug(size_t is, size_t js, size_t ks, size_t ls) {
   const GaussianShell & shi=envp->get_shell(is);
   const GaussianShell & shj=envp->get_shell(js);

--- a/src/eriworker.h
+++ b/src/eriworker.h
@@ -98,6 +98,11 @@ class IntegralWorker {
 
 /// Worker for computing electron repulsion integrals
 class ERIWorker: public IntegralWorker {
+  /// Integrals over a quartet of generally contracted shells
+  std::vector<double> blockints;
+  /// The evaluated blocks, and their contraction and function counts
+  size_t block[4], block_nctr[4], block_nbf[4];
+
  public:
   /// Constructor
   ERIWorker(const CintEnv & env, double omega=0.0, double alpha=1.0, double beta=0.0);
@@ -114,6 +119,16 @@ class ERIWorker: public IntegralWorker {
   /// Compute the four-center integrals with the in-house Huzinaga
   /// routines: the independent reference used by integraltest
   void compute_debug(size_t is, size_t js, size_t ks, size_t ls);
+
+  /// Compute the four-center integrals over a quartet of generally
+  /// contracted shells: the integrals over every combination of their
+  /// contractions come out of a single recursion. The combinations are
+  /// then handed out one at a time by get_ctr.
+  void compute_block(size_t bi, size_t bj, size_t bk, size_t bl);
+  /// Get the integrals of one combination of contractions of the block
+  /// evaluated by compute_block. The shells are given by their index in
+  /// the basis, and have to belong to the blocks that were evaluated.
+  const std::vector<double> * get_ctr(size_t is, size_t js, size_t ks, size_t ls);
 
   /// Get the integrals
   std::vector<double> get() const;


### PR DESCRIPTION
The shells a basis set library splits out of a generally contracted shell — same center, same angular momentum, **same primitives**, different contraction coefficients — have their integrals in a *single* recursion: libcint contracts each primitive quartet into every combination of the contractions at once. ERKALE evaluated them one at a time, repeating the recursion for every combination.

## What this does

Shells are grouped into blocks by their primitives. `CintEnv` carries a second shell table in which a block is one shell with several contractions; `ERIWorker::compute_block` evaluates a quartet of blocks and `get_ctr` serves the combinations from the same buffer, in ERKALE's index order — including for a quartet whose bra and ket are the evaluated quartet's the other way round, since (ij|kl) = (kl|ij). The J/K driver and the two-step Cholesky pivot selection iterate block quartets.

**Screening is unchanged** — every shell pair is still screened individually, so nothing previously computed is skipped and nothing previously skipped is computed. Quartets whose blocks all hold a single shell take the plain path, so a **segmented basis is bit-for-bit as before**, and buffers are reused (nothing allocated in the loops).

## The Cholesky decomposition gains the most

The pivot selection amortizes a shell pair's integrals by taking every pivot whose residual is within a factor σ (`shell_reuse_thr`) of the largest anywhere. The block quartet widens the pool the recursion has *already paid for*: from the functions of one shell pair to those of every combination of the contractions. Pivots are still chosen by residual, so **the auxiliary basis does not grow — only the pool it is chosen from**.

⚠️ This changes *which* pivots are selected, so **Cholesky energies move within the decomposition's own threshold** (1e-7; e.g. cc-pVTZ water −76.05712747 → −76.05712737). Everything else is unchanged to the last digit. Well inside `chkcompare`'s 1e-5 / 1e-6 tolerances.

A subtlety worth recording: **both sides of the quartet must be grouped.** libcint returns every combination of all four blocks, so consuming one bra combination throws the rest of the recursion away — grouping only the ket made the decomposition *slower*.

## Results (Hartree–Fock on water, one thread)

| basis | four-index | Cholesky |
|---|---|---|
| def2-TZVP | unchanged | unchanged (no shared primitives) |
| cc-pVDZ | 1.25× | — |
| cc-pVTZ | 1.12× | **1.40×** |
| **ANO-RCC (H₂)** | **8.3×** (133 s → 16 s) | 1.25× |

The gain follows the basis: correlation-consistent sets share one block of primitives, segmented sets (def2, Pople) share none, and ANO sets share nearly everything — ANO-RCC carbon is 24 shells of 204 primitives that are really **5 blocks of 32**. This makes ANO-class basis sets practical in ERKALE.

**187/187 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)