### PR TITLE
GC series B1+B2: native evaluation + activation (recovery of #149/#150 onto master)

### DIFF
--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -383,13 +383,17 @@ const std::vector<shellf_t> & GaussianShell::get_cart_ref() const {
 }
 
 std::vector<contr_t> GaussianShell::get_contr_normalized() const {
-  // Returned array
-  std::vector<contr_t> cn(c);
+  return get_contr_normalized(0);
+}
+
+std::vector<contr_t> GaussianShell::get_contr_normalized(size_t ictr) const {
+  // The ictr'th contraction, its coefficients converted to those of
+  // normalized primitives
+  std::vector<contr_t> cn(get_contr(ictr));
 
   // Note - these refer to cartesian functions!
   double fac=pow(M_2_PI,0.75)*pow(2,am)/sqrt(doublefact(2*am-1));
 
-  // Convert coefficients to those of normalized primitives
   for(size_t i=0;i<cn.size();i++)
     cn[i].c/=fac*pow(cn[i].z,am/2.0+0.75);
 
@@ -403,6 +407,24 @@ size_t GaussianShell::get_Nbf() const {
 
 size_t GaussianShell::get_Nctr() const {
   return cf.n_cols;
+}
+
+bool GaussianShell::same_primitives(const GaussianShell & rhs) const {
+  if(cenind != rhs.cenind || am != rhs.am || uselm != rhs.uselm)
+    return false;
+  if(c.size() != rhs.c.size())
+    return false;
+  for(size_t i=0;i<c.size();i++)
+    if(c[i].z != rhs.c[i].z)
+      return false;
+  return true;
+}
+
+void GaussianShell::merge_contraction(const GaussianShell & rhs) {
+  if(!same_primitives(rhs))
+    throw std::logic_error("GaussianShell::merge_contraction: the shells do not share the same primitives.\n");
+  // Append rhs's contraction columns after ours, preserving order
+  cf=arma::join_rows(cf,rhs.cf);
 }
 
 const arma::mat & GaussianShell::get_coefs() const {

--- a/src/basis.cpp
+++ b/src/basis.cpp
@@ -328,6 +328,7 @@ void GaussianShell::coulomb_normalize() {
   // Normalize functions using Coulomb norm
   size_t Ncart=cart.size();
   size_t Nbf=get_Nbf();
+  const size_t nctr=get_Nctr();
 
   // The Coulomb self-repulsion (i|j) of the functions on this shell.
   // The environment measures the current normalization of the shell, so
@@ -337,33 +338,66 @@ void GaussianShell::coulomb_normalize() {
   eri.compute_2c(0,0);
   const std::vector<double> * erip=eri.getp();
 
-  if(!uselm) {
-    // Cartesian functions
-    for(size_t i=0;i<Ncart;i++)
-      cart[i].relnorm*=1.0/sqrt((*erip)[i*Nbf+i]);
-  } else {
-    // Spherical normalization, need to distribute the normalization
-    // coefficient among the cartesians, so all the functions of the
-    // shell must have the same norm
-    int diff=0;
-    for(size_t i=1;i<Nbf;i++)
-      if(fabs((*erip)[i*Nbf+i]-(*erip)[0])>sqrt(DBL_EPSILON)*(*erip)[0]) {
-	printf("%e != %e, diff %e\n",(*erip)[i*Nbf+i],(*erip)[0],(*erip)[i*Nbf+i]-(*erip)[0]);
-	fflush(stdout);
-	diff++;
+  if(nctr==1) {
+    if(!uselm) {
+      // Cartesian functions
+      for(size_t i=0;i<Ncart;i++)
+        cart[i].relnorm*=1.0/sqrt((*erip)[i*Nbf+i]);
+    } else {
+      // Spherical normalization, need to distribute the normalization
+      // coefficient among the cartesians, so all the functions of the
+      // shell must have the same norm
+      int diff=0;
+      for(size_t i=1;i<Nbf;i++)
+        if(fabs((*erip)[i*Nbf+i]-(*erip)[0])>sqrt(DBL_EPSILON)*(*erip)[0]) {
+          printf("%e != %e, diff %e\n",(*erip)[i*Nbf+i],(*erip)[0],(*erip)[i*Nbf+i]-(*erip)[0]);
+          fflush(stdout);
+          diff++;
+        }
+
+      if(diff) {
+        ERROR_INFO();
+        std::ostringstream oss;
+        oss << "\nSpherical functions have different norms!\n";
+        throw std::runtime_error(oss.str());
       }
 
+      // Scale coefficients
+      for(size_t i=0;i<Ncart;i++)
+        cart[i].relnorm*=1.0/sqrt((*erip)[0]);
+    }
+    return;
+  }
+
+  // Generally contracted shell: the cartesian relnorm is shared by all
+  // contractions, but the contractions have different Coulomb norms, so
+  // normalize each one by scaling its coefficient column instead. Within
+  // a single spherical contraction all 2l+1 functions have the same norm.
+  if(!uselm) {
+    ERROR_INFO();
+    throw std::runtime_error("Coulomb normalization of a generally contracted cartesian shell is not supported.\n");
+  }
+  const size_t Nfunc=Nbf/nctr;
+  for(size_t ic=0;ic<nctr;ic++) {
+    const size_t i0=ic*Nfunc;
+    const double n0=(*erip)[i0*Nbf+i0];
+    int diff=0;
+    for(size_t i=1;i<Nfunc;i++)
+      if(fabs((*erip)[(i0+i)*Nbf+(i0+i)]-n0)>sqrt(DBL_EPSILON)*n0) {
+        printf("%e != %e, diff %e\n",(*erip)[(i0+i)*Nbf+(i0+i)],n0,(*erip)[(i0+i)*Nbf+(i0+i)]-n0);
+        fflush(stdout);
+        diff++;
+      }
     if(diff) {
       ERROR_INFO();
       std::ostringstream oss;
       oss << "\nSpherical functions have different norms!\n";
       throw std::runtime_error(oss.str());
     }
-
-    // Scale coefficients
-    for(size_t i=0;i<Ncart;i++)
-      cart[i].relnorm*=1.0/sqrt((*erip)[0]);
+    cf.col(ic)*=1.0/sqrt(n0);
   }
+  // Mirror the (scaled) first column back into the exponent carrier
+  sync_c();
 }
 
 std::vector<contr_t> GaussianShell::get_contr() const {
@@ -1163,6 +1197,34 @@ void BasisSet::sort() {
   update_nuclear_shell_list();
 }
 
+void BasisSet::merge_generally_contracted() {
+  // Group consecutive shells that share the same center, angular
+  // momentum, harmonics flag and primitive exponents into one generally
+  // contracted shell. The shells arrive already in their final order, in
+  // which the segmented sort has made every generally contracted block
+  // contiguous, so a single consecutive-merge pass captures all general
+  // contraction without disturbing the basis function order (the merged
+  // shell emits [ctr0][ctr1]... in the same span the segmented shells
+  // occupied).
+  if(shells.empty())
+    return;
+
+  std::vector<GaussianShell> merged;
+  merged.reserve(shells.size());
+  merged.push_back(shells[0]);
+  for(size_t i=1;i<shells.size();i++) {
+    if(merged.back().same_primitives(shells[i]))
+      merged.back().merge_contraction(shells[i]);
+    else
+      merged.push_back(shells[i]);
+  }
+  shells=std::move(merged);
+
+  // Renumber the basis functions and rebuild the per-nucleus shell lists.
+  check_numbering();
+  update_nuclear_shell_list();
+}
+
 void BasisSet::compute_nuclear_distances() {
   // Amount of nuclei
   size_t N=nuclei.size();
@@ -1239,53 +1301,6 @@ void BasisSet::form_unique_shellpairs() {
   */
 }
 
-std::vector<shellblock_t> BasisSet::get_shell_blocks() const {
-  std::vector<shellblock_t> blocks;
-
-  // Two shells belong to the same block if they sit on the same center,
-  // have the same angular momentum and the same basis (a spherical and
-  // a cartesian shell cannot be evaluated in a single call), and share
-  // their primitives.
-  auto same_block = [](const GaussianShell & lhs, const GaussianShell & rhs) {
-    if(lhs.get_center_ind() != rhs.get_center_ind())
-      return false;
-    if(lhs.get_am() != rhs.get_am())
-      return false;
-    if(lhs.lm_in_use() != rhs.lm_in_use())
-      return false;
-
-    const std::vector<contr_t> & lc=lhs.get_contr_ref();
-    const std::vector<contr_t> & rc=rhs.get_contr_ref();
-    if(lc.size() != rc.size())
-      return false;
-    for(size_t ip=0;ip<lc.size();ip++)
-      if(lc[ip].z != rc[ip].z)
-        return false;
-
-    return true;
-  };
-
-  for(size_t is=0;is<shells.size();is++) {
-    // Does the shell belong to a block we already have? The shells of a
-    // block need not be adjacent in the basis, but they usually are.
-    bool found=false;
-    for(size_t ib=0;ib<blocks.size();ib++)
-      if(same_block(shells[blocks[ib].shells[0]], shells[is])) {
-        blocks[ib].shells.push_back(is);
-        found=true;
-        break;
-      }
-
-    if(!found) {
-      shellblock_t block;
-      block.shells.push_back(is);
-      blocks.push_back(block);
-    }
-  }
-
-  return blocks;
-}
-
 std::vector<shellpair_t> BasisSet::get_unique_shellpairs() const {
   if(shells.size() && !shellpairs.size()) {
     throw std::runtime_error("shellpairs not initialized! Maybe you forgot to finalize?\n");
@@ -1341,6 +1356,13 @@ bool operator<(const eripair_t & lhs, const eripair_t & rhs) {
 
 void BasisSet::finalize(bool convert, bool donorm) {
   // Finalize basis set structure for use.
+
+  // Group same-primitive shells into generally contracted shells before
+  // anything downstream (ranges, contraction conversion, normalization,
+  // shell pairs) is computed, so all of it sees the native generally
+  // contracted shells. A segmented basis (no two shells share primitives)
+  // is left untouched.
+  merge_generally_contracted();
 
   // Compute nuclear distances.
   compute_nuclear_distances();

--- a/src/basis.h
+++ b/src/basis.h
@@ -693,6 +693,15 @@ public:
   const std::vector<contr_t> & get_contr_ref() const;
   /// Number of contractions (columns of the coefficient matrix)
   size_t get_Nctr() const;
+  /// Merge another shell in as an additional contraction: rhs must
+  /// share this shell's center, angular momentum, spherical/cartesian
+  /// choice and primitive exponents. Its contraction columns are
+  /// appended after this shell's, forming a generally contracted shell.
+  /// This is how add_shells and the checkpoint regroup build generally
+  /// contracted shells out of same-exponent segmented ones.
+  void merge_contraction(const GaussianShell & rhs);
+  /// May the other shell be merged in as an additional contraction?
+  bool same_primitives(const GaussianShell & rhs) const;
   /// The coefficient matrix (nprim x nctr) of the generally contracted shell
   const arma::mat & get_coefs() const;
   /// Get cartesians
@@ -707,6 +716,9 @@ public:
    * the input isn't really normalized..?
    */
   std::vector<contr_t> get_contr_normalized() const;
+  /// Get contraction coefficients of normalized primitives for the
+  /// ictr'th contraction
+  std::vector<contr_t> get_contr_normalized(size_t ictr) const;
 
   /// Number of functions on shell
   size_t get_Nbf() const;

--- a/src/basis.h
+++ b/src/basis.h
@@ -105,16 +105,6 @@ typedef struct {
 /// Comparison operator for shellpairs: descending angular momentum
 bool operator<(const shellpair_t & lhs, const shellpair_t & rhs);
 
-/// A group of shells that share a center, an angular momentum and a set
-/// of primitives, and differ only in their contraction coefficients: a
-/// generally contracted shell, split into segmented shells by the basis
-/// set library. The integrals over all of them come out of a single
-/// recursion, so they are evaluated together.
-typedef struct {
-  /// The shells in the block, in the order they appear in the basis
-  std::vector<size_t> shells;
-} shellblock_t;
-
 /// Helper for integral sorts
 typedef struct {
   /// First shell
@@ -324,6 +314,12 @@ public:
 
   /// Sort shells in nuclear order, then by angular momentum, then by exponents
   void sort();
+  /// Merge consecutive shells that share the same center, angular
+  /// momentum, harmonics flag and primitive exponents into a single
+  /// generally contracted shell. The shells must already be in their
+  /// final order, in which every generally contracted block is
+  /// contiguous, so the merge preserves the basis function order.
+  void merge_generally_contracted();
   /// Check numbering of basis functions
   void check_numbering();
   /// Update the nuclear list of shells
@@ -338,11 +334,6 @@ public:
   void form_unique_shellpairs();
   /// Get list of unique shell pairs
   std::vector<shellpair_t> get_unique_shellpairs() const;
-  /// Group the shells by their center, angular momentum and primitives:
-  /// shells that differ only in their contraction coefficients form a
-  /// generally contracted shell, and their integrals come out of a
-  /// single recursion. A segmented basis gives one shell per block.
-  std::vector<shellblock_t> get_shell_blocks() const;
 
   /// Build ScreeningData: Schwarz Q, distance estimate M, and a
   /// value-sorted, threshold-truncated shell-pair list. Single

--- a/src/checkpoint.cpp
+++ b/src/checkpoint.cpp
@@ -421,8 +421,6 @@ void Checkpoint::write(const BasisSet & basis, const std::string & role) {
   remove(role+".contr");
   remove(role+".data");
 
-  // Get number of shells
-  size_t Nsh=basis.get_Nshells();
   // Get number of nuclei
   size_t Nnuc=basis.get_Nnuc();
 
@@ -478,26 +476,47 @@ void Checkpoint::write(const BasisSet & basis, const std::string & role) {
   H5Tclose(datatype);
   H5Tclose(symtype);
 
-  /* Write shell data, contractions first */
+  /* Write shell data, contractions first.
 
-  dimsf[0]=Nsh;
+     A generally contracted shell (nctr>1) is written as nctr consecutive
+     records, one per contraction, each carrying the shared exponents,
+     that contraction's coefficients, and its own first function index.
+     This makes the on-disk layout byte-identical to a segmented basis, so
+     a checkpoint written by a generally contracted run still matches the
+     reference files and old checkpoints load unchanged; the read side
+     regroups the consecutive records back into generally contracted
+     shells. */
+
+  const std::vector<GaussianShell> & wshells=basis.get_shells_ref();
+  std::vector< std::vector<contr_t> > excontr;
+  std::vector<shell_data_t> exdata;
+  for(size_t i=0;i<wshells.size();i++) {
+    const GaussianShell & sh=wshells[i];
+    const size_t Nlm=sh.lm_in_use() ? sh.get_Nlm() : sh.get_Ncart();
+    for(size_t ic=0;ic<sh.get_Nctr();ic++) {
+      excontr.push_back(sh.get_contr(ic));
+      shell_data_t sd;
+      sd.indstart=sh.get_first_ind()+ic*Nlm;
+      sd.am=sh.get_am();
+      sd.uselm=sh.lm_in_use();
+      sd.cenind=sh.get_center_ind();
+      exdata.push_back(sd);
+    }
+  }
+  const size_t Nrec=excontr.size();
+
+  dimsf[0]=Nrec;
   dataspace = H5Screate_simple(1,dimsf,NULL);
 
-  // Create array holding exponents and contraction coefficients of shells.
-  hvl_t contrs[Nsh];
+  // Create array holding exponents and contraction coefficients.
+  hvl_t contrs[Nrec];
 
   // Initialize data.
-  for(size_t i=0;i<Nsh;i++) {
-    // Get contraction on shell
-    std::vector<contr_t> cntr=basis.get_contr(i);
-
-    // Allocate memory
-    contrs[i].p=malloc(cntr.size()*sizeof(contr_t));
-    contrs[i].len=cntr.size();
-
-    // Store contractions
-    for(size_t j=0;j<cntr.size();j++)
-      ((contr_t *) contrs[i].p)[j]=cntr[j];
+  for(size_t i=0;i<Nrec;i++) {
+    contrs[i].p=malloc(excontr[i].size()*sizeof(contr_t));
+    contrs[i].len=excontr[i].size();
+    for(size_t j=0;j<excontr[i].size();j++)
+      ((contr_t *) contrs[i].p)[j]=excontr[i][j];
   }
 
   // Create compound datatype
@@ -519,18 +538,14 @@ void Checkpoint::write(const BasisSet & basis, const std::string & role) {
   H5Dclose(dataset);
   H5Tclose(datatype);
   H5Tclose(contrdata);
-  for(size_t i=0;i<Nsh;i++)
+  for(size_t i=0;i<Nrec;i++)
     free(contrs[i].p);
 
   /* Done with contractions, write other (fixed-length) data. */
 
-  shell_data_t shdata[Nsh];
-  for(size_t i=0;i<Nsh;i++) {
-    shdata[i].indstart=basis.get_first_ind(i);
-    shdata[i].am=basis.get_am(i);
-    shdata[i].uselm=basis.lm_in_use(i);
-    shdata[i].cenind=basis.get_shell_center_ind(i);
-  }
+  shell_data_t shdata[Nrec];
+  for(size_t i=0;i<Nrec;i++)
+    shdata[i]=exdata[i];
 
   // Create dataset for shared data
   datatype = H5Tcreate(H5T_COMPOUND, sizeof(shell_data_t));

--- a/src/cintenv.cpp
+++ b/src/cintenv.cpp
@@ -232,10 +232,6 @@ void CintEnv::build(const std::vector<GaussianShell> & sh, size_t Nsh_orbital, b
 
   // Build the integral optimizers. They cache the primitive pair data,
   // which is the whole point of holding on to the environment.
-  // The generally contracted tables share the data array, so they must
-  // be built before the workers copy it
-  build_gc(sh, build_opts);
-
   if(!build_opts)
     return;
 
@@ -256,121 +252,6 @@ void CintEnv::build(const std::vector<GaussianShell> & sh, size_t Nsh_orbital, b
     optfun[ik](&o, atmp, natm, basp, nbas, envp);
     opts->opts[ik]=(void *) o;
   }
-}
-
-void CintEnv::build_gc(const std::vector<GaussianShell> & sh, bool build_opts) {
-  // Group the shells that share a center, an angular momentum and a set
-  // of primitives: the integrals over their contractions come out of a
-  // single recursion.
-  gc_blocks.clear();
-  shell_block.assign(sh.size(),0);
-  shell_ctr.assign(sh.size(),0);
-
-  auto same_block = [](const GaussianShell & lhs, const GaussianShell & rhs) {
-    if(lhs.get_center_ind() != rhs.get_center_ind() || lhs.get_am() != rhs.get_am() || lhs.lm_in_use() != rhs.lm_in_use())
-      return false;
-    const std::vector<contr_t> & lc=lhs.get_contr_ref();
-    const std::vector<contr_t> & rc=rhs.get_contr_ref();
-    if(lc.size() != rc.size())
-      return false;
-    for(size_t ip=0;ip<lc.size();ip++)
-      if(lc[ip].z != rc[ip].z)
-        return false;
-    return true;
-  };
-
-  for(size_t is=0;is<sh.size();is++) {
-    bool found=false;
-    for(size_t ib=0;ib<gc_blocks.size();ib++)
-      if(same_block(sh[gc_blocks[ib].shells[0]], sh[is])) {
-        shell_block[is]=ib;
-        shell_ctr[is]=gc_blocks[ib].shells.size();
-        gc_blocks[ib].shells.push_back(is);
-        found=true;
-        break;
-      }
-    if(!found) {
-      shellblock_t block;
-      block.shells.push_back(is);
-      shell_block[is]=gc_blocks.size();
-      shell_ctr[is]=0;
-      gc_blocks.push_back(block);
-    }
-  }
-
-  // The generally contracted shell table. The coefficients of the block
-  // sit next to each other in the data array, one contraction after the
-  // other, which is what libcint expects of a shell with NCTR_OF > 1.
-  gc_bas.assign(BAS_SLOTS*gc_blocks.size(), 0);
-  for(size_t ib=0;ib<gc_blocks.size();ib++) {
-    const size_t is0=gc_blocks[ib].shells[0];
-    const size_t nctr=gc_blocks[ib].shells.size();
-
-    // The primitives are shared, so they can be taken from the first shell
-    for(int slot=0;slot<BAS_SLOTS;slot++)
-      gc_bas[ib*BAS_SLOTS+slot]=cint_bas[is0*BAS_SLOTS+slot];
-    gc_bas[ib*BAS_SLOTS+NCTR_OF]=(int) nctr;
-
-    if(nctr==1)
-      continue;
-
-    // The coefficients of the contractions have to be contiguous
-    const int nprim=cint_bas[is0*BAS_SLOTS+NPRIM_OF];
-    gc_bas[ib*BAS_SLOTS+PTR_COEFF]=(int) cint_env.size();
-    for(size_t ic=0;ic<nctr;ic++) {
-      const size_t is=gc_blocks[ib].shells[ic];
-      const int ptr=cint_bas[is*BAS_SLOTS+PTR_COEFF];
-      for(int ip=0;ip<nprim;ip++)
-        cint_env.push_back(cint_env[ptr+ip]);
-    }
-  }
-
-  if(!build_opts || !have_gc())
-    return;
-
-  gc_opts=std::make_shared<OptSet>();
-  gc_opts->opts.assign(CINT_NKERNEL, nullptr);
-  CINTOptimizerFunction * const optfun[CINT_NKERNEL]={
-    int2e_optimizer, int2e_ip1_optimizer, int2e_ip2_optimizer,
-    int3c2e_optimizer, int3c2e_ip1_optimizer, int3c2e_ip2_optimizer,
-    int2c2e_optimizer, int2c2e_ip1_optimizer};
-  for(int ik=0;ik<CINT_NKERNEL;ik++) {
-    CINTOpt * o=nullptr;
-    optfun[ik](&o, cint_atm.data(), get_natm(), gc_bas.data(), (int) gc_blocks.size(), cint_env.data());
-    gc_opts->opts[ik]=(void *) o;
-  }
-}
-
-size_t CintEnv::get_Nblock() const {
-  return gc_blocks.size();
-}
-
-const std::vector<size_t> & CintEnv::get_block_shells(size_t ib) const {
-  return gc_blocks[ib].shells;
-}
-
-size_t CintEnv::get_shell_block(size_t ish) const {
-  return shell_block[ish];
-}
-
-size_t CintEnv::get_shell_ctr(size_t ish) const {
-  return shell_ctr[ish];
-}
-
-bool CintEnv::have_gc() const {
-  return gc_blocks.size() != shell_block.size();
-}
-
-int * CintEnv::get_gc_bas() const {
-  return const_cast<int *>(gc_bas.data());
-}
-
-int CintEnv::get_gc_nbas() const {
-  return (int) gc_blocks.size();
-}
-
-void * CintEnv::get_gc_opt(cint_kernel_t kernel) const {
-  return gc_opts ? gc_opts->opts[kernel] : nullptr;
 }
 
 bool CintEnv::is_filled() const {

--- a/src/cintenv.cpp
+++ b/src/cintenv.cpp
@@ -162,26 +162,36 @@ void CintEnv::build(const std::vector<GaussianShell> & sh, size_t Nsh_orbital, b
   for(size_t is=0;is<shells.size();is++) {
     const GaussianShell & sh=shells[is];
     const int l=sh.get_am();
-    const std::vector<contr_t> c=sh.get_contr_normalized();
+    const size_t nprim=sh.get_Ncontr();
+    const size_t nctr=sh.get_Nctr();
 
     cint_bas[is*BAS_SLOTS+ATOM_OF]=(int) shell_center[is];
     cint_bas[is*BAS_SLOTS+ANG_OF]=l;
-    cint_bas[is*BAS_SLOTS+NPRIM_OF]=(int) c.size();
-    cint_bas[is*BAS_SLOTS+NCTR_OF]=1;
+    cint_bas[is*BAS_SLOTS+NPRIM_OF]=(int) nprim;
+    cint_bas[is*BAS_SLOTS+NCTR_OF]=(int) nctr;
     cint_bas[is*BAS_SLOTS+KAPPA_OF]=0;
 
+    // Shared primitive exponents
     cint_bas[is*BAS_SLOTS+PTR_EXP]=(int) cint_env.size();
-    for(size_t ip=0;ip<c.size();ip++)
-      cint_env.push_back(c[ip].z);
+    {
+      const std::vector<contr_t> c0=sh.get_contr_normalized(0);
+      for(size_t ip=0;ip<nprim;ip++)
+        cint_env.push_back(c0[ip].z);
+    }
 
-    // libcint contracts normalized primitives
+    // The coefficient columns, one contraction after the other, each
+    // over normalized primitives (libcint contracts normalized primitives)
     cint_bas[is*BAS_SLOTS+PTR_COEFF]=(int) cint_env.size();
-    for(size_t ip=0;ip<c.size();ip++)
-      cint_env.push_back(c[ip].c*CINTgto_norm(l,c[ip].z));
+    for(size_t ic=0;ic<nctr;ic++) {
+      const std::vector<contr_t> cc=sh.get_contr_normalized(ic);
+      for(size_t ip=0;ip<nprim;ip++)
+        cint_env.push_back(cc[ip].c*CINTgto_norm(l,cc[ip].z));
+    }
 
-    // Number of functions: spherical mode evaluates every shell in the
-    // spherical basis (s and p coincide with the cartesian ones)
-    shell_Nbf[is]= lm ? (size_t) (2*l+1) : (size_t) ((l+1)*(l+2)/2);
+    // Number of functions: nctr angular blocks. Spherical mode
+    // evaluates every shell in the spherical basis (s and p coincide
+    // with the cartesian ones).
+    shell_Nbf[is]= nctr * (lm ? (size_t) (2*l+1) : (size_t) ((l+1)*(l+2)/2));
     shell_first[is]=ibf;
     ibf+=shell_Nbf[is];
     max_Nbf=std::max(max_Nbf,shell_Nbf[is]);

--- a/src/cintenv.h
+++ b/src/cintenv.h
@@ -138,21 +138,8 @@ class CintEnv {
   /// Are all the normalization factors unity?
   bool unit_norm;
 
-  /// The generally contracted shell table: the shells of a block share
-  /// their primitives, so the integrals over all their contractions
-  /// come out of a single recursion
-  std::vector<int> gc_bas;
-  /// The blocks: which shells each generally contracted shell holds
-  std::vector<shellblock_t> gc_blocks;
-  /// The block each shell belongs to, and its contraction index in it
-  std::vector<size_t> shell_block, shell_ctr;
-  /// Integral optimizers of the generally contracted tables
-  std::shared_ptr<OptSet> gc_opts;
-
   /// Fill the tables from a list of shells
   void build(const std::vector<GaussianShell> & shells, size_t Nsh_orbital, bool build_opts);
-  /// Build the generally contracted shell tables
-  void build_gc(const std::vector<GaussianShell> & shells, bool build_opts);
 
  public:
   /// Dummy constructor
@@ -203,25 +190,6 @@ class CintEnv {
 
   /// Integral optimizer for the given kernel (a libcint CINTOpt *)
   void * get_opt(cint_kernel_t kernel) const;
-
-  // ---- Generally contracted shells ----
-
-  /// Number of generally contracted shells (blocks)
-  size_t get_Nblock() const;
-  /// The shells of block ib
-  const std::vector<size_t> & get_block_shells(size_t ib) const;
-  /// The block shell ish belongs to
-  size_t get_shell_block(size_t ish) const;
-  /// The contraction index of shell ish within its block
-  size_t get_shell_ctr(size_t ish) const;
-  /// Does any block hold more than one shell?
-  bool have_gc() const;
-  /// The generally contracted shell table
-  int * get_gc_bas() const;
-  /// Number of generally contracted shells
-  int get_gc_nbas() const;
-  /// Integral optimizer of the generally contracted tables
-  void * get_gc_opt(cint_kernel_t kernel) const;
 
 };
 

--- a/src/contrib/complex_orbs.cpp
+++ b/src/contrib/complex_orbs.cpp
@@ -175,7 +175,15 @@ int main_guarded(int argc, char **argv) {
   if (complexbas) {
     const auto & shells = basis.get_shells();
     for (size_t i=0; i<shells.size(); i++) {
-      D.submat(shells[i].get_first_ind(), shells[i].get_first_ind(), shells[i].get_last_ind(), shells[i].get_last_ind()) = basis_transform_mat(shells[i].get_am());
+      // The transform acts on one set of 2l+1 spherical harmonics. A
+      // generally contracted shell carries nctr such sets stacked
+      // contraction-slowest, so place the transform block-diagonally,
+      // once per contraction.
+      const arma::cx_mat Tm = basis_transform_mat(shells[i].get_am());
+      const size_t Nlm = Tm.n_rows;
+      const size_t i0 = shells[i].get_first_ind();
+      for(size_t ic=0; ic<shells[i].get_Nctr(); ic++)
+        D.submat(i0+ic*Nlm, i0+ic*Nlm, i0+(ic+1)*Nlm-1, i0+(ic+1)*Nlm-1) = Tm;
     }
   } else
     D.eye();

--- a/src/density_fitting.cpp
+++ b/src/density_fitting.cpp
@@ -357,28 +357,6 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
 
   // Remove active column c: move the last active column into slot c
   // (preserving its nvec built components) and drop the active count.
-  // Group the significant shell pairs by the blocks of their shells: the
-  // integrals of a whole block quartet come out of a single recursion,
-  // so the shell pairs of a block pair are evaluated together. A
-  // segmented basis gives one shell pair per group, and the loop below
-  // is the plain one.
-  std::vector<std::vector<size_t>> brapairs;
-  std::vector<std::pair<size_t,size_t>> brablocks;
-  {
-    std::map<std::pair<size_t,size_t>, size_t> bmap;
-    for(size_t ipair=0;ipair<shpairs.size();ipair++) {
-      const std::pair<size_t,size_t> bp(lcenv.get_shell_block(shpairs[ipair].is),
-                                        lcenv.get_shell_block(shpairs[ipair].js));
-      auto it=bmap.find(bp);
-      if(it==bmap.end()) {
-        bmap[bp]=brapairs.size();
-        brapairs.push_back(std::vector<size_t>(1,ipair));
-        brablocks.push_back(bp);
-      } else
-        brapairs[it->second].push_back(ipair);
-    }
-  }
-
   auto drop_col = [&](arma::uword c) {
     const arma::uword last = actprod.size()-1;
     const arma::uword removed = actprod[c];
@@ -411,31 +389,17 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
     size_t max_Nk=basis.get_Nbf(max_ks);
     size_t max_Nl=basis.get_Nbf(max_ls);
 
-    // The shell pairs whose integrals come out of the same recursion as
-    // the one holding the pivot: the shells of a generally contracted
-    // block share their primitives, so the products of every
-    // combination of their contractions are candidates at no further
-    // cost. In a segmented basis this is the shell pair itself, and the
-    // sweep below is the one of the paper.
-    const size_t bk=lcenv.get_shell_block(max_ks);
-    const size_t bl=lcenv.get_shell_block(max_ls);
-    std::vector<std::pair<size_t,size_t>> cols;
-    for(auto ks: lcenv.get_block_shells(bk))
-      for(auto ls: lcenv.get_block_shells(bl)) {
-        // The products of (ks, ls) and of (ls, ks) are the same, so
-        // only one orientation is taken
-        if(bk==bl && ls<ks)
-          continue;
-        cols.push_back(std::make_pair(ks,ls));
-      }
-    const size_t ncol=cols.size();
+    // The pivot's shell pair. In the native generally contracted basis a
+    // single recursion over this shell pair yields the integrals of every
+    // combination of its contractions, so its whole radial block -- all
+    // the orbital products of (max_ks, max_ls) -- is covered at once, and
+    // the block-draining sweep below runs over that one shell pair.
+    const size_t max_Nkl=max_Nk*max_Nl;
 
-    // Screening bounds of the whole set
-    double Qblk=0.0;
-    for(size_t ic=0;ic<ncol;ic++)
-      Qblk=std::max(Qblk, Q(cols[ic].first,cols[ic].second));
+    // Screening bound of the pivot shell pair
+    const double Qblk=Q(max_ks,max_ls);
 
-    arma::mat A(d.n_elem,ncol*max_Nk*max_Nl, arma::fill::zeros);
+    arma::mat A(d.n_elem,max_Nkl, arma::fill::zeros);
     t.set();
 #ifdef _OPENMP
 #pragma omp parallel
@@ -447,77 +411,32 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
 #ifdef _OPENMP
 #pragma omp for schedule(dynamic,1)
 #endif
-      for(size_t ibra=0;ibra<brapairs.size();ibra++) {
-        // The shell pairs of this block pair that are significant for
-        // any of the shell pairs the pivot's block holds
-        bool any=false;
-        for(size_t ipi=0;ipi<brapairs[ibra].size() && !any;ipi++) {
-          const size_t is=shpairs[brapairs[ibra][ipi]].is;
-          const size_t js=shpairs[brapairs[ibra][ipi]].js;
-          if(Q(is,js)*Qblk<shell_screen_tol)
-            continue;
-          for(size_t ic=0;ic<ncol && !any;ic++) {
-            const size_t ks=cols[ic].first, ls=cols[ic].second;
-            if(M_screen(is,ks)*M_screen(js,ls)>=shell_screen_tol &&
-               M_screen(is,ls)*M_screen(js,ks)>=shell_screen_tol)
-              any=true;
+      for(size_t ipair=0;ipair<shpairs.size();ipair++) {
+        const size_t is=shpairs[ipair].is;
+        const size_t js=shpairs[ipair].js;
+        if(Q(is,js)*Qblk<shell_screen_tol)
+          continue;
+        if(M_screen(is,max_ks)*M_screen(js,max_ls)<shell_screen_tol ||
+           M_screen(is,max_ls)*M_screen(js,max_ks)<shell_screen_tol)
+          continue;
+
+        const size_t Ni(shells[is].get_Nbf());
+        const size_t Nj(shells[js].get_Nbf());
+        const size_t i0(shells[is].get_first_ind());
+        const size_t j0(shells[js].get_first_ind());
+
+        eri->compute(is,js,max_ks,max_ls);
+        erip=eri->getp();
+
+        for(size_t ii=0;ii<Ni;ii++)
+          for(size_t jj=0;jj<Nj;jj++) {
+            const size_t i=i0+ii;
+            const size_t j=j0+jj;
+            if(prodmap(i,j)>Nbf_local*Nbf_local) continue;
+            for(size_t kk=0;kk<max_Nk;kk++)
+              for(size_t ll=0;ll<max_Nl;ll++)
+                A(prodmap(i,j),kk*max_Nl+ll)=(*erip)[((ii*Nj+jj)*max_Nk+kk)*max_Nl+ll];
           }
-        }
-        if(!any) continue;
-
-        // One recursion for the whole block quartet: every combination
-        // of the contractions of the four blocks comes out of it
-        const size_t bi=brablocks[ibra].first;
-        const size_t bj=brablocks[ibra].second;
-        const bool shared =
-          lcenv.get_block_shells(bi).size()*lcenv.get_block_shells(bj).size()*
-          lcenv.get_block_shells(bk).size()*lcenv.get_block_shells(bl).size() > 1;
-        if(shared)
-          eri->compute_block(bi,bj,bk,bl);
-
-        for(size_t ipi=0;ipi<brapairs[ibra].size();ipi++) {
-          const size_t ipair=brapairs[ibra][ipi];
-          const size_t is=shpairs[ipair].is;
-          const size_t js=shpairs[ipair].js;
-          if(Q(is,js)*Qblk<shell_screen_tol)
-            continue;
-
-          const size_t Ni(shells[is].get_Nbf());
-          const size_t Nj(shells[js].get_Nbf());
-          const size_t i0(shells[is].get_first_ind());
-          const size_t j0(shells[js].get_first_ind());
-
-          for(size_t ic=0;ic<ncol;ic++) {
-            const size_t ks=cols[ic].first, ls=cols[ic].second;
-            if(M_screen(is,ks)*M_screen(js,ls)<shell_screen_tol ||
-               M_screen(is,ls)*M_screen(js,ks)<shell_screen_tol)
-              continue;
-
-            if(shared)
-              erip=eri->get_ctr(is,js,ks,ls);
-            else {
-              eri->compute(is,js,ks,ls);
-              erip=eri->getp();
-            }
-
-            const size_t k0(shells[ks].get_first_ind());
-            const size_t l0(shells[ls].get_first_ind());
-            const size_t Nk(shells[ks].get_Nbf());
-            const size_t Nl(shells[ls].get_Nbf());
-            const size_t coff=ic*max_Nk*max_Nl;
-
-            for(size_t ii=0;ii<Ni;ii++)
-              for(size_t jj=0;jj<Nj;jj++) {
-                const size_t i=i0+ii;
-                const size_t j=j0+jj;
-                if(prodmap(i,j)>Nbf_local*Nbf_local) continue;
-                for(size_t kk=0;kk<Nk;kk++)
-                  for(size_t ll=0;ll<Nl;ll++)
-                    A(prodmap(i,j),coff+kk*Nl+ll)=(*erip)[((ii*Nj+jj)*Nk+kk)*Nl+ll];
-              }
-            (void) k0; (void) l0;
-          }
-        }
       }
     }
     t_int+=t.get();
@@ -536,22 +455,17 @@ size_t DensityFit::select_two_step_pivots(const BasisSet & basis,
       double blockerr=0;
       arma::uword blockc=SENT;
       size_t Aind=0;
-      for(size_t ic=0;ic<ncol;ic++) {
-        const size_t ks=cols[ic].first, ls=cols[ic].second;
-        const size_t k0=shells[ks].get_first_ind();
-        const size_t l0=shells[ls].get_first_ind();
-        const size_t Nk=shells[ks].get_Nbf();
-        const size_t Nl=shells[ls].get_Nbf();
-        const size_t coff=ic*max_Nk*max_Nl;
-
-        for(size_t kk=0;kk<Nk;kk++)
-          for(size_t ll=0;ll<Nl;ll++) {
+      {
+        const size_t k0=shells[max_ks].get_first_ind();
+        const size_t l0=shells[max_ls].get_first_ind();
+        for(size_t kk=0;kk<max_Nk;kk++)
+          for(size_t ll=0;ll<max_Nl;ll++) {
             const size_t ind=prodmap(kk+k0,ll+l0);
             if(ind>Nbf_local*Nbf_local) continue;   // not a significant product
             const arma::uword c=colof(ind);
             if(c==SENT) continue;                   // already a pivot, or shed
             if(d(ind)>blockerr) {
-              Aind=coff+kk*Nl+ll;
+              Aind=kk*max_Nl+ll;
               blockc=c;
               blockerr=d(ind);
             }

--- a/src/emd/emd_gto.cpp
+++ b/src/emd/emd_gto.cpp
@@ -124,6 +124,14 @@ std::vector< std::vector<ylmcoeff_t> > form_clm(const BasisSet & bas) {
   for(size_t iid=0;iid<idsh.size();iid++) {
     // Angular momentum
     int l=bas.get_am(idsh[iid][0]);
+    // Number of contractions: a generally contracted shell carries nctr
+    // sets of the same angular functions (they differ only in the radial
+    // part), matching find_identical_functions / form_radial which count
+    // get_Nbf = nctr*(2l+1) functions per shell.
+    const size_t nctr=bas.get_shell(idsh[iid][0]).get_Nctr();
+
+    // The angular coefficients of one contraction's functions
+    std::vector< std::vector<ylmcoeff_t> > block;
 
     // Are spherical harmonics used?
     if(bas.lm_in_use(idsh[iid][0])) {
@@ -160,8 +168,8 @@ std::vector< std::vector<ylmcoeff_t> > form_clm(const BasisSet & bas) {
 	  c.push_back(tmp);
 	}
 
-	// Add function to stack
-	ret.push_back(c);
+	// Add function to block
+	block.push_back(c);
       }
     } else {
       // Need to do cartesian decomposition. Loop over functions on shell.
@@ -184,11 +192,16 @@ std::vector< std::vector<ylmcoeff_t> > form_clm(const BasisSet & bas) {
 	  for(size_t ic=0;ic<c.size();ic++)
 	    c[ic].c/=n;
 
-	  // and add them to the stack
-	  ret.push_back(c);
+	  // and add them to the block
+	  block.push_back(c);
 	}
       }
     }
+
+    // Repeat the angular block for each contraction of the shell.
+    for(size_t ic=0;ic<nctr;ic++)
+      for(size_t k=0;k<block.size();k++)
+	ret.push_back(block[k]);
   }
 
   /*
@@ -220,51 +233,58 @@ std::vector< std::vector<RadialGaussian> > form_radial(const BasisSet & bas) {
     // Angular momentum
     int am=bas.get_am(idsh[iid][0]);
 
-    // Normalized contraction for shell
-    std::vector<contr_t> c=bas.get_contr_normalized(idsh[iid][0]);
+    // The shell may be generally contracted: each contraction has its own
+    // radial part, shared by that contraction's angular functions. The
+    // contractions are stacked slowest, matching find_identical_functions
+    // / form_clm (get_Nbf = nctr*Nlm functions per shell).
+    const GaussianShell shell=bas.get_shell(idsh[iid][0]);
+    const size_t nctr=shell.get_Nctr();
+    // Functions per contraction (2l+1 spherical, or the cartesian count)
+    const size_t Nlm=bas.get_Nbf(idsh[iid][0])/nctr;
 
-    // The radial part for this shell
-    std::vector<RadialGaussian> rad;
+    for(size_t ictr=0;ictr<nctr;ictr++) {
+      // Normalized contraction for this column
+      std::vector<contr_t> c=shell.get_contr_normalized(ictr);
 
-    // Are spherical harmonics used?
-    if(bas.lm_in_use(idsh[iid][0])) {
-      // Yes. We only get a single l value.
-      RadialGaussian help(am,am);
+      // The radial part for this contraction
+      std::vector<RadialGaussian> rad;
 
-      // Add the contractions.
-      for(size_t i=0;i<c.size();i++) {
-	contr_t term;
-	term.z=c[i].z;
-	term.c=c[i].c*pow(c[i].z,-am/2.0-3.0/4.0);
-	help.add_term(term);
-      }
-      rad.push_back(help);
-
-      // All functions on shell have the same radial part
-      for(size_t ind=0;ind<bas.get_Nbf(idsh[iid][0]);ind++)
-	ret.push_back(rad);
-
-    } else {
-      // No, we get multiple values of l.
-
-      // Loop over possible l values
-      for(int l=am;l>=0;l-=2) {
-	// Construct the radial gaussian
-	RadialGaussian help(am,l);
+      // Are spherical harmonics used?
+      if(bas.lm_in_use(idsh[iid][0])) {
+	// Yes. We only get a single l value.
+	RadialGaussian help(am,am);
 
 	// Add the contractions.
 	for(size_t i=0;i<c.size();i++) {
 	  contr_t term;
 	  term.z=c[i].z;
-	  term.c=c[i].c*pow(c[i].z,-l/2.0-3.0/4.0);
+	  term.c=c[i].c*pow(c[i].z,-am/2.0-3.0/4.0);
 	  help.add_term(term);
 	}
-	// and add the term
 	rad.push_back(help);
+
+      } else {
+	// No, we get multiple values of l.
+
+	// Loop over possible l values
+	for(int l=am;l>=0;l-=2) {
+	  // Construct the radial gaussian
+	  RadialGaussian help(am,l);
+
+	  // Add the contractions.
+	  for(size_t i=0;i<c.size();i++) {
+	    contr_t term;
+	    term.z=c[i].z;
+	    term.c=c[i].c*pow(c[i].z,-l/2.0-3.0/4.0);
+	    help.add_term(term);
+	  }
+	  // and add the term
+	  rad.push_back(help);
+	}
       }
 
-      // All functions on shell have the same radial part
-      for(size_t ind=0;ind<bas.get_Nbf(idsh[iid][0]);ind++)
+      // All angular functions of this contraction share its radial part
+      for(size_t ind=0;ind<Nlm;ind++)
 	ret.push_back(rad);
     }
   }

--- a/src/emd/gto_fourier.cpp
+++ b/src/emd/gto_fourier.cpp
@@ -314,50 +314,59 @@ std::vector< std::vector<GTO_Fourier> > fourier_expand(const BasisSet & bas, std
   // Compute the expansions of the non-identical shells
   std::vector< std::vector<GTO_Fourier> > fourier;
   for(size_t i=0;i<idents.size();i++) {
-    // Get exponents, contraction coefficients and cartesians
-    std::vector<contr_t> contr=bas.get_contr(idents[i][0]);
-    std::vector<shellf_t> cart=bas.get_cart(idents[i][0]);
+    // Representative shell of this identical group
+    const size_t rep=idents[i][0];
+    // Cartesians and (if used) the spherical-harmonic transform are the
+    // same for every contraction of the shell
+    const std::vector<shellf_t> cart=bas.get_cart(rep);
+    const bool lm=bas.lm_in_use(rep);
+    const arma::mat transmat= lm ? bas.get_trans(rep) : arma::mat();
+    const int l=bas.get_am(rep);
+    // The shell may be generally contracted: expand each contraction and
+    // stack the results contraction-slowest, matching the basis function
+    // order (get_Nbf = nctr*(2l+1)).
+    const GaussianShell sh=bas.get_shell(rep);
 
-    // Compute expansion of basis functions on shell
-    // Form expansions of cartesian functions
-    std::vector<GTO_Fourier> cart_expansion;
-    for(size_t icart=0;icart<cart.size();icart++) {
-      // Expansion of current function
-      GTO_Fourier func;
-      for(size_t iexp=0;iexp<contr.size();iexp++)
-        func+=contr[iexp].c*GTO_Fourier(cart[icart].l,cart[icart].m,cart[icart].n,contr[iexp].z);
-      // Plug in the normalization factor
-      func=cart[icart].relnorm*func;
-      // Clean out terms with zero contribution
-      func.clean();
-      // Add to cartesian expansion
-      cart_expansion.push_back(func);
+    std::vector<GTO_Fourier> shell_expansion;
+    for(size_t ic=0;ic<sh.get_Nctr();ic++) {
+      const std::vector<contr_t> contr=sh.get_contr(ic);
+
+      // Form expansions of cartesian functions for this contraction
+      std::vector<GTO_Fourier> cart_expansion;
+      for(size_t icart=0;icart<cart.size();icart++) {
+        // Expansion of current function
+        GTO_Fourier func;
+        for(size_t iexp=0;iexp<contr.size();iexp++)
+          func+=contr[iexp].c*GTO_Fourier(cart[icart].l,cart[icart].m,cart[icart].n,contr[iexp].z);
+        // Plug in the normalization factor
+        func=cart[icart].relnorm*func;
+        // Clean out terms with zero contribution
+        func.clean();
+        // Add to cartesian expansion
+        cart_expansion.push_back(func);
+      }
+
+      // If spherical harmonics are used, transform this contraction's
+      // functions into the spherical harmonics basis; otherwise keep the
+      // cartesians. Either way, append to the shell's expansion.
+      if(lm) {
+        for(int m=-l;m<=l;m++) {
+          // Expansion for current term
+          GTO_Fourier mcomp;
+          // Form expansion
+          for(size_t icart=0;icart<transmat.n_cols;icart++)
+            mcomp+=transmat(l+m,icart)*cart_expansion[icart];
+          // clean it
+          mcomp.clean();
+          // and add it to the stack
+          shell_expansion.push_back(mcomp);
+        }
+      } else
+        for(size_t icart=0;icart<cart_expansion.size();icart++)
+          shell_expansion.push_back(cart_expansion[icart]);
     }
 
-    // If spherical harmonics are used, we need to transform the
-    // functions into the spherical harmonics basis.
-    if(bas.lm_in_use(idents[i][0])) {
-      std::vector<GTO_Fourier> sph_expansion;
-      // Get transformation matrix
-      arma::mat transmat=bas.get_trans(idents[i][0]);
-      // Form expansion
-      int l=bas.get_am(idents[i][0]);
-      for(int m=-l;m<=l;m++) {
-        // Expansion for current term
-        GTO_Fourier mcomp;
-        // Form expansion
-        for(size_t icart=0;icart<transmat.n_cols;icart++)
-          mcomp+=transmat(l+m,icart)*cart_expansion[icart];
-        // clean it
-        mcomp.clean();
-        // and add it to the stack
-        sph_expansion.push_back(mcomp);
-      }
-      // Now we have all components, add everything to the stack
-      fourier.push_back(sph_expansion);
-    } else
-      // No need to transform, cartesians are used.
-      fourier.push_back(cart_expansion);
+    fourier.push_back(shell_expansion);
   }
 
   return fourier;

--- a/src/eriscreen.cpp
+++ b/src/eriscreen.cpp
@@ -130,59 +130,7 @@ size_t ERIscreen::fill(const BasisSet * basisv, double shtol, bool verbose) {
   deri_pool_.clear();
   deri_pool_.resize(nth);
 
-  // Group the shell pairs by the blocks of their shells, so that the
-  // integrals of a generally contracted basis can be evaluated one
-  // block at a time
-  form_blockpairs();
-
   return shpairs.size();
-}
-
-void ERIscreen::form_blockpairs() {
-  blockpairs.clear();
-  blockpair_blocks.clear();
-  blockpair_Q.clear();
-
-  // A basis without generally contracted shells has nothing to gain
-  if(!cenv.have_gc())
-    return;
-
-  // Group the significant shell pairs by the blocks of their shells
-  std::map<std::pair<size_t,size_t>, size_t> map;
-  for(size_t ip=0;ip<shpairs.size();ip++) {
-    const std::pair<size_t,size_t> bp(cenv.get_shell_block(shpairs[ip].is),
-                                      cenv.get_shell_block(shpairs[ip].js));
-    auto it=map.find(bp);
-    if(it==map.end()) {
-      map[bp]=blockpairs.size();
-      blockpairs.push_back(std::vector<size_t>(1,ip));
-      blockpair_blocks.push_back(bp);
-      blockpair_Q.push_back(shpairs[ip].eri);
-    } else {
-      blockpairs[it->second].push_back(ip);
-      blockpair_Q[it->second]=std::max(blockpair_Q[it->second], shpairs[ip].eri);
-    }
-  }
-
-  // Sort the block pairs by their bound, as the shell pairs are sorted:
-  // the loop can then stop as soon as the bound drops below the
-  // threshold
-  std::vector<size_t> idx(blockpairs.size());
-  for(size_t i=0;i<idx.size();i++)
-    idx[i]=i;
-  std::stable_sort(idx.begin(), idx.end(), [&](size_t a, size_t b) { return blockpair_Q[a] > blockpair_Q[b]; });
-
-  std::vector<std::vector<size_t>> sp(blockpairs.size());
-  std::vector<std::pair<size_t,size_t>> sb(blockpairs.size());
-  std::vector<double> sq(blockpairs.size());
-  for(size_t i=0;i<idx.size();i++) {
-    sp[i]=blockpairs[idx[i]];
-    sb[i]=blockpair_blocks[idx[i]];
-    sq[i]=blockpair_Q[idx[i]];
-  }
-  blockpairs=sp;
-  blockpair_blocks=sb;
-  blockpair_Q=sq;
 }
 
 ERIWorker * ERIscreen::acquire_eri(int ith) const {
@@ -246,103 +194,9 @@ void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & diges
     // Integral array
     const std::vector<double> * erip;
 
-    // Reused buffer for the quartets of a block pair
-    std::vector<std::pair<size_t,size_t>> quartets;
-
-    // A generally contracted basis is evaluated one block quartet at a
-    // time: the recursion over the primitives is then shared by every
-    // combination of the contractions. The shell pairs are screened one
-    // by one as in the plain loop, so nothing is lost; only the
-    // evaluation is grouped.
-    if(blockpairs.size()) {
-#ifdef _OPENMP
-#pragma omp for schedule(dynamic)
-#endif
-      for(size_t ib=0;ib<blockpairs.size();ib++) {
-	for(size_t jb=0;jb<=ib;jb++) {
-	  // The bound of the block pair is that of its largest shell pair
-	  if(blockpair_Q[ib]*blockpair_Q[jb]<tol)
-	    break;
-	  if(screen_thresh_>0.0 && blockpair_Q[ib]*blockpair_Q[jb]*Dmax<screen_thresh_)
-	    break;
-
-	  // The quartets of this block pair that survive the screening.
-	  // The buffer is reused: nothing is allocated in the hot loop.
-	  quartets.clear();
-	  for(size_t ipi=0;ipi<blockpairs[ib].size();ipi++)
-	    for(size_t jpi=0;jpi<blockpairs[jb].size();jpi++) {
-	      size_t ip=blockpairs[ib][ipi];
-	      size_t jp=blockpairs[jb][jpi];
-	      // Every unordered pair of shell pairs is visited once
-	      if(jp>ip) {
-		if(ib==jb)
-		  continue;
-		std::swap(ip,jp);
-	      }
-
-	      const size_t is=shpairs[ip].is, js=shpairs[ip].js;
-	      const size_t ks=shpairs[jp].is, ls=shpairs[jp].js;
-
-	      const double QQ=Q(is,js)*Q(ks,ls);
-	      if(QQ<tol)
-		continue;
-	      if(screen_thresh_>0.0 && QQ*Dmax<screen_thresh_)
-		continue;
-
-	      const double MM=std::min(M(is,ks)*M(js,ls), M(is,ls)*M(js,ks));
-	      if(MM<tol)
-		continue;
-
-	      if(screen_thresh_>0.0) {
-		double Dq=D(is,js);
-		Dq=std::max(Dq,D(ks,ls));
-		Dq=std::max(Dq,D(is,ks));
-		Dq=std::max(Dq,D(is,ls));
-		Dq=std::max(Dq,D(js,ks));
-		Dq=std::max(Dq,D(js,ls));
-		if(QQ*Dq<screen_thresh_ || MM*Dq<screen_thresh_)
-		  continue;
-	      }
-
-	      quartets.push_back(std::make_pair(ip,jp));
-	    }
-
-	  if(!quartets.size())
-	    continue;
-
-	  const size_t bi=blockpair_blocks[ib].first;
-	  const size_t bj=blockpair_blocks[ib].second;
-	  const size_t bk=blockpair_blocks[jb].first;
-	  const size_t bl=blockpair_blocks[jb].second;
-
-	  // Nothing is shared if every block holds a single shell: the
-	  // quartet is then evaluated as in a segmented basis, and going
-	  // through the block would only add a copy
-	  const bool shared =
-	    cenv.get_block_shells(bi).size()*cenv.get_block_shells(bj).size()*
-	    cenv.get_block_shells(bk).size()*cenv.get_block_shells(bl).size() > 1;
-
-	  if(shared)
-	    // One recursion for every combination of the contractions
-	    eri->compute_block(bi,bj,bk,bl);
-
-	  for(size_t iq=0;iq<quartets.size();iq++) {
-	    const size_t ip=quartets[iq].first;
-	    const size_t jp=quartets[iq].second;
-	    if(shared)
-	      erip=eri->get_ctr(shpairs[ip].is,shpairs[ip].js,shpairs[jp].is,shpairs[jp].js);
-	    else {
-	      eri->compute(shpairs[ip].is,shpairs[ip].js,shpairs[jp].is,shpairs[jp].js);
-	      erip=eri->getp();
-	    }
-	    for(size_t i=0;i<digest[ith].size();i++)
-	      digest[ith][i]->digest(shpairs,ip,jp,*erip,0);
-	  }
-	}
-      }
-
-    } else {
-
+    // Each shell is a (possibly generally contracted) shell, so
+    // compute() over a shell pair yields the whole generally contracted
+    // quartet in one recursion.
 #ifdef _OPENMP
 #pragma omp for schedule(dynamic)
 #endif
@@ -407,7 +261,6 @@ void ERIscreen::calculate(std::vector< std::vector<IntegralDigestor *> > & diges
 	for(size_t i=0;i<digest[ith].size();i++)
 	  digest[ith][i]->digest(shpairs,ip,jp,*erip,0);
       }
-    }
     }
     // eri is owned by eri_pool_ -- do not delete.
   }

--- a/src/eriscreen.h
+++ b/src/eriscreen.h
@@ -56,19 +56,6 @@ class ERIscreen {
   /// libcint description of the basis, shared by the worker pools
   CintEnv cenv;
 
-  /// Shell pairs grouped by the blocks of their shells: the integrals
-  /// over the shell pairs of a block pair come out of a single
-  /// recursion, so they are evaluated together. Empty for a basis
-  /// without generally contracted shells, which then uses the plain
-  /// shell pair loop.
-  std::vector<std::vector<size_t>> blockpairs;
-  /// The blocks of each block pair
-  std::vector<std::pair<size_t,size_t>> blockpair_blocks;
-  /// The largest Schwarz bound of the shell pairs of each block pair
-  std::vector<double> blockpair_Q;
-
-  /// Group the shell pairs into block pairs, sorted by their bound
-  void form_blockpairs();
   /// Index helper
   std::vector<size_t> iidx;
 

--- a/src/eriworker.cpp
+++ b/src/eriworker.cpp
@@ -283,117 +283,6 @@ void ERIWorker::compute_2c(size_t is, size_t js) {
   normalize(erk,2,1,ints);
 }
 
-void ERIWorker::compute_block(size_t bi, size_t bj, size_t bk, size_t bl) {
-  // libcint gives the integrals over all the contractions of the blocks
-  // in one call: the recursion over the primitives is shared, and only
-  // the contraction step is repeated. As for a single shell, the
-  // reversed quartet gives ERKALE's index order.
-  int shls[4]={(int) bl, (int) bk, (int) bj, (int) bi};
-
-  CINTIntegralFunction * intor=envp->lm_in_use() ? int2e_sph : int2e_cart;
-  CINTOpt * opt=(CINTOpt *) envp->get_gc_opt(CINT_ERI);
-
-  block[0]=bi;
-  block[1]=bj;
-  block[2]=bk;
-  block[3]=bl;
-
-  size_t N=1;
-  for(int q=0;q<4;q++) {
-    const std::vector<size_t> & bsh=envp->get_block_shells(block[q]);
-    // Every shell of a block has the same number of functions
-    block_nctr[q]=bsh.size();
-    block_nbf[q]=envp->get_Nbf(bsh[0]);
-    N*=block_nctr[q]*block_nbf[q];
-  }
-  blockints.resize(N);
-
-  auto evaluate_omega=[&](double omega, std::vector<double> & buf) {
-    env[PTR_RANGE_OMEGA]=omega;
-    const size_t csize=intor(NULL,NULL,shls,envp->get_atm(),envp->get_natm(),envp->get_gc_bas(),envp->get_gc_nbas(),env.data(),NULL,NULL);
-    if(csize>cache.size())
-      cache.resize(csize);
-    if(!intor(buf.data(),NULL,shls,envp->get_atm(),envp->get_natm(),envp->get_gc_bas(),envp->get_gc_nbas(),env.data(),(omega==0.0)?opt:NULL,cache.data()))
-      std::fill(buf.begin(),buf.end(),0.0);
-  };
-
-  if(rs_alpha!=0.0)
-    evaluate_omega(0.0,blockints);
-  else
-    std::fill(blockints.begin(),blockints.end(),0.0);
-
-  if(rs_beta!=0.0) {
-    srbuf.resize(N);
-    evaluate_omega(-rs_omega,srbuf);
-    for(size_t i=0;i<N;i++)
-      blockints[i]=rs_alpha*blockints[i]+rs_beta*srbuf[i];
-  } else if(rs_alpha!=1.0)
-    for(size_t i=0;i<N;i++)
-      blockints[i]*=rs_alpha;
-}
-
-const std::vector<double> * ERIWorker::get_ctr(size_t is, size_t js, size_t ks, size_t ls) {
-  size_t sh[4]={is, js, ks, ls};
-
-  // (ij|kl) = (kl|ij), so a quartet whose bra and ket sit in the ket
-  // and the bra block of the evaluated quartet is served from the same
-  // buffer, with the two halves of the index swapped.
-  bool swapped=false;
-  if(envp->get_shell_block(is) != block[0] || envp->get_shell_block(js) != block[1] ||
-     envp->get_shell_block(ks) != block[2] || envp->get_shell_block(ls) != block[3]) {
-    if(envp->get_shell_block(is) == block[2] && envp->get_shell_block(js) == block[3] &&
-       envp->get_shell_block(ks) == block[0] && envp->get_shell_block(ls) == block[1]) {
-      swapped=true;
-      sh[0]=ks;
-      sh[1]=ls;
-      sh[2]=is;
-      sh[3]=js;
-    } else {
-      ERROR_INFO();
-      throw std::logic_error("The shell does not belong to the evaluated block!\n");
-    }
-  }
-
-  // The contraction each shell is in its block, and the sizes. In the
-  // output of a generally contracted shell the contraction runs slower
-  // than the functions of the shell.
-  size_t ctr[4], nbf[4], nctr[4];
-  for(int q=0;q<4;q++) {
-    ctr[q]=envp->get_shell_ctr(sh[q]);
-    nbf[q]=block_nbf[q];
-    nctr[q]=block_nctr[q];
-  }
-
-  const size_t N=nbf[0]*nbf[1]*nbf[2]*nbf[3];
-  ints.resize(N);
-
-  // The index of a function in the block runs over the contraction and
-  // the functions of the shell; the quartet index runs over the four
-  // shells with the last one fastest, as everywhere in ERKALE. A
-  // swapped quartet is written out with its bra and ket exchanged.
-  for(size_t i=0;i<nbf[0];i++) {
-    const size_t bi=(ctr[0]*nbf[0]+i)*nctr[1]*nbf[1];
-    for(size_t j=0;j<nbf[1];j++) {
-      const size_t bj=(bi+ctr[1]*nbf[1]+j)*nctr[2]*nbf[2];
-      for(size_t k=0;k<nbf[2];k++) {
-        const size_t bk=(bj+ctr[2]*nbf[2]+k)*nctr[3]*nbf[3];
-        for(size_t l=0;l<nbf[3];l++) {
-          const double val=blockints[bk+ctr[3]*nbf[3]+l];
-          if(swapped)
-            ints[((k*nbf[3]+l)*nbf[0]+i)*nbf[1]+j]=val;
-          else
-            ints[((i*nbf[1]+j)*nbf[2]+k)*nbf[3]+l]=val;
-        }
-      }
-    }
-  }
-
-  const size_t erk[4]={is, js, ks, ls};
-  normalize(erk,4,1,ints);
-
-  return &ints;
-}
-
 void ERIWorker::compute_debug(size_t is, size_t js, size_t ks, size_t ls) {
   const GaussianShell & shi=envp->get_shell(is);
   const GaussianShell & shj=envp->get_shell(js);
@@ -406,75 +295,99 @@ void ERIWorker::compute_debug(size_t is, size_t js, size_t ks, size_t ls) {
   const std::vector<shellf_t> & ck=shk.get_cart_ref();
   const std::vector<shellf_t> & cl=shl.get_cart_ref();
 
-  const std::vector<contr_t> coni(shi.get_contr());
-  const std::vector<contr_t> conj(shj.get_contr());
-  const std::vector<contr_t> conk(shk.get_contr());
-  const std::vector<contr_t> conl(shl.get_contr());
-
   const coords_t Ri(shi.get_center()), Rj(shj.get_center()), Rk(shk.get_center()), Rl(shl.get_center());
 
-  // Cartesian integrals over the Huzinaga routines
-  std::vector<double> cart(ci.size()*cj.size()*ck.size()*cl.size(),0.0);
-  for(size_t ic=0;ic<ci.size();ic++)
-    for(size_t jc=0;jc<cj.size();jc++)
-      for(size_t kc=0;kc<ck.size();kc++)
-        for(size_t lc=0;lc<cl.size();lc++) {
-          double el=0.0;
-          for(size_t xi=0;xi<coni.size();xi++)
-            for(size_t xj=0;xj<conj.size();xj++)
-              for(size_t xk=0;xk<conk.size();xk++)
-                for(size_t xl=0;xl<conl.size();xl++)
-                  el+=coni[xi].c*conj[xj].c*conk[xk].c*conl[xl].c*
-                    ERI_int(ci[ic].l,ci[ic].m,ci[ic].n,Ri.x,Ri.y,Ri.z,coni[xi].z,
-                            cj[jc].l,cj[jc].m,cj[jc].n,Rj.x,Rj.y,Rj.z,conj[xj].z,
-                            ck[kc].l,ck[kc].m,ck[kc].n,Rk.x,Rk.y,Rk.z,conk[xk].z,
-                            cl[lc].l,cl[lc].m,cl[lc].n,Rl.x,Rl.y,Rl.z,conl[xl].z);
-
-          cart[((ic*cj.size()+jc)*ck.size()+kc)*cl.size()+lc]=
-            ci[ic].relnorm*cj[jc].relnorm*ck[kc].relnorm*cl[lc].relnorm*el;
-        }
-
-  // Transform the indices into the basis the environment evaluates in.
-  // A cartesian shell, and any shell in a cartesian basis, transforms
-  // with the identity.
-  std::vector<double> in(cart), out;
-  size_t Ncart[4], Nbf[4];
+  // Per-index cartesian and final function counts, and per-contraction
+  // (single-column) function count Nlm[q]=Nbf[q]/nctr[q]. A generally
+  // contracted shell carries nctr[q]>1 columns; each is transformed
+  // separately and stacked contraction-slowest, matching the engine.
+  const size_t nctr[4]={shi.get_Nctr(), shj.get_Nctr(), shk.get_Nctr(), shl.get_Nctr()};
+  size_t Ncart[4], Nbf[4], Nlm[4];
   for(int q=0;q<4;q++) {
     Ncart[q]=shs[q]->get_Ncart();
     Nbf[q]=envp->get_Nbf(q==0 ? is : (q==1 ? js : (q==2 ? ks : ls)));
+    Nlm[q]=Nbf[q]/nctr[q];
   }
 
-  // The transform is done one index at a time; the index being
-  // transformed is rotated to the front and back again.
-  for(int q=0;q<4;q++) {
-    const bool trans=envp->lm_in_use() && shs[q]->lm_in_use();
-    const arma::mat T(trans ? shs[q]->get_trans() : arma::mat());
+  ints.assign(Nbf[0]*Nbf[1]*Nbf[2]*Nbf[3],0.0);
 
-    // Sizes of the indices, with the ones before q already transformed
-    size_t Nbefore=1, Nafter=1;
-    for(int r=0;r<q;r++)
-      Nbefore*=Nbf[r];
-    for(int r=q+1;r<4;r++)
-      Nafter*=Ncart[r];
+  // Loop over every combination of the four shells' contractions: the
+  // exponents are shared, only the contraction coefficients differ.
+  for(size_t di=0;di<nctr[0];di++) {
+    const std::vector<contr_t> coni(shi.get_contr(di));
+    for(size_t dj=0;dj<nctr[1];dj++) {
+      const std::vector<contr_t> conj(shj.get_contr(dj));
+      for(size_t dk=0;dk<nctr[2];dk++) {
+        const std::vector<contr_t> conk(shk.get_contr(dk));
+        for(size_t dl=0;dl<nctr[3];dl++) {
+          const std::vector<contr_t> conl(shl.get_contr(dl));
 
-    if(!trans) {
-      continue;
-    }
+          // Cartesian integrals over the Huzinaga routines
+          std::vector<double> cart(ci.size()*cj.size()*ck.size()*cl.size(),0.0);
+          for(size_t ic=0;ic<ci.size();ic++)
+            for(size_t jc=0;jc<cj.size();jc++)
+              for(size_t kc=0;kc<ck.size();kc++)
+                for(size_t lc=0;lc<cl.size();lc++) {
+                  double el=0.0;
+                  for(size_t xi=0;xi<coni.size();xi++)
+                    for(size_t xj=0;xj<conj.size();xj++)
+                      for(size_t xk=0;xk<conk.size();xk++)
+                        for(size_t xl=0;xl<conl.size();xl++)
+                          el+=coni[xi].c*conj[xj].c*conk[xk].c*conl[xl].c*
+                            ERI_int(ci[ic].l,ci[ic].m,ci[ic].n,Ri.x,Ri.y,Ri.z,coni[xi].z,
+                                    cj[jc].l,cj[jc].m,cj[jc].n,Rj.x,Rj.y,Rj.z,conj[xj].z,
+                                    ck[kc].l,ck[kc].m,ck[kc].n,Rk.x,Rk.y,Rk.z,conk[xk].z,
+                                    cl[lc].l,cl[lc].m,cl[lc].n,Rl.x,Rl.y,Rl.z,conl[xl].z);
 
-    out.assign(Nbefore*Nbf[q]*Nafter,0.0);
-    for(size_t b=0;b<Nbefore;b++)
-      for(size_t n=0;n<Nbf[q];n++)
-        for(size_t c=0;c<Ncart[q];c++) {
-          const double t=T(n,c);
-          if(t==0.0)
-            continue;
-          for(size_t a=0;a<Nafter;a++)
-            out[(b*Nbf[q]+n)*Nafter+a]+=t*in[(b*Ncart[q]+c)*Nafter+a];
+                  cart[((ic*cj.size()+jc)*ck.size()+kc)*cl.size()+lc]=
+                    ci[ic].relnorm*cj[jc].relnorm*ck[kc].relnorm*cl[lc].relnorm*el;
+                }
+
+          // Transform the indices into the basis the environment
+          // evaluates in, one index at a time. A cartesian shell, and any
+          // shell in a cartesian basis, transforms with the identity.
+          std::vector<double> in(cart), out;
+          for(int q=0;q<4;q++) {
+            const bool trans=envp->lm_in_use() && shs[q]->lm_in_use();
+            if(!trans)
+              continue;
+            const arma::mat T(shs[q]->get_trans());
+
+            // Sizes of the indices, with the ones before q already
+            // transformed (per contraction, so Nlm rather than Nbf)
+            size_t Nbefore=1, Nafter=1;
+            for(int r=0;r<q;r++)
+              Nbefore*=Nlm[r];
+            for(int r=q+1;r<4;r++)
+              Nafter*=Ncart[r];
+
+            out.assign(Nbefore*Nlm[q]*Nafter,0.0);
+            for(size_t b=0;b<Nbefore;b++)
+              for(size_t n=0;n<Nlm[q];n++)
+                for(size_t c=0;c<Ncart[q];c++) {
+                  const double t=T(n,c);
+                  if(t==0.0)
+                    continue;
+                  for(size_t a=0;a<Nafter;a++)
+                    out[(b*Nlm[q]+n)*Nafter+a]+=t*in[(b*Ncart[q]+c)*Nafter+a];
+                }
+            in.swap(out);
+          }
+
+          // Scatter this contraction combination's block into the full
+          // output at its contraction offsets (contraction slowest per
+          // index), matching the engine's layout.
+          const size_t o0=di*Nlm[0], o1=dj*Nlm[1], o2=dk*Nlm[2], o3=dl*Nlm[3];
+          for(size_t a=0;a<Nlm[0];a++)
+            for(size_t b=0;b<Nlm[1];b++)
+              for(size_t c=0;c<Nlm[2];c++)
+                for(size_t e=0;e<Nlm[3];e++)
+                  ints[(((o0+a)*Nbf[1]+o1+b)*Nbf[2]+o2+c)*Nbf[3]+o3+e]=
+                    in[((a*Nlm[1]+b)*Nlm[2]+c)*Nlm[3]+e];
         }
-    in.swap(out);
+      }
+    }
   }
-
-  ints=in;
 }
 
 std::vector<double> ERIWorker::get() const {

--- a/src/eriworker.h
+++ b/src/eriworker.h
@@ -98,11 +98,6 @@ class IntegralWorker {
 
 /// Worker for computing electron repulsion integrals
 class ERIWorker: public IntegralWorker {
-  /// Integrals over a quartet of generally contracted shells
-  std::vector<double> blockints;
-  /// The evaluated blocks, and their contraction and function counts
-  size_t block[4], block_nctr[4], block_nbf[4];
-
  public:
   /// Constructor
   ERIWorker(const CintEnv & env, double omega=0.0, double alpha=1.0, double beta=0.0);
@@ -119,16 +114,6 @@ class ERIWorker: public IntegralWorker {
   /// Compute the four-center integrals with the in-house Huzinaga
   /// routines: the independent reference used by integraltest
   void compute_debug(size_t is, size_t js, size_t ks, size_t ls);
-
-  /// Compute the four-center integrals over a quartet of generally
-  /// contracted shells: the integrals over every combination of their
-  /// contractions come out of a single recursion. The combinations are
-  /// then handed out one at a time by get_ctr.
-  void compute_block(size_t bi, size_t bj, size_t bk, size_t bl);
-  /// Get the integrals of one combination of contractions of the block
-  /// evaluated by compute_block. The shells are given by their index in
-  /// the basis, and have to belong to the blocks that were evaluated.
-  const std::vector<double> * get_ctr(size_t is, size_t js, size_t ks, size_t ls);
 
   /// Get the integrals
   std::vector<double> get() const;

--- a/src/external/fchkpt.cpp
+++ b/src/external/fchkpt.cpp
@@ -96,17 +96,18 @@ std::vector<int> form_shelltypes(const BasisSet & basis) {
   // Get the shells
   std::vector<GaussianShell> shells=basis.get_shells();
 
-  // Get shell types.
-  std::vector<int> shtypes(shells.size());
+  // Get shell types. Gaussian has no generally contracted shells, so a
+  // shell with nctr contractions is written as nctr segmented shells of
+  // the same type, matching the contraction-slowest basis function order.
+  std::vector<int> shtypes;
   for(size_t i=0;i<shells.size();i++) {
     // Get angular momentum
     int am=shells[i].get_am();
-
     // Use spherical harmonics?
-    if(shells[i].lm_in_use())
-      shtypes[i]=-am;
-    else
-      shtypes[i]=am;
+    const int t = shells[i].lm_in_use() ? -am : am;
+
+    for(size_t ic=0;ic<shells[i].get_Nctr();ic++)
+      shtypes.push_back(t);
   }
 
   return shtypes;
@@ -232,42 +233,38 @@ void write_basis(const BasisSet & basis, FILE *out) {
   // Get the shells
   std::vector<GaussianShell> shells=basis.get_shells();
 
-  // Print shell types.
+  // Print shell types (one Gaussian shell per contraction).
   std::vector<int> shtypes=form_shelltypes(basis);
   print("Shell types",shtypes,out);
 
-  // Print shell to atom map
-  std::vector<int> shmap(shells.size());
-  for(size_t i=0;i<shells.size();i++)
-    shmap[i]=(int) shells[i].get_center_ind()+1;
-  print("Shell to atom map",shmap,out);
-
-  // Print the coordinates of the shells
-  std::vector<double> shcoords(3*shells.size());
-  for(size_t i=0;i<shells.size();i++) {
-    coords_t r=shells[i].get_center();
-
-    shcoords[3*i]=r.x;
-    shcoords[3*i+1]=r.y;
-    shcoords[3*i+2]=r.z;
-  }
-  print("Coordinates of each shell",shcoords,out);
-
-  // Print number of primitives per shell, exponents and contraction coefficients.
+  // The remaining per-shell arrays explode a generally contracted shell
+  // into one Gaussian shell per contraction, matching form_shelltypes and
+  // the contraction-slowest basis function order.
+  std::vector<int> shmap;
+  std::vector<double> shcoords;
+  std::vector<int> nprim;
   std::vector<double> exps;
   std::vector<double> contr;
-  std::vector<int> nprim(shells.size());
   for(size_t i=0;i<shells.size();i++) {
-    // Get the contraction of *normalized* primitives
-    std::vector<contr_t> c=shells[i].get_contr_normalized();
-    nprim[i]=(int) c.size();
+    const coords_t r=shells[i].get_center();
+    for(size_t ic=0;ic<shells[i].get_Nctr();ic++) {
+      // Shell to atom map and shell coordinates
+      shmap.push_back((int) shells[i].get_center_ind()+1);
+      shcoords.push_back(r.x);
+      shcoords.push_back(r.y);
+      shcoords.push_back(r.z);
 
-    // Save exponents and *primitive* contraction coefficients
-    for(size_t j=0;j<c.size();j++) {
-      exps.push_back(c[j].z);
-      contr.push_back(c[j].c);
+      // Contraction of *normalized* primitives for this contraction
+      std::vector<contr_t> c=shells[i].get_contr_normalized(ic);
+      nprim.push_back((int) c.size());
+      for(size_t j=0;j<c.size();j++) {
+        exps.push_back(c[j].z);
+        contr.push_back(c[j].c);
+      }
     }
   }
+  print("Shell to atom map",shmap,out);
+  print("Coordinates of each shell",shcoords,out);
   print("Number of primitives per shell",nprim,out);
   print("Primitive exponents",exps,out);
   print("Contraction coefficients",contr,out);

--- a/src/test/basictests.cpp
+++ b/src/test/basictests.cpp
@@ -19,6 +19,10 @@
 #include "../linalg.h"
 #include "../mathf.h"
 #include "../settings.h"
+#include "../basis.h"
+#include "../basislibrary.h"
+#include "../cintenv.h"
+#include "../eriworker.h"
 
 /// Check orthogonality of spherical harmonics up to
 const int Lmax=10;
@@ -196,6 +200,68 @@ void test_checkpoint() {
 
 Settings settings;
 
+/// Check that a natively generally contracted shell (built by merging
+/// two same-exponent contractions) reproduces the two separate
+/// segmented shells, both when its functions are evaluated in real
+/// space and when its integrals are computed.
+void check_general_contraction() {
+  // Two d-shells sharing three exponents but with different
+  // contraction coefficients: a generally contracted block, built in
+  // memory so the test needs no basis-set library.
+  std::vector<contr_t> c0(3), c1(3);
+  const double z[3]={4.0, 1.1, 0.35};
+  const double a0[3]={0.20, 0.55, 0.35};
+  const double a1[3]={-0.09, 0.31, 0.82};
+  for(int i=0;i<3;i++) {
+    c0[i].z=z[i]; c0[i].c=a0[i];
+    c1[i].z=z[i]; c1[i].c=a1[i];
+  }
+
+  const coords_t orig{0.0,0.0,0.0};
+  GaussianShell s0(2,true,c0), s1(2,true,c1);
+  s0.set_center(orig,0); s1.set_center(orig,0);
+  s0.normalize(); s1.normalize();
+  s0.set_first_ind(0); s1.set_first_ind(0);
+
+  GaussianShell gc=s0;
+  gc.merge_contraction(s1);
+  gc.set_first_ind(0);
+
+  if(gc.get_Nctr()!=2 || gc.get_Nbf()!=2*(2*2+1))
+    throw std::runtime_error("check_general_contraction: merged shell has the wrong shape.\n");
+
+  // Real-space evaluation
+  const double px=0.3, py=-0.2, pz=0.15;
+  const arma::vec fgc=gc.eval_func(px,py,pz);
+  const arma::vec fstack=arma::join_cols(s0.eval_func(px,py,pz), s1.eval_func(px,py,pz));
+  if(arma::abs(fgc-fstack).max() > 1e-12)
+    throw std::runtime_error("check_general_contraction: eval_func of the generally contracted shell disagrees.\n");
+
+  // Integrals: the native-GC self-quartet against the segmented one
+  std::vector<GaussianShell> gcv{gc};
+  CintEnv egc(gcv,false); ERIWorker wgc(egc);
+  wgc.compute(0,0,0,0);
+  const std::vector<double> igc(*wgc.getp());
+
+  std::vector<GaussianShell> segv{s0,s1};
+  CintEnv eseg(segv,false); ERIWorker wseg(eseg);
+  const size_t nb=gc.get_Nbf();
+  const size_t nlm=nb/gc.get_Nctr();
+  double maxd=0.0;
+  for(int ci=0;ci<2;ci++)for(int cj=0;cj<2;cj++)for(int ck=0;ck<2;ck++)for(int cl=0;cl<2;cl++) {
+    wseg.compute(ci,cj,ck,cl);
+    const std::vector<double> * p=wseg.getp();
+    for(size_t fi=0;fi<nlm;fi++)for(size_t fj=0;fj<nlm;fj++)for(size_t fk=0;fk<nlm;fk++)for(size_t fl=0;fl<nlm;fl++) {
+      const size_t gi=ci*nlm+fi, gj=cj*nlm+fj, gk=ck*nlm+fk, gl=cl*nlm+fl;
+      const double vgc=igc[((gi*nb+gj)*nb+gk)*nb+gl];
+      const double vseg=(*p)[((fi*nlm+fj)*nlm+fk)*nlm+fl];
+      maxd=std::max(maxd,std::fabs(vgc-vseg));
+    }
+  }
+  if(maxd > 1e-10)
+    throw std::runtime_error("check_general_contraction: generally contracted integrals disagree with the segmented ones.\n");
+}
+
 int main(void) {
   settings.add_scf_settings();
   // Test indices
@@ -206,6 +272,9 @@ int main(void) {
   // Then, check checkpoint utilities
   test_checkpoint();
   printf("Checkpointing OK.\n");
+  // Generally contracted shells
+  check_general_contraction();
+  printf("General contraction OK.\n");
   // Test lapack thread safety
   try {
     check_lapack_thread();

--- a/src/xrs/bfprod.cpp
+++ b/src/xrs/bfprod.cpp
@@ -396,60 +396,68 @@ void prod_gaussian_3d::print() const {
 
 
 std::vector<prod_gaussian_3d> compute_product(const BasisSet & bas, size_t is, size_t js) {
-  // Contractions on shells
-  std::vector<contr_t> icontr=bas.get_contr(is);
-  std::vector<contr_t> jcontr=bas.get_contr(js);
+  // Shells (may be generally contracted)
+  const GaussianShell shi=bas.get_shell(is);
+  const GaussianShell shj=bas.get_shell(js);
 
-  // Cartesian functions on shells
-  std::vector<shellf_t> icart=bas.get_cart(is);
-  std::vector<shellf_t> jcart=bas.get_cart(js);
+  // Cartesian functions on shells (shared by every contraction)
+  const std::vector<shellf_t> icart=bas.get_cart(is);
+  const std::vector<shellf_t> jcart=bas.get_cart(js);
 
   // Centers of shells
-  coords_t icen=bas.get_shell_center(is);
-  coords_t jcen=bas.get_shell_center(js);
+  const coords_t icen=bas.get_shell_center(is);
+  const coords_t jcen=bas.get_shell_center(js);
 
-  // Returned array
-  std::vector<prod_gaussian_3d> ret;
-  ret.reserve(icart.size()*jcart.size());
+  // Per-contraction function counts and the whole-shell (generally
+  // contracted) target sizes get_Nbf = nctr*Nlm.
+  const bool lm_i=bas.lm_in_use(is), lm_j=bas.lm_in_use(js);
+  const size_t Ni_lm= lm_i ? (size_t)(2*bas.get_am(is)+1) : icart.size();
+  const size_t Nj_lm= lm_j ? (size_t)(2*bas.get_am(js)+1) : jcart.size();
+  const size_t Nj_tgt=shj.get_Nctr()*Nj_lm;
 
-  // Form products
-  for(size_t ii=0;ii<icart.size();ii++)
-    for(size_t jj=0;jj<jcart.size();jj++) {
+  // Returned array, indexed [i-function][j-function] with the whole-shell
+  // (contraction-slowest) function order.
+  std::vector<prod_gaussian_3d> ret(shi.get_Nctr()*Ni_lm*Nj_tgt);
 
-      // Result;
-      prod_gaussian_3d tmp;
+  // Loop over the contractions of the two shells: each pair gives a
+  // single-contraction product block, which is transformed and scattered
+  // into the generally contracted output at its contraction offset.
+  for(size_t ci=0;ci<shi.get_Nctr();ci++) {
+    const std::vector<contr_t> icontr=shi.get_contr(ci);
+    for(size_t cj=0;cj<shj.get_Nctr();cj++) {
+      const std::vector<contr_t> jcontr=shj.get_contr(cj);
 
-      // Loop over exponents
-      for(size_t ix=0;ix<icontr.size();ix++)
-	for(size_t jx=0;jx<jcontr.size();jx++) {
-	  // Compute product
-	  prod_gaussian_3d term(icen.x,jcen.x,icen.y,jcen.y,icen.z,jcen.z,icart[ii].l,jcart[jj].l,icart[ii].m,jcart[jj].m,icart[ii].n,jcart[jj].n,icontr[ix].z,jcontr[jx].z);
-	  // Add to partial result
-	  tmp+=term*(icontr[ix].c*jcontr[jx].c);
-
-	  /*
-	  printf("Product gaussian of (%i,%i,%i) centered at (% e,% e,% e) and (%i,%i,%i) centered at (% e,% e,% e) is\n",icart[ii].l,icart[ii].m,icart[ii].n,icen.x,icen.y,icen.z,jcart[jj].l,jcart[jj].m,jcart[jj].n,jcen.x,jcen.y,jcen.z);
-	  term.print();
-	  */
+      // Cartesian products for this contraction pair
+      std::vector<prod_gaussian_3d> block;
+      block.reserve(icart.size()*jcart.size());
+      for(size_t ii=0;ii<icart.size();ii++)
+	for(size_t jj=0;jj<jcart.size();jj++) {
+	  prod_gaussian_3d tmp;
+	  for(size_t ix=0;ix<icontr.size();ix++)
+	    for(size_t jx=0;jx<jcontr.size();jx++) {
+	      prod_gaussian_3d term(icen.x,jcen.x,icen.y,jcen.y,icen.z,jcen.z,icart[ii].l,jcart[jj].l,icart[ii].m,jcart[jj].m,icart[ii].n,jcart[jj].n,icontr[ix].z,jcontr[jx].z);
+	      tmp+=term*(icontr[ix].c*jcontr[jx].c);
+	    }
+	  // Plug in normalization factors
+	  tmp=tmp*(icart[ii].relnorm*jcart[jj].relnorm);
+	  block.push_back(tmp);
 	}
 
-      // Plug in normalization factors
-      tmp=tmp*(icart[ii].relnorm*jcart[jj].relnorm);
+      // Transform this block into the spherical basis if necessary
+      if(lm_i || lm_j)
+	block=spherical_transform(bas,is,js,block);
+      else
+	for(size_t i=0;i<block.size();i++)
+	  block[i].clean();
 
-      // Add to stack
-      ret.push_back(tmp);
+      // Scatter into the generally contracted output
+      for(size_t fi=0;fi<Ni_lm;fi++)
+	for(size_t fj=0;fj<Nj_lm;fj++)
+	  ret[(ci*Ni_lm+fi)*Nj_tgt + (cj*Nj_lm+fj)]=block[fi*Nj_lm+fj];
     }
-
-  // Transform into spherical basis if necessary
-  if(bas.lm_in_use(is) || bas.lm_in_use(js))
-    return spherical_transform(bas,is,js,ret);
-  else {
-    // Clean out terms with zero contribution
-    for(size_t i=0;i<ret.size();i++)
-      ret[i].clean();
-    // Return result
-    return ret;
   }
+
+  return ret;
 }
 
 std::vector<prod_gaussian_3d> spherical_transform(const BasisSet & bas, size_t is, size_t js, std::vector<prod_gaussian_3d> & res) {
@@ -459,8 +467,11 @@ std::vector<prod_gaussian_3d> spherical_transform(const BasisSet & bas, size_t i
   const size_t Ni_cart=bas.get_Ncart(is);
   const size_t Nj_cart=bas.get_Ncart(js);
 
-  const size_t Ni_tgt=bas.get_Nbf(is);
-  const size_t Nj_tgt=bas.get_Nbf(js);
+  // Single-contraction block: the target sizes are the per-contraction
+  // spherical-harmonic (or cartesian) counts, not the whole shell's
+  // get_Nbf, which for a generally contracted shell spans nctr blocks.
+  const size_t Ni_tgt= lm_i ? (size_t)(2*bas.get_am(is)+1) : Ni_cart;
+  const size_t Nj_tgt= lm_j ? (size_t)(2*bas.get_am(js)+1) : Nj_cart;
 
   // First, transform over j. Helper array
   std::vector<prod_gaussian_3d> tmp(Ni_cart*Nj_tgt);


### PR DESCRIPTION
Recovery PR. Stages B1 (#149) and B2 (#150) were merged into the
`gc-a-gaussianshell-matrix` branch instead of master (a stacked-PR
retargeting mishap), so their content never reached master. This PR
carries exactly those two commits (Stage A is already on master via
#148, so it does not appear in the diff).

- B1: evaluate generally contracted shells natively in CintEnv/ERIWorker
- B2: construct native GC shells in finalize(); delete the #147
  build_gc reconstruction heuristic

Full suite was green (187/187) at each stage. Stage C follows in #151
(retargeted to master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)